### PR TITLE
Adding new test cases for below OPAL features

### DIFF
--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -38,6 +38,24 @@
 
         <test>
             <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_i2c_driver()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_at24_driver()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_real_time_clock()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_sensors()"</cmd>
                 <exitonerror>no</exitonerror>
             </testcase>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -46,6 +46,9 @@ import ConfigParser
 
 from testcases.OpTestSensors import OpTestSensors
 from testcases.OpTestSwitchEndianSyscall import OpTestSwitchEndianSyscall
+from testcases.OpTestRTCdriver import OpTestRTCdriver
+from testcases.OpTestAt24driver import OpTestAt24driver
+from testcases.OpTestI2Cdriver import OpTestI2Cdriver
 
 
 def _config_read():
@@ -77,6 +80,30 @@ opTestSwitchEndianSyscall = OpTestSwitchEndianSyscall(bmcCfg['ip'],
                                                       lparCfg['lparuser'],
                                                       lparCfg['lparpasswd'])
 
+opTestRTCdriver = OpTestRTCdriver(bmcCfg['ip'],
+                                  bmcCfg['username'],
+                                  bmcCfg['password'],
+                                  bmcCfg['usernameipmi'],
+                                  bmcCfg['passwordipmi'],
+                                  testCfg['ffdcdir'],
+                                  lparCfg['lparip'],
+                                  lparCfg['lparuser'],
+                                  lparCfg['lparpasswd'])
+
+opTestAt24driver = OpTestAt24driver(bmcCfg['ip'], bmcCfg['username'],
+                                    bmcCfg['password'],
+                                    bmcCfg['usernameipmi'],
+                                    bmcCfg['passwordipmi'],
+                                    testCfg['ffdcdir'], lparCfg['lparip'],
+                                    lparCfg['lparuser'], lparCfg['lparpasswd'])
+
+opTestI2Cdriver = OpTestI2Cdriver(bmcCfg['ip'], bmcCfg['username'],
+                                  bmcCfg['password'],
+                                  bmcCfg['usernameipmi'],
+                                  bmcCfg['passwordipmi'],
+                                  testCfg['ffdcdir'], lparCfg['lparip'],
+                                  lparCfg['lparuser'], lparCfg['lparpasswd'])
+
 
 def test_init():
     """This function validates the test config before running other functions
@@ -105,3 +132,24 @@ def test_switch_endian_syscall():
     returns: int 0: success, 1: error
     """
     return opTestSwitchEndianSyscall.testSwitchEndianSysCall()
+
+
+def test_real_time_clock():
+    """This function tests Real Time Clock driver functionalites using hwclock utility
+    returns: int 0-success, raises exception-error
+    """
+    return opTestRTCdriver.test_RTC_driver()
+
+
+def test_at24_driver():
+    """This function tests Atmel EEPROM 24(AT24) driver functionalites
+    returns: int 0-success, raises exception-error
+    """
+    return opTestAt24driver.testAt24driver()
+
+
+def test_i2c_driver():
+    """This function tests I2C driver capabilites using i2c-tools
+    returns: int 0-success, raises exception-error
+    """
+    return opTestI2Cdriver.testI2Cdriver()

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -44,3 +44,15 @@ def test_sensors():
 
 def test_switchendian_syscall():
     assert op_opal_fvt.test_switch_endian_syscall() == 0
+
+
+def test_rtc_driver():
+    assert op_opal_fvt.test_real_time_clock() == 0
+
+
+def test_at24_driver():
+    assert op_opal_fvt.test_at24_driver() == 0
+
+
+def test_i2c_driver():
+    assert op_opal_fvt.test_i2c_driver() == 0

--- a/testcases/OpTestAt24driver.py
+++ b/testcases/OpTestAt24driver.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestAt24driver.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestAt24driver
+#  At24(Atmel24) eeprom driver to support openpower platform
+#
+#  This driver has following functionalities.
+#  'at24' is the i2c client driver that interface the EEPROMs on the system.
+#   In P8 system, EEPROM devices contain the system VPDs information and this
+#   driver is capable of reading and programming the data to these devices.
+#
+
+import time
+import subprocess
+import re
+import sys
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestAt24driver():
+    ## Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief  This function has following test steps
+    #         1. Getting the lpar infromation(OS and kernel information)
+    #         2. Loading the necessary modules to test at24 device driver functionalites
+    #            (i2c_dev, i2c_opal and at24)
+    #         3. Getting the list of i2c buses and eeprom chip addresses
+    #         4. Accessing the registers visible through the i2cbus using i2cdump utility
+    #         5. Getting the eeprom device data using hexdump utility in hex + Ascii format
+    #
+    # @return BMC_CONST.FW_SUCCESS-success or raise OpTestError
+    #
+    def testAt24driver(self):
+
+        # Get OS level
+        self.cv_LPAR.lpar_get_OS_Level()
+
+        # Check whether i2cdump and hexdump commands are available on lpar
+        self.cv_LPAR.lpar_check_command("i2cdump")
+        self.cv_LPAR.lpar_check_command("hexdump")
+
+        # Get Kernel Version
+        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+
+        # Loading i2c_opal module based on config option
+        l_config = "CONFIG_I2C_OPAL"
+        l_module = "i2c_opal"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # Loading i2c_dev module based on config option
+        l_config = "CONFIG_I2C_CHARDEV"
+        l_module = "i2c_dev"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # Loading at24 module based on config option
+        l_config = "CONFIG_EEPROM_AT24"
+        l_module = "at24"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # Get infomtion of EEPROM chips
+        self.cv_LPAR.lpar_get_info_of_eeprom_chips()
+
+        # Get list of pairs of i2c bus and EEPROM device addresses in the lpar
+        l_chips = self.cv_LPAR.lpar_get_list_of_eeprom_chips()
+        for l_args in l_chips:
+            # Accessing the registers visible through the i2cbus using i2cdump utility
+            # l_args format: "0 0x51","1 0x53",.....etc
+            self.i2c_dump(l_args)
+
+        # Getting the list of sysfs eeprom interfaces
+        l_res = self.cv_LPAR.lpar_run_command("find /sys/ -name eeprom; echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            pass
+        else:
+            l_msg = "EEPROM sysfs entries are not created"
+            print l_msg
+            raise OpTestError(l_msg)
+        for l_dev in l_res:
+            if l_dev.__contains__("eeprom"):
+                # Getting the eeprom device data using hexdump utility in hex + Ascii format
+                self.cv_LPAR.lpar_hexdump(l_dev)
+            else:
+                pass
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This i2cdump function takes arguments in pair of a string like "i2cbus address".
+    #        i2cbus indicates the number or name of the I2C bus to be scanned. This number should
+    #        correspond  to  one  of  the busses listed by i2cdetect -l. address indicates
+    #        the address to be scanned on that bus, and is an integer between 0x03 and 0x77
+    #        i2cdump is a program to examine registers visible through the I2C bus
+    #
+    # @param i_args @type string: this is the argument to i2cdump utility
+    #                             args are in the form of "i2c-bus-number eeprom-chip-address"
+    #                             Ex: "0 0x51","3 0x52" ....etc
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def i2c_dump(self, i_args):
+        l_res = self.cv_LPAR.lpar_run_command("i2cdump -f -y %s; echo $?" % i_args)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "i2cdump failed on addr %s" % i_args
+            print l_msg
+            raise OpTestError(l_msg)

--- a/testcases/OpTestI2Cdriver.py
+++ b/testcases/OpTestI2Cdriver.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestI2Cdriver.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestI2Cdriver
+#  I2C driver to support openpower platform
+#
+#  This class will test functionality of following drivers
+#  I2C Driver(Inter-Integrated Circuit) driver
+#
+#
+
+import time
+import subprocess
+import re
+import sys
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestI2Cdriver():
+    ## Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief  This function has following test steps
+    #         1. Getting lpar information(OS and kernel info)
+    #         2. Checking the required utilites are present on lpar or not
+    #         3. Loading the necessary modules to test I2C device driver functionalites
+    #            (i2c_dev, i2c_opal and at24)
+    #         4. Getting the list of i2c buses
+    #         5. Querying the i2c bus for devices
+    #         3. Getting the list of i2c buses and eeprom chip addresses
+    #         4. Accessing the registers visible through the i2cbus using i2cdump utility
+    #         5. Listing the i2c adapter conetents and i2c bus entries to make sure sysfs entries
+    #            created for each bus.
+    #         6. Testing i2cget functionality for limited samples
+    #            Avoiding i2cset functionality, it may damage the system.
+    #
+    # @return BMC_CONST.FW_SUCCESS-success or raise OpTestError-fail
+    #
+    def testI2Cdriver(self):
+
+        # Get OS level
+        self.cv_LPAR.lpar_get_OS_Level()
+
+        # make sure install "i2c-tools" package in-order to run the test
+
+        # Check whether i2cdump, i2cdetect and hexdump commands are available on lpar
+        self.cv_LPAR.lpar_check_command("i2cdump")
+        self.cv_LPAR.lpar_check_command("i2cdetect")
+        self.cv_LPAR.lpar_check_command("hexdump")
+        self.cv_LPAR.lpar_check_command("i2cget")
+        self.cv_LPAR.lpar_check_command("i2cset")
+
+        # Get Kernel Version
+        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+
+        # loading i2c_opal module based on config option
+        l_config = "CONFIG_I2C_OPAL"
+        l_module = "i2c_opal"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # loading i2c_dev module based on config option
+        l_config = "CONFIG_I2C_CHARDEV"
+        l_module = "i2c_dev"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # loading at24 module based on config option
+        l_config = "CONFIG_EEPROM_AT24"
+        l_module = "at24"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # Get information of EEPROM chips
+        self.cv_LPAR.lpar_get_info_of_eeprom_chips()
+
+        # Get list of i2c buses available on lpar,
+        # l_list=["0","1"....]
+        # l_list1=["i2c-0","i2c-1","i2c-2"....]
+        l_list, l_list1 = self.cv_LPAR.lpar_get_list_of_i2c_buses()
+
+        # Scanning i2c bus for devices attached to it.
+        for l_bus in l_list:
+            self.query_i2c_bus(l_bus)
+
+        # Get list of pairs of i2c bus and EEPROM device addresses in the lpar
+        l_chips = self.cv_LPAR.lpar_get_list_of_eeprom_chips()
+        for l_args in l_chips:
+            # Accessing the registers visible through the i2cbus using i2cdump utility
+            # l_args format: "0 0x51","1 0x53",.....etc
+            self.i2c_dump(l_args)
+
+        # list i2c adapter conetents
+        l_res = self.cv_LPAR.lpar_run_command("ls -l /sys/class/i2c-adapter; echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            pass
+        else:
+            l_msg = "listing i2c adapter contents through the sysfs entry failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+        # Checking the sysfs entry of each i2c bus
+        for l_bus in l_list1:
+            l_res = self.cv_LPAR.lpar_run_command("ls -l /sys/class/i2c-adapter/%s; echo $?" % l_bus)
+            l_res = l_res.splitlines()
+            if int(l_res[-1]) == 0:
+                pass
+            else:
+                l_msg = "listing i2c bus contents through the sysfs entry failed"
+                print l_msg
+                raise OpTestError(l_msg)
+
+        # Currently testing only getting the data from a data address, avoiding setting data.
+        # Only four samples are gathered to check whether reading eeprom  data is working or not.
+        # Setting eeprom data is dangerous and make your system UNBOOTABLE
+        l_addrs = ["0x00", "0x10", "0x20", "0x30", "0x40", "0x50", "0x60", "0x70", "0x80", "0x90", "0xa0", "0xb0", "0xc0", "0xd0", "0xe0", "0xf0"]
+        for l_addr in l_addrs:
+            l_val = self.i2c_get(l_chips[1], l_addr)
+            # self.i2c_set(l_list2[1], l_addr, "0x50")
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function query's the i2c bus for devices attached to it.
+    #        i2cdetect is a utility to scan an I2C bus for devices
+    #
+    # @param i_bus @type string: i2c bus numer
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def query_i2c_bus(self, i_bus):
+        print "Querying the i2c bus for devices attached to it"
+        l_res = self.cv_LPAR.lpar_run_command("i2cdetect -y %i; echo $?" % int(i_bus))
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Querying the i2cbus for devices failed:%s" % i_bus
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This i2cdump function takes arguments in pair of a string like "i2cbus address".
+    #        i2cbus indicates the number or name of the I2C bus to be scanned. This number should
+    #        correspond  to  one  of  the busses listed by i2cdetect -l. address indicates
+    #        the address to be scanned on that bus, and is an integer between 0x03 and 0x77
+    #        i2cdump is a program to examine registers visible through the I2C bus
+    #
+    # @param i_args @type string: this is the argument to i2cdump utility
+    #                             args are in the form of "i2c-bus-number eeprom-chip-address"
+    #                             Ex: "0 0x51","3 0x52" ....etc
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def i2c_dump(self, i_args):
+        l_res = self.cv_LPAR.lpar_run_command("i2cdump -f -y %s; echo $?" % i_args)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "i2cdump failed for the device: %s" % i_args
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function i2cget read from I2C/SMBus chip registers
+    #        command usage: i2cget [-f] [-y] i2cbus chip-address [data-address [mode]]
+    #
+    # @param i_args @type string: this is the argument to i2cget utility
+    #                             args are in the form of "i2c-bus-number eeprom-chip-address"
+    #                             Ex: "0 0x51","3 0x52" ....etc
+    # @param i_addr @type string: this is the data-address on chip, from where data will be read
+    #                             Ex: "0x00","0x10","0x20"...
+    #
+    # @return l_res @type string: data present on data-address or raise OpTestError
+    #
+    def i2c_get(self, i_args, i_addr):
+        l_res = self.cv_LPAR.lpar_run_command("i2cget -f -y %s %s;echo $?" % (i_args, i_addr))
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return l_res
+        else:
+            l_msg = "i2cget: Getting data from address %s failed" % i_addr
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function i2cset will be used for setting I2C registers
+    #        command usage: i2cset [-f] [-y] [-m mask] [-r] i2cbus chip-address data-address [value] ...  [mode]
+    #
+    # @param i_args @type string: this is the argument to i2cset utility
+    #                             args are in the form of "i2c-bus-number eeprom-chip-address"
+    #                             Ex: "0 0x51","3 0x52" ....etc
+    # @param i_addr @type string: this is the data-address on chip, where data will be set
+    #                             Ex: "0x00","0x10","0x20"...
+    # @param i_val @type string: this is the value which will be set into data-address i_addr
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def i2c_set(self, i_args, i_addr, i_val):
+        l_res = self.cv_LPAR.lpar_run_command("i2cset -f -y %s %s %s;echo $?" % (i_args, i_addr, i_val))
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "i2cset: Setting the data to a address %s failed" % i_addr
+            print l_msg
+            raise OpTestError(l_msg)

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -1,0 +1,401 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestRTCdriver.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestRTCdriver
+#  RTC package for OpenPower testing.
+#
+#  This class will test the functionality of following drivers
+#  1. RTC driver: Real time clock
+
+import time
+import subprocess
+import re
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestRTCdriver():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief This function will cover following test steps
+    #        1. Getting lpar information(OS and Kernel info)
+    #        2. Loading rtc_opal module based on config option
+    #        3. Testing the rtc driver functions
+    #                Display the current time,
+    #                set the Hardware Clock to a specified time,
+    #                set the Hardware Clock from the System Time, or
+    #                set the System Time from the Hardware Clock
+    #                keep the Hardware clock in UTC or local time format
+    #                Hardware clock compare, predict and adjust functions
+    #                Hardware clock debug and test modes
+    #                Reading the Hardware clock from special file instead of default
+    #        4. After executing above each function reading the Hardware clock in b/w functions.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_RTC_driver(self):
+
+        # Get OS level
+        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+
+        # Get Kernel Version
+        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+
+        # Get hwclock version
+        l_hwclock = self.cv_LPAR.lpar_run_command("hwclock -V;echo $?")
+
+        # loading rtc_opal module based on config option
+        l_config = "CONFIG_RTC_DRV_OPAL"
+        l_module = "rtc_opal"
+        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+
+        # Get the device files for rtc driver
+        l_res = self.cv_LPAR.lpar_run_command("ls /dev/ | grep -i --color=never rtc")
+        l_files = l_res.splitlines()
+        l_list = []
+        for name in l_files:
+            if name.__contains__("rtc"):
+                l_file = "/dev/" + name
+                l_list.append(l_file)
+            else:
+                continue
+        print l_list
+
+        # Display the time of hwclock from device files
+        for l_file in l_list:
+            self.read_hwclock_from_file(l_file)
+
+        self.cv_LPAR.lpar_read_hwclock()
+        time.sleep(5)
+        self.cv_LPAR.lpar_set_hwclock_time("2015-01-01 10:10:10")
+        time.sleep(5)
+        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_LPAR.lpar_set_hwclock_time("2016-01-01 20:20:20")
+        self.cv_LPAR.lpar_read_hwclock()
+        self.set_hwclock_in_utc("2017-01-01 10:10:10")
+        self.cv_LPAR.lpar_read_hwclock()
+        self.set_hwclock_in_localtime("2014-01-01 05:05:05")
+        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_LPAR.lpar_read_systime()
+        self.systime_to_hwclock()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.systime_to_hwclock_in_utc()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.systime_to_hwclock_in_localtime()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_to_systime()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_LPAR.lpar_read_systime()
+        self.hwclock_in_utc()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_in_localtime()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_predict("2015-01-01 10:10:10")
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_debug_mode()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_test_mode("2018-01-01 10:10:10")
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_adjust()
+        self.cv_LPAR.lpar_read_hwclock()
+        self.hwclock_compare()
+        self.cv_LPAR.lpar_read_hwclock()
+
+    ##
+    # @brief This function reads hwclock from special /dev/... file instead of default
+    #
+    # @param i_file @type string: special /dev/ file
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def read_hwclock_from_file(self, i_file):
+        print "Reading the hwclock from special file /dev/ ...: %s" % i_file
+        l_res = self.cv_LPAR.lpar_run_command("hwclock -r -f %s;echo $?" % i_file)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Reading the hwclock from file failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets hwclock in UTC format
+    #
+    # @param i_time @type string: time to set hwclock
+    #                             Ex: "2016-01-01 12:12:12"
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def set_hwclock_in_utc(self, i_time):
+        print "Setting the hwclock in UTC: %s" % i_time
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --utc;echo $?" % i_time)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the hwclock in UTC failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets hwclock in local time format
+    #
+    # @param i_time @type string: Time to set hwclock
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def set_hwclock_in_localtime(self, i_time):
+        print "Setting the hwclock in localtime: %s" % i_time
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --localtime;echo $?" % i_time)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the hwclock in localtime failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets the time of hwclock from system time
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def systime_to_hwclock(self):
+        print "Setting the hwclock from system time"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the hwclock from system time failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets the time of hwclock from system time in UTC format
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def systime_to_hwclock_in_utc(self):
+        print "Setting the hwclock from system time, in UTC format"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --utc;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the hwclock from system time in UTC format failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets the time of hwclock from system time in local time format
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def systime_to_hwclock_in_localtime(self):
+        print "Setting the hwclock from system time, in localtime format"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --localtime;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the hwclock from system time in localtime format failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function sets the system time from hwclock.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_to_systime(self):
+        print "Setting the system time from hwclock"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --hctosys;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the system time from hwclock failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function keeps hwclock in UTC format.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_in_utc(self):
+        print "Keeping the hwclock in UTC format"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --utc;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Keeping the hwclock in UTC is failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function keeps hwclock in local time format.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_in_localtime(self):
+        print "Keeping the hwclock in localtime"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --localtime;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Keeping the hwclock in localtime is failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function tests hwclock compare functionality for a time of 100 seconds.
+    #        Here checking the return status of timeout as 124, if compare works fine. any
+    #        other return value means compare function failed.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_compare(self):
+        print "Testing hwclock compare functionality for a time of 100 seconds"
+        l_res = self.cv_LPAR.lpar_run_command("timeout 100 hwclock --compare; echo $?")
+        l_res = l_res.splitlines()
+        print l_res
+        if int(l_res[-1]) == 124:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "hwclock compare function failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function predict RTC reading at time given with --date
+    #
+    # @param i_time @type string: time at which predict hwclock reading
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_predict(self, i_time):
+        print "Testing the hwclock predict function to a time: %s" % i_time
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --predict --date \'%s\';echo $?" % i_time)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "hwclock predict function failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function tests hwclock debug mode.
+    #        In this mode setting hwclock from system time
+    #        and setting system time from hwclock
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_debug_mode(self):
+        print "Testing the hwclock debug mode"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --debug;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            pass
+        else:
+            l_msg = "Setting the hwclock from system time in debug mode failed"
+            print l_msg
+            raise OpTestError(l_msg)
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --hctosys --debug;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "Setting the system time from hwclock in debug mode failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function tests the hwclock test mode. In this mode setting the hwclock
+    #        time using --set option. Here it just execute but should not set hwclock time.
+    #
+    # @param i_time @type string: time to set hwclock in test mode
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_test_mode(self, i_time):
+        print "Testing the hwclock test mode, set time to: %s" % i_time
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --test;echo $?" % i_time)
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "hwclock test function failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function tests hwclock adjust functionality
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def hwclock_adjust(self):
+        print "Testing the hwclock adjust function"
+        l_res = self.cv_LPAR.lpar_run_command("hwclock --adjust;echo $?")
+        l_res = l_res.splitlines()
+        if int(l_res[-1]) == 0:
+            l_res = self.cv_LPAR.lpar_run_command("cat /etc/adjtime")
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "hwclock adjust function failed"
+            print l_msg
+            raise OpTestError(l_msg)


### PR DESCRIPTION
OpTestRTCdriver.py--->To test Real time clock driver(RTC driver)
OpTestAt24driver.py-->To test Atmel 24 driver(At24 driver)
OpTestI2Cdriver.py--->To test I2C driver

Signed-off-by: pridhiviraj <ppaidipe@linux.vnet.ibm.com>