### PR TITLE
Added new test cases for below OPAL features

### DIFF
--- a/bvt/op-opal-fvt-bvt.xml
+++ b/bvt/op-opal-fvt-bvt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-opal-fvt-bvt.xml $                        -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+<bvts>
+
+<bvt>
+    <id>op-opal-fvt</id>
+    <title>OP OPAL FVT BVT</title>
+    <bvt-xml>op-opal-fvt.xml</bvt-xml>
+    <coverage/>
+</bvt>
+
+</bvts>

--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-opal-fvt.xml $                            -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+
+<integrationtest>
+    <platform>
+
+        <include>op-ci-setup.xml</include>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_sensors()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_switch_endian_syscall()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/ci/source/op_opal_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+"""
+.. module:: op_opal_fvt
+    :platform: Unix
+    :synopsis: This module contains functional verification test functions
+               for OPAL firmware. Corresponding source files for new OPAL
+               features will be adding in testcases directory
+
+.. moduleauthor:: Pridhiviraj Paidipeddi <ppaidipe@in.ibm.com>
+
+
+"""
+import sys
+import os
+
+# Get path to base directory and append to path to get common modules
+full_path = os.path.dirname(os.path.abspath(__file__))
+full_path = full_path.split('ci')[0]
+
+sys.path.append(full_path)
+import ConfigParser
+
+from testcases.OpTestSensors import OpTestSensors
+from testcases.OpTestSwitchEndianSyscall import OpTestSwitchEndianSyscall
+
+
+def _config_read():
+    """ returns bmc system and test config options """
+    bmcConfig = ConfigParser.RawConfigParser()
+    configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
+    print configFile
+    bmcConfig.read(configFile)
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+
+''' Read the configuration settings into global space so they can be used by
+    other functions '''
+
+bmcCfg, testCfg, lparCfg = _config_read()
+opTestSensors = OpTestSensors(bmcCfg['ip'], bmcCfg['username'],
+                              bmcCfg['password'],
+                              bmcCfg['usernameipmi'],
+                              bmcCfg['passwordipmi'],
+                              testCfg['ffdcdir'], lparCfg['lparip'],
+                              lparCfg['lparuser'], lparCfg['lparpasswd'])
+
+opTestSwitchEndianSyscall = OpTestSwitchEndianSyscall(bmcCfg['ip'],
+                                                      bmcCfg['username'],
+                                                      bmcCfg['password'],
+                                                      bmcCfg['usernameipmi'],
+                                                      bmcCfg['passwordipmi'],
+                                                      testCfg['ffdcdir'],
+                                                      lparCfg['lparip'],
+                                                      lparCfg['lparuser'],
+                                                      lparCfg['lparpasswd'])
+
+
+def test_init():
+    """This function validates the test config before running other functions
+    """
+
+    ''' create FFDC dir if it does not exist '''
+    ffdcDir = testCfg['ffdcdir']
+    if not os.path.exists(os.path.dirname(ffdcDir)):
+        os.makedirs(os.path.dirname(ffdcDir))
+
+    return 0
+
+
+def test_sensors():
+    """This function tests the hwmon driver for hardware monitoring sensors
+    using sensors utility
+    returns: int 0-success, raises exception-error
+    """
+    return opTestSensors.test_hwmon_driver()
+
+
+def test_switch_endian_syscall():
+    """This function executes the switch_endian() sys call test which is
+    implemented in /linux/tools/testing/selftests/powerpc/switch_endian
+    git  repository
+    returns: int 0: success, 1: error
+    """
+    return opTestSwitchEndianSyscall.testSwitchEndianSysCall()

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -1,8 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/python
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-ci-bmc-run $
+# $Source: op-auto-test/ci/source/test_opal_fvt.py $
 #
 # OpenPOWER Automated Test Project
 #
@@ -23,23 +23,24 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-use strict;
-my @argv = @ARGV;
-my $function = shift(@argv);
-my $cmd = "python -c \"";
-$cmd .= "import sys
-import os
-# Get path to base directory and append to path to get common modules
-full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('bvt')[0]
-sys.path.append(full_path)
-# TODO - Just call common API's directly
-import ci.source.op_ci_bmc as op_ci_bmc
-import ci.source.op_inbound_hpm as op_inbound_hpm
-import ci.source.op_opal_fvt as op_opal_fvt
 
-sys.exit( $function )\"";
-#print "cmd: $cmd\n";
-my $rc = system($cmd);
-#print "python returned $rc from system()\n";
-if ($rc) { $rc = 1; } # make sure the exit code is OK for the shell
-exit($rc);
+import os
+import sys
+# from op_ci_bmc import bmc_reboot
+# full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+# sys.path.append(full_path)
+# import op_ci_bmc
+# Fixture
+import op_opal_fvt
+
+
+def test_config_check():
+    assert op_opal_fvt.test_init() == 0
+
+
+def test_sensors():
+    assert op_opal_fvt.test_sensors() == 0
+
+
+def test_switchendian_syscall():
+    assert op_opal_fvt.test_switch_endian_syscall() == 0

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestSensors.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestSensors
+#  Sensors package for OpenPower testing.
+#
+#  This class will test the functionality of following drivers
+#  1. Hardware monitoring sensors(hwmon driver) using sensors utility
+
+import time
+import subprocess
+import re
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestSensors():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief This function will cover following test steps
+    #        1. It will check for kernel config option CONFIG_SENSORS_IBMPOWERNV
+    #        2. It will load ibmpowernv driver only on powernv platform
+    #        3. It will check for sensors command existence and lm_sensors package
+    #        4. start the lm_sensors service and detect any sensor chips
+    #           using sensors-detect.
+    #        5. At the end it will test sensors command functionality
+    #           with different options
+    #
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_hwmon_driver(self):
+
+        # Get OS level
+        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+
+        # Get kernel version
+        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+
+        # Checking for sensors config option CONFIG_SENSORS_IBMPOWERNV
+        l_config = "CONFIG_SENSORS_IBMPOWERNV"
+
+        l_val = self.cv_LPAR.lpar_check_config(l_kernel, l_config)
+        if l_val == "y":
+            print "Driver build into kernel itself"
+        else:
+            print "Driver will be built as module"
+
+        # Loading ibmpowernv driver only on powernv platform
+        self.cv_LPAR.lpar_load_ibmpowernv(l_oslevel)
+
+        # Checking for sensors command and lm_sensors package
+        self.cv_LPAR.lpar_check_command("sensors")
+
+        l_pkg = self.cv_LPAR.lpar_check_pkg_for_utility(l_oslevel, "sensors")
+        print "Installed package: %s" % l_pkg
+
+        # Restart the lm_sensor service
+        self.cv_LPAR.lpar_start_lm_sensor_svc(l_oslevel)
+
+        # To detect different sensor chips and modules
+        res = self.cv_LPAR.lpar_run_command("yes | sensors-detect")
+        print res
+
+        # Checking sensors command functionality with different options
+        output = self.cv_LPAR.lpar_run_command("sensors; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR.lpar_run_command("sensors -f; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -f not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR.lpar_run_command("sensors -A; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -A not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        output = self.cv_LPAR.lpar_run_command("sensors -u; echo $?")
+        response = output.splitlines()
+        if int(response[-1]):
+            l_msg = "sensors -u not working,exiting...."
+            raise OpTestError(l_msg)
+        print output
+        return BMC_CONST.FW_SUCCESS

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestSwitchEndianSyscall.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestSwitchEndianSyscall
+#  Switch endian system call package for OpenPower testing.
+#
+#  This class will test the functionality of following.
+#  1. It will test switch_endian() system call by executing the registers
+#     changes in other endian. By calling switch_endian sys call,
+#     should not effect register and memory space.
+#  2. This functionality is implemented in linux git repository
+#     /linux/tools/testing/selftests/powerpc/switch_endian
+#  3. In this test, will clone latest linux git repository and make required
+#     files. At the end will execute switch_endian_test executable file.
+
+import time
+import subprocess
+import re
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestSwitchEndianSyscall():
+    ## Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief  If git and gcc commands are availble on lpar, this function will clone linux
+    #         git repository and check for switch_endian_test directory and make
+    #         the required files. And finally execute bin file switch_endian_test.
+    #
+    # @return BMC_CONST.FW_SUCCESS-success or BMC_CONST.FW_FAILED-fail
+    #
+    def testSwitchEndianSysCall(self):
+
+        # Get OS level
+        self.cv_LPAR.lpar_get_OS_Level()
+
+        # Check whether git and gcc commands are available on lpar
+        self.cv_LPAR.lpar_check_command("git")
+        self.cv_LPAR.lpar_check_command("gcc")
+
+        # Clone latest linux git repository into l_dir
+        l_dir = "/tmp/linux"
+        self.cv_LPAR.lpar_clone_linux_source(l_dir)
+
+        # Check for switch_endian test directory.
+        self.check_dir_exists(l_dir)
+
+        # make the required files
+        self.make_test(l_dir)
+
+        # Run the switch_endian sys call test once
+        l_rc = self.run_once(l_dir)
+        if int(l_rc) == 1:
+            print "Switch endian sys call test got succesful"
+            return BMC_CONST.FW_SUCCESS
+        else:
+            print "Switch endian sys call test failed"
+            return BMC_CONST.FW_FAILED
+
+    ##
+    # @brief  It will check for existence of switch_endian directory in the cloned repository
+    #
+    # @param i_dir @type string: linux source directory
+    #
+    # @return 1-success or raise OpTestError
+    #
+    def check_dir_exists(self, i_dir):
+        l_dir = '%s/tools/testing/selftests/powerpc/switch_endian' % i_dir
+        l_cmd = "test -d %s; echo $?" % l_dir
+        print l_cmd
+        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        print l_res
+        l_res = l_res.replace("\r\n", "")
+        if int(l_res) == 0:
+            print "Switch endian test directory exists"
+            return 1
+        else:
+            l_msg = "Switch endian directory is not present"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief  It will prepare for executable bin files using make command
+    #         At the end it will check for bin file switch_endian_test and
+    #         will throw an exception in case of missing bin file after make
+    #
+    # @param i_dir @type string: linux source directory
+    #
+    # @return 1-success or raise OpTestError
+    #
+    def make_test(self, i_dir):
+        l_cmd = "cd %s/tools/testing/selftests/powerpc/switch_endian;\
+                 make;" % i_dir
+        print l_cmd
+        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_cmd = "test -f %s/tools/testing/selftests/powerpc/switch_endian/switch_endian_test; echo $?" % i_dir
+        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = l_res.replace("\r\n", "")
+        if int(l_res) == 0:
+            print "Executable binary switch_endian_test is available"
+            return 1
+        else:
+            l_msg = "Switch_endian_test bin file is not present after make"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function will run executable file switch_endian_test and
+    #        check for switch_endian() sys call functionality
+    #
+    # @param i_dir @type string: linux source directory
+    #
+    # @return 1-success ; 0-fail
+    #
+    def run_once(self, i_dir):
+        l_cmd = "cd %s/tools/testing/selftests/powerpc/switch_endian/;\
+                 ./switch_endian_test" % i_dir
+        print l_cmd
+        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        if (l_res.__contains__('success: switch_endian_test')):
+            return 1
+        else:
+            return 0

--- a/testcases/__init__.py
+++ b/testcases/__init__.py
@@ -1,8 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/python
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-ci-bmc-run $
+# $Source: op-auto-test/testcases/__init__.py $
 #
 # OpenPOWER Automated Test Project
 #
@@ -23,23 +23,3 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-use strict;
-my @argv = @ARGV;
-my $function = shift(@argv);
-my $cmd = "python -c \"";
-$cmd .= "import sys
-import os
-# Get path to base directory and append to path to get common modules
-full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('bvt')[0]
-sys.path.append(full_path)
-# TODO - Just call common API's directly
-import ci.source.op_ci_bmc as op_ci_bmc
-import ci.source.op_inbound_hpm as op_inbound_hpm
-import ci.source.op_opal_fvt as op_opal_fvt
-
-sys.exit( $function )\"";
-#print "cmd: $cmd\n";
-my $rc = system($cmd);
-#print "python returned $rc from system()\n";
-if ($rc) { $rc = 1; } # make sure the exit code is OK for the shell
-exit($rc);


### PR DESCRIPTION
    1. Hardware monitoring sensors(hwmon driver) using sensors utility
    2. Switch endian sys call test which is implemented in linux git repository
For the above two features source files OpTestSensors.py and OpTestSwitchEndianSyscall.py are implemented in common directory

op_ci_fvt.py,test_op_fvt.py : In these files will keep adding new OPAL feature test functions, which are implemented in common directory.

op-fvt-basic.xml : In this xml file calling above test functions inorder to execute the above test functions

op-ci-bmc-run : In this file imported op_ci_fvt, inoreder to invoke the test case.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>