### PR TITLE
Making changes for checking the OCC being Active for Firestone Hardware

### DIFF
--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -224,17 +224,13 @@ class OpTestIPMI():
 
         timeout = time.time() + 60*timeout
 
-        ''' WORKAROUND FOR AMI BUG
-         After updating the AMI level the Host Status sensor no longer works
-         as expected.  To workaround this we use the OCC Active sensor instead.
-         When OCC Active is in Device Enabled state we consider this working
-         state.'''
-    #    cmd = 'sdr elist |grep \'Host Status\''
-        cmd = 'sdr elist |grep \'OCC Active\''
+        ''' AMI BUG is fixed now
+         After updating the AMI level the Host Status sensor works as expected.
+        '''
+        cmd = 'sdr elist |grep \'Host Status\''
         while True:
             output = self._ipmitool_cmd_run(self.cv_cmd + cmd)
-            #if 'S0/G0: working' in output:
-            if 'Device Enabled' in output:
+            if 'S0/G0: working' in output:
                 print "Host Status is S0/G0: working, IPL finished"
                 break
             if time.time() > timeout:


### PR DESCRIPTION
The BVT tests were failing for Open Power Firestone Hardware since the below command was failing
ipmitool -H <BMCIP> -I lanplus -U ADMIN -P admin sdr elist |grep 'OCC Active'

There are 2 OCC chips being Active in Firestone Hardware where as in Habanero LC Hardware, we have 1 OCC chip being Active and hence the sdr elist was not returning the correct values for Firestone Open Power Hardware.
Hence, making this fix in-order to fetch the correct values of 'OCC Active' for both Firestone and Habanero LC Open Power Hardware's.