### PR TITLE
Removing the redundancy code lines from the ipmi_get_occ_status function

### DIFF
--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -538,6 +538,3 @@ class OpTestIPMI():
             raise OpTestError(l_msg)
 
         return l_result
-        l_rc =  self._ipmitool_cmd_run(self.cv_cmd + BMC_CONST.BMC_MCHBLD)
-        print l_rc
-        return l_rc


### PR DESCRIPTION
Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>