### PR TITLE
Added new test cases for below OPAL features

### DIFF
--- a/bvt/op-fvt-basic-bvt.xml
+++ b/bvt/op-fvt-basic-bvt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-fvt-basic-bvt.xml $                        -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+<bvts>
+
+<bvt>
+    <id>op-fvt-basic</id>
+    <title>OP FVT Basic BVT</title>
+    <bvt-xml>op-fvt-basic.xml</bvt-xml>
+    <coverage/>
+</bvt>
+
+</bvts>

--- a/bvt/op-fvt-basic.xml
+++ b/bvt/op-fvt-basic.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-fvt-basic.xml $                            -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+
+<integrationtest>
+    <platform>
+
+        <include>op-ci-setup.xml</include>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_fvt.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_fvt.test_sensors()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_fvt.test_switch_endian_syscall()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/ci/source/op_ci_fvt.py
+++ b/ci/source/op_ci_fvt.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/ci/source/op_ci_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+"""
+.. module:: op_ci_fvt
+    :platform: Unix
+    :synopsis: This module contains functional verification test functions
+               for OPAL firmware. Corresponding source files for new OPAL
+               features will be adding in common directory
+
+.. moduleauthor:: Pridhiviraj Paidipeddi <ppaidipe@in.ibm.com>
+
+
+"""
+import sys
+import os
+
+# Get path to base directory and append to path to get common modules
+full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+sys.path.append(full_path)
+
+import ConfigParser
+from common.OpTestSensors import OpTestSensors
+from common.OpTestSwitchEndianSyscall import OpTestSwitchEndianSyscall
+
+
+def _config_read():
+    """ returns bmc system and test config options """
+    bmcConfig = ConfigParser.RawConfigParser()
+    configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
+    print configFile
+    bmcConfig.read(configFile)
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+
+''' Read the configuration settings into global space so they can be used by
+    other functions '''
+
+bmcCfg, testCfg, lparCfg = _config_read()
+opTestSensors = OpTestSensors(bmcCfg['ip'], bmcCfg['username'],
+                              bmcCfg['password'],
+                              bmcCfg['usernameipmi'],
+                              bmcCfg['passwordipmi'],
+                              testCfg['ffdcdir'], lparCfg['lparip'],
+                              lparCfg['lparuser'], lparCfg['lparpasswd'])
+
+opTestSwitchEndianSyscall = OpTestSwitchEndianSyscall(bmcCfg['ip'],
+                                                      bmcCfg['username'],
+                                                      bmcCfg['password'],
+                                                      bmcCfg['usernameipmi'],
+                                                      bmcCfg['passwordipmi'],
+                                                      testCfg['ffdcdir'],
+                                                      lparCfg['lparip'],
+                                                      lparCfg['lparuser'],
+                                                      lparCfg['lparpasswd'])
+
+
+def test_init():
+    """This function validates the test config before running other functions
+    """
+
+    ''' create FFDC dir if it does not exist '''
+    ffdcDir = testCfg['ffdcdir']
+    if not os.path.exists(os.path.dirname(ffdcDir)):
+        os.makedirs(os.path.dirname(ffdcDir))
+
+    return 0
+
+
+def test_sensors():
+    """This function tests the hwmon driver for hardware monitoring sensors
+    using sensors utility
+    returns: int 0-success, raises exception-error
+    """
+    return opTestSensors.test_hwmon_driver()
+
+
+def test_switch_endian_syscall():
+    """This function executes the switch_endian() sys call test which is
+    implemented in /linux/tools/testing/selftests/powerpc/switch_endian
+    git  repository
+    returns: int 0: success, 1: error
+    """
+    return opTestSwitchEndianSyscall.testSwitchEndianSysCall()

--- a/ci/source/test_op_fvt.py
+++ b/ci/source/test_op_fvt.py
@@ -1,8 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/python
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-ci-bmc-run $
+# $Source: op-auto-test/ci/source/test_op_fvt.py $
 #
 # OpenPOWER Automated Test Project
 #
@@ -23,23 +23,24 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-use strict;
-my @argv = @ARGV;
-my $function = shift(@argv);
-my $cmd = "python -c \"";
-$cmd .= "import sys
-import os
-# Get path to base directory and append to path to get common modules
-full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('bvt')[0]
-sys.path.append(full_path)
-# TODO - Just call common API's directly
-import ci.source.op_ci_bmc as op_ci_bmc
-import ci.source.op_inbound_hpm as op_inbound_hpm
-import ci.source.op_ci_fvt as op_ci_fvt
 
-sys.exit( $function )\"";
-#print "cmd: $cmd\n";
-my $rc = system($cmd);
-#print "python returned $rc from system()\n";
-if ($rc) { $rc = 1; } # make sure the exit code is OK for the shell
-exit($rc);
+import os
+import sys
+# from op_ci_bmc import bmc_reboot
+# full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+# sys.path.append(full_path)
+# import op_ci_bmc
+# Fixture
+import op_ci_fvt
+
+
+def test_config_check():
+    assert op_ci_fvt.test_init() == 0
+
+
+def test_sensors():
+    assert op_ci_fvt.test_sensors() == 0
+
+
+def test_switchendian_syscall():
+    assert test_switch_endian_syscall() == 0

--- a/common/OpTestSensors.py
+++ b/common/OpTestSensors.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/common/OpTestSensors.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestSensors
+#  Sensors package for OpenPower testing.
+#
+#  This class will test the functionality of following drivers
+#  1. Hardware monitoring sensors(hwmon driver) using sensors utility
+
+import time
+import subprocess
+import re
+
+from OpTestBMC import OpTestBMC
+from OpTestIPMI import OpTestIPMI
+from OpTestConstants import OpTestConstants as BMC_CONST
+from OpTestError import OpTestError
+from OpTestLpar import OpTestLpar
+from OpTestUtil import OpTestUtil
+
+
+class OpTestSensors():
+    #  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    def test_hwmon_driver(self):
+        # This function will cover following
+        # 1. It will check for kernel config option CONFIG_SENSORS_IBMPOWERNV
+        # 2. It will load ibmpowernv driver only on powernv platform
+        # 3. It will check for sensors command existence and lm_sensors package
+        # 4. start the lm_sensors service and detect any sensor chips
+        #    using sensors-detect.
+        # 5. At the end it will test sensors command functionality
+        #    with different options
+
+        # Get OS level
+        OS = self.cv_LPAR.lpar_get_OS_Level()
+
+        # Checking for sensors config option CONFIG_SENSORS_IBMPOWERNV
+        kernel = self.cv_LPAR._ssh_execute("uname -a | awk {'print $3'}")
+        kernel = kernel.replace("\r\n", "")
+        print kernel
+        cmd = "cat /boot/config-%s | grep -i SENSORS_IBMPOWERNV" % kernel
+        print cmd
+        try:
+            res = self.cv_LPAR._ssh_execute(cmd)
+            print res
+        except:
+            l_msg = "Getting Config file is failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+        try:
+            val = ((res.split("=")[1]).replace("\r\n", ""))
+            if val == "y":
+                print "Driver build into kernel itself"
+            else:
+                print "Driver will be built as module"
+        except:
+            print val
+            l_msg = "config option is not set,exiting..."
+            print l_msg
+            raise OpTestError(l_msg)
+
+        # Loading ibmpowernv driver only on powernv platform
+        if "PowerKVM" not in OS:
+            l_rc = self.cv_LPAR._ssh_execute("modprobe ibmpowernv; echo $?")
+            if int(l_rc) == 0:
+                cmd = "lsmod | grep -i ibmpowernv"
+                response = self.cv_LPAR._ssh_execute(cmd)
+                if "ibmpowernv" not in response:
+                    l_msg = "ibmpowernv module is not loaded, exiting"
+                    raise OpTestError(l_msg)
+                else:
+                    print "ibmpowernv module is loaded"
+                print cmd
+                print response
+            else:
+                l_msg = "modprobe failed while loading ibmpowernv,exiting..."
+                print l_msg
+                raise OpTestError(l_msg)
+        else:
+            pass
+
+        # Checking for sensors command and lm_sensors package
+        response = self.cv_LPAR._ssh_execute("sensors")
+        matchObj = re.search(r"command not found", response)
+        if matchObj:
+            l_msg = "sensors not working, install lm_sensors package"
+            print l_msg
+            raise OpTestError(l_msg)
+        else:
+            pkg = self.cv_LPAR._ssh_execute("rpm -qf /bin/sensors")
+            print "Installed package:%s" % pkg
+        print response
+
+        try:
+            # Start the lm_sensors service
+            cmd = "/bin/systemctl stop  lm_sensors.service"
+            self.cv_LPAR._ssh_execute(cmd)
+            cmd = "/bin/systemctl start  lm_sensors.service"
+            self.cv_LPAR._ssh_execute(cmd)
+            cmd = "/bin/systemctl status  lm_sensors.service"
+            res = self.cv_LPAR._ssh_execute(cmd)
+            print res
+
+            # To detect different sensor chips and modules
+            res = self.cv_LPAR._ssh_execute("yes | sensors-detect")
+            print res
+        except:
+            l_msg = "loading lm_sensors service failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+        # Checking sensors command functionality with different options
+        output = self.cv_LPAR._ssh_execute("sensors; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR._ssh_execute("sensors -f; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -f not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR._ssh_execute("sensors -A; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -A not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR._ssh_execute("sensors -u; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -u not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        return BMC_CONST.FW_SUCCESS

--- a/common/OpTestSwitchEndianSyscall.py
+++ b/common/OpTestSwitchEndianSyscall.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/common/OpTestSwitchEndianSyscall.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestSwitchEndianSyscall
+#  Switch endian system call package for OpenPower testing.
+#
+#  This class will test the functionality of following.
+#  1. It will test switch_endian() system call by executing the registers
+#     changes in other endian. By calling switch_endian should not effect.
+#  2. This functionality is implemented in linux git repository
+#     /linux/tools/testing/selftests/powerpc/switch_endian
+#  3. In this test, will clone latest linux git repository and make required
+#     files. At the end will execute switch_endian_test executable file.
+
+import time
+import subprocess
+import re
+
+from OpTestBMC import OpTestBMC
+from OpTestIPMI import OpTestIPMI
+from OpTestConstants import OpTestConstants as BMC_CONST
+from OpTestError import OpTestError
+from OpTestLpar import OpTestLpar
+from OpTestUtil import OpTestUtil
+
+
+class OpTestSwitchEndianSyscall():
+            # Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    def testSwitchEndianSysCall(self):
+        # This function will perform below steps one by one.
+
+        # Get OS level
+        self.cv_LPAR.lpar_get_OS_Level()
+
+        # Clone latest linux git repository
+        self.clone_linux_source()
+
+        # Check for switch_endian test directory.
+        self.check_dir_exists()
+
+        # make the required files
+        self.make_test()
+
+        # Run the switch_endian sys call test once
+        l_rc = self.run_once()
+        if int(l_rc) == 1:
+            print "Switch endian sys call test got succesful"
+            return BMC_CONST.FW_SUCCESS
+        else:
+            print "Switch endian sys call test failed"
+            return BMC_CONST.FW_FAILED
+
+    def clone_linux_source(self):
+        # It will clone latest linux git repository in /tmp directory
+        msg = 'git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+        cmd = "git clone %s /tmp/linux" % msg
+        self.cv_LPAR._ssh_execute("rm -rf /tmp/linux")
+        self.cv_LPAR._ssh_execute("mkdir /tmp/linux")
+        try:
+            print cmd
+            res = self.cv_LPAR._ssh_execute(cmd)
+            print res
+        except:
+            l_msg = "Cloning linux git repository is failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    def check_dir_exists(self):
+        # It will check for switch_endian directory in the cloned repository
+        # It will raise exception incase of missing directory
+        dir = '/tmp/linux/tools/testing/selftests/powerpc/switch_endian'
+        cmd = "test -d %s; echo $?" % dir
+        print cmd
+        res = self.cv_LPAR._ssh_execute(cmd)
+        print res
+        if (res.__contains__(str(0))):
+            print "Switch endian test directory exists"
+            return 1
+        else:
+            l_msg = "Switch endian directory is not present"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    def make_test(self):
+        # It will prepare for executable bin files using make command
+        # At the end it will check for bin file switch_endian_test and
+        # will throw an exception in case of missing bin file after make
+        cmd = "cd /tmp/linux/tools/testing/selftests/powerpc/switch_endian;\
+                 make;"
+        print cmd
+        res = self.cv_LPAR._ssh_execute(cmd)
+        print res
+        cmd = "test -f /tmp/linux/tools/testing/selftests/powerpc/switch_endian/switch_endian_test; echo $?"
+        res = self.cv_LPAR._ssh_execute(cmd)
+        print res
+        if (res.__contains__(str(0))):
+            print "Executable binary switch_endian_test is available"
+            return 1
+        else:
+            l_msg = "Switch_endian_test bin file is not present after make"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    def run_once(self):
+        # This function will run executable file switch_endian_test and
+        # check for switch_endian() sys call functionality
+        cmd = "cd /tmp/linux/tools/testing/selftests/powerpc/switch_endian/;\
+                 ./switch_endian_test"
+        print cmd
+        res = self.cv_LPAR._ssh_execute(cmd)
+        print res
+        if (res.__contains__('success: switch_endian_test')):
+            return 1
+        else:
+            return 0


### PR DESCRIPTION
    1. Hardware monitoring sensors(hwmon driver) using sensors utility
    2. Switch endian sys call test which is implemented in linux git repository
For the above two features source files OpTestSensors.py and OpTestSwitchEndianSyscall.py are implemented in common directory

op_ci_fvt.py,test_op_fvt.py : In these files will keep adding new OPAL feature test functions, which are implemented in common directory.

op-fvt-basic.xml : In this xml file calling above test functions inorder to execute the above test functions

op-ci-bmc-run : In this file imported op_ci_fvt, inorder to invoke the test case.

Signed-off-by: pridhiviraj <ppaidipe@linux.vnet.ibm.com>