### PR TITLE
In this script sys.argv[0] is taking "python -c" from op-ci-bmc-run f…

### DIFF
--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -37,7 +37,8 @@ import sys
 import os
 
 # Get path to base directory and append to path to get common modules
-full_path = os.path.abspath(os.path.dirname(sys.argv[0])).split('ci')[0]
+full_path = os.path.dirname(os.path.abspath(__file__))
+full_path = full_path.split('ci')[0]
 sys.path.append(full_path)
 
 import ConfigParser


### PR DESCRIPTION
…ile, it is not

taking full path of current file. This fix will get initially full path to current file.
Then we are extracting path of base directory and adding to PATH, in order to import common
modules

Signed-off-by: pridhiviraj <ppaidipe@linux.vnet.ibm.com>
