### PR TITLE
Added addidtional command line parameters for getting lpar IP address…

### DIFF
--- a/bvt/op-ci-bvt
+++ b/bvt/op-ci-bvt
@@ -39,6 +39,10 @@ passwordipmi="???"
 cfgfiledir="???"
 imagedir="???"
 imagename="???"
+lparip="???"
+lparuser="???"
+lparPasswd="???"
+hpmimage="???"
 
 bvtoutfile="/tmp/op-ci-bvt-$$.out"
 fvfile="/tmp/op-ci-bvt-fv-$$.out"
@@ -46,7 +50,7 @@ fvfile="/tmp/op-ci-bvt-fv-$$.out"
 # If you have special code to set env vars to get python 2.7 active, edit and uncomment:
 #source ???
 export PATH="$PATH:."
-run-op-bvt --fverbose $fvfile --bmcip $bmcip --bmcuser $bmcuser --bmcpwd $bmcpwd --usernameipmi $usernameipmi --passwordipmi $passwordipmi --cfgfiledir $cfgfiledir --imagedir $imagedir --imagename $imagename $1 2>&1 | tee $bvtoutfile
+run-op-bvt --fverbose $fvfile --bmcip $bmcip --bmcuser $bmcuser --bmcpwd $bmcpwd --usernameipmi $usernameipmi --passwordipmi $passwordipmi --cfgfiledir $cfgfiledir --imagedir $imagedir --imagename $imagename --lparip $lparip --lparuser $lparuser --lparPasswd $lparPasswd --hpmimage $hpmimage $1 2>&1 | tee $bvtoutfile
 rc=${PIPESTATUS[0]}
 set +x
 echo "run-op-bvt finished with exit code $rc"

--- a/bvt/op-inbound-basic-bvt.xml
+++ b/bvt/op-inbound-basic-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-ci-setup.xml $                            -->
+<!-- $Source: op-auto-test/bvt/op-inbound-basic-bvt.xml $                   -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->
@@ -23,10 +23,13 @@
 <!-- permissions and limitations under the License.                         -->
 <!--                                                                        -->
 <!-- IBM_PROLOG_END_TAG                                                     -->
+<bvts>
 
-<test>
-    <testcase>
-        <cmd>run-bvt-setup --bmcip %%bmcip%% --bmcuser %%bmcuser%% --bmcpwd %%bmcpwd%% --usernameipmi %%usernameipmi%% --passwordipmi %%passwordipmi%% --cfgfiledir %%cfgfiledir%% --ffdcdir %%ffdcdir%% --imagedir %%imagedir%% --imagename %%imagename%% --lparip %%lparip%% --lparuser %%lparuser%% --lparPasswd %%lparPasswd%% --hpmimage %%hpmimage%%</cmd>
-        <exitonerror>yes</exitonerror>
-    </testcase>
-</test>
+<bvt>
+    <id>op-inbound-basic</id>
+    <title>OP Inbound BVT</title>
+    <bvt-xml>op-inbound-basic.xml</bvt-xml>
+    <coverage/>
+</bvt>
+
+</bvts>

--- a/bvt/op-inbound-basic.xml
+++ b/bvt/op-inbound-basic.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-ci-setup.xml $                            -->
+<!-- $Source: op-auto-test/bvt/op-inbound-basic.xml $                       -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->
@@ -24,9 +24,38 @@
 <!--                                                                        -->
 <!-- IBM_PROLOG_END_TAG                                                     -->
 
-<test>
-    <testcase>
-        <cmd>run-bvt-setup --bmcip %%bmcip%% --bmcuser %%bmcuser%% --bmcpwd %%bmcpwd%% --usernameipmi %%usernameipmi%% --passwordipmi %%passwordipmi%% --cfgfiledir %%cfgfiledir%% --ffdcdir %%ffdcdir%% --imagedir %%imagedir%% --imagename %%imagename%% --lparip %%lparip%% --lparuser %%lparuser%% --lparPasswd %%lparPasswd%% --hpmimage %%hpmimage%%</cmd>
-        <exitonerror>yes</exitonerror>
-    </testcase>
-</test>
+<integrationtest>
+    <platform>
+
+        <include>op-ci-setup.xml</include>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_inbound_hpm.get_OS_Level()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_inbound_hpm.cold_reset()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_inbound_hpm.protect_network_setting()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_inbound_hpm.code_update()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -242,10 +242,10 @@ printf OUTF $cfgfile_fmt,
         $ffdcdir,
         $imagedir,
         $imagename,
-	$lparip,
-	$lparuser,
-	$lparPasswd,
-	$hpmimage;
+        $lparip,
+        $lparuser,
+        $lparPasswd,
+        $hpmimage;
 close(OUTF);
 if ($verbose)
 {

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -48,6 +48,10 @@ my $imagedir = "";
 my $ffdcdir = "ffdc/";
 my $imagename = "habanero.pnor";
 my $cfgfiledir = ".";
+my $lparip = "";
+my $lparuser = "";
+my $lparPasswd = "";
+my $hpmimage = "";
 
 my $usage = "Setup an OP CI BVT test config file per the passed arguments (v${version})
 
@@ -78,6 +82,13 @@ prompt = \#
 ffdcdir = %s
 imagedir = %s
 imagename = %s
+
+[lpar]
+lparip = %s
+lparuser = %s
+lparPasswd = %s
+prompt = \#
+hpmimage = %s
 
 ";
 
@@ -156,6 +167,10 @@ while(@argv)
         if (setArg("--bmcpwd", \$bmcpwd)) { next; }
         if (setArg("--usernameipmi", \$usernameipmi)) { next; }
         if (setArg("--passwordipmi", \$passwordipmi)) { next; }
+        if (setArg("--lparip", \$lparip)) { next; }
+        if (setArg("--lparuser", \$lparuser)) { next; }
+        if (setArg("--lparPasswd", \$lparPasswd)) { next; }
+        if (setArg("--hpmimage", \$hpmimage)) { next; }
         if (setArg("--ffdcdir", \$ffdcdir)) { next; }
         if (setArg("--cfgfiledir", \$cfgfiledir)) { next; }
         if (setArg("--imagedir", \$imagedir)) { next; }
@@ -189,6 +204,26 @@ if ($passwordipmi eq "")
         print STDERR "ERROR: missing required argument --passwordipmi\n";
         exit(1);
 }
+if ($lparip eq "")
+{
+        print STDERR "ERROR: missing required argument --lparip\n";
+        exit(1);
+}
+if ($lparuser eq "")
+{
+        print STDERR "ERROR: missing required argument --lparuser\n";
+        exit(1);
+}
+if ($lparPasswd eq "")
+{
+        print STDERR "ERROR: missing required argument --lparPasswd\n";
+        exit(1);
+}
+if ($hpmimage eq "")
+{
+        print STDERR "ERROR: missing required argument --hpmimage\n";
+        exit(1);
+}
 
 # The OP CI tools want dirs to end in slash...
 if ($ffdcdir !~ /\/$/) { $ffdcdir .= "/"; }
@@ -206,7 +241,11 @@ printf OUTF $cfgfile_fmt,
         $passwordipmi,
         $ffdcdir,
         $imagedir,
-        $imagename;
+        $imagename,
+	$lparip,
+	$lparuser,
+	$lparPasswd,
+	$hpmimage;
 close(OUTF);
 if ($verbose)
 {

--- a/ci/source/op_inbound_hpm.py
+++ b/ci/source/op_inbound_hpm.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/ci/source/op_inbound_hpm.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+"""
+.. module:: op_inbound_hpm
+    :platform: Unix
+    :synopsis: This module contains the test functions for enabling LPAR communication in OpenPower systems.
+
+.. moduleauthor:: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>
+
+
+"""
+import sys
+import os
+
+# Get path to base directory and append to path to get common modules
+full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+sys.path.append(full_path)
+
+import ConfigParser
+from common.OpTestSystem import OpTestSystem
+from common.OpTestLpar import OpTestLpar
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+
+def _config_read():
+    """ returns bmc system and test config options """
+    bmcConfig = ConfigParser.RawConfigParser()
+    configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
+    bmcConfig.read(configFile)
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+
+''' Read the configuration settings into global space so they can be used by
+    other functions '''
+
+bmcCfg, testCfg, lparCfg = _config_read()
+
+opTestLp = OpTestLpar(lparCfg['lparip'],lparCfg['lparuser'],lparCfg['lparpasswd'])
+
+def get_OS_Level():
+    """This function gets the OS level installed on the machine
+    :returns: int -- 0: success, 1: error
+    """
+    opTestLp.lpar_get_OS_Level()
+
+    return 0
+
+def protect_network_setting():
+    """This function Executes a command on the os of the bmc to protect network setting
+    :returns: int -- 0: success, 1: error
+    """
+    return opTestLp.lpar_protect_network_setting()
+
+def cold_reset():
+    """This function Performs a cold reset onto the lpar
+    :returns: int -- 0: success, 1: error
+    """
+    opTestLp.lpar_cold_reset()
+
+    return 0
+
+def code_update():
+    """This function Flashes component 1 Firmware image of hpm file using ipmitool
+    :returns: int -- 0: success, 1: error
+    """
+    opTestLp.lpar_code_update(lparCfg['hpmimage'],str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
+
+    return 0
+

--- a/ci/source/test_op_inbound.py
+++ b/ci/source/test_op_inbound.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/ci/source/test_op_inbound.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+import os
+import sys
+#from op_ci_bmc import bmc_reboot
+#full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+#sys.path.append(full_path)
+#import op_ci_bmc
+# Fixture
+import op_ci_bmc
+import op_inbound_hpm
+
+def test_get_OS_Level():
+    assert op_inbound_hpm.get_OS_Level() == 0
+
+def test_cold_reset():
+    assert op_inbound_hpm.cold_reset() == 0
+
+def test_protect_network_setting():
+    assert op_inbound_hpm.protect_network_setting() == 0
+
+def test_code_update():
+    assert op_inbound_hpm.code_update() == 0
+


### PR DESCRIPTION
…, lpar user, lpar password, hpmimage respectively in op-ci-bvt

Added addidtional command line parameters for getting lpar IP address, lpar user, lpar password, hpmimage respectively in op-ci-setup.xml
Added the new arguments lparip, lparuser, lparPasswd and hpmimage to be used in setting up the config file in run-bvt-setup
Developed new ci source script files op_inbound_hpm.py and test_op_inbound.py to verify the functionalities of OpTestLpar.py
The new file op_inbound_hpm.py contains the test functions for enabling LPAR communication in OpenPower systems
Also developed new op-inbound-basic.xml and op-inbound-basic-bvt.xml test xml files
The test case file op-inbound-basic.xml tests the get_OS_Level, cold_reset, protect_network_setting and HPM code_update functioanlities of lpar

Signed-off-by:  Pavaman Subramaniyam  <pavsubra@linux.vnet.ibm.com>