### PR TITLE
Test cases for HMI Handling

### DIFF
--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -38,6 +38,43 @@
 
         <test>
             <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_proc_recv_done()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_proc_recv_error_masked()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_malfunction_alert()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.clear_gard_entries()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_hypervisor_resource_error()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.clear_gard_entries()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_i2c_driver()"</cmd>
                 <exitonerror>no</exitonerror>
             </testcase>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -44,6 +44,7 @@ full_path = full_path.split('ci')[0]
 sys.path.append(full_path)
 import ConfigParser
 
+from common.OpTestConstants import OpTestConstants as BMC_CONST
 from testcases.OpTestSensors import OpTestSensors
 from testcases.OpTestSwitchEndianSyscall import OpTestSwitchEndianSyscall
 from testcases.OpTestHeartbeat import OpTestHeartbeat
@@ -52,6 +53,7 @@ from testcases.OpTestAt24driver import OpTestAt24driver
 from testcases.OpTestI2Cdriver import OpTestI2Cdriver
 from testcases.OpTestMtdPnorDriver import OpTestMtdPnorDriver
 from testcases.OpTestInbandIPMI import OpTestInbandIPMI
+from testcases.OpTestHMIHandling import OpTestHMIHandling
 
 
 def _config_read():
@@ -128,6 +130,12 @@ opTestInbandIPMI = OpTestInbandIPMI(bmcCfg['ip'], bmcCfg['username'],
                               testCfg['ffdcdir'], lparCfg['lparip'],
                               lparCfg['lparuser'], lparCfg['lparpasswd'])
 
+opTestHMIHandling = OpTestHMIHandling(bmcCfg['ip'], bmcCfg['username'],
+                                          bmcCfg['password'],
+                                          bmcCfg['usernameipmi'],
+                                          bmcCfg['passwordipmi'],
+                                          testCfg['ffdcdir'], lparCfg['lparip'],
+                                          lparCfg['lparuser'], lparCfg['lparpasswd'])
 
 def test_init():
     """This function validates the test config before running other functions
@@ -192,9 +200,44 @@ def test_mtd_pnor_driver():
     """
     return opTestMtdPnorDriver.testMtdPnorDriver()
 
+
 def test_ipmi_inband_functionality():
     """This function tests whether the kopald service is running in platform OS
     returns: int 0-success, raises exception-error
     """
     return opTestInbandIPMI.test_ipmi_inband_functionality()
 
+
+def test_hmi_proc_recv_done():
+    """This function tests HMI recoverable error: processor recovery done
+    returns: int 0-success, raises exception-error
+    """
+    return opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_PROC_RECV_DONE)
+
+def test_hmi_proc_recv_error_masked():
+    """This function tests HMI recoverable error: proc_recv_error_masked
+    returns: int 0-success, raises exception-error
+    """
+    return opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_PROC_RECV_ERROR_MASKED)
+
+
+def clear_gard_entries():
+    """This function reboots the system and then clears any hardware gards through gard utility.
+    And finally reboots the system again to stable point.
+    returns: int 0-success, raises exception-error
+    """
+    return opTestHMIHandling.clearGardEntries()
+
+
+def test_hmi_malfunction_alert():
+    """This function tests HMI Malfunction alert: Core checkstop functionality
+    returns: int 0-success, raises exception-error
+    """
+    return opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_MALFUNCTION_ALERT)
+
+
+def test_hmi_hypervisor_resource_error():
+    """This function tests HMI: Hypervisor resource error functionality
+        returns: int 0-success, raises exception-error
+    """
+    return opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_HYPERVISOR_RESOURCE_ERROR)

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -55,3 +55,18 @@ def test_mtdpnor_driver():
 def test_ipmi_inband_functionality():
     assert op_opal_fvt.test_ipmi_inband_functionality() == 0
 
+def test_hmi_proc_recv_done():
+    assert op_opal_fvt.test_hmi_proc_recv_done() == 0
+
+def test_hmi_proc_recv_error_masked():
+    assert op_opal_fvt.test_hmi_proc_recv_error_masked() == 0
+
+def test_hmi_malfunction_alert():
+    assert op_opal_fvt.test_hmi_malfunction_alert() == 0
+
+def test_hmi_hypervisor_resource_error():
+    assert op_opal_fvt.test_hmi_hypervisor_resource_error() == 0
+
+def test_clearing_gard_entries():
+    assert op_opal_fvt.clear_gard_entries() == 0
+

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -30,6 +30,8 @@
 #  This class encapsulates commands and constants which deals with the BMC in OpenPower
 #  systems
 
+import pexpect
+
 class OpTestConstants():
 
     # Platforms
@@ -135,3 +137,35 @@ class OpTestConstants():
     SCP_TO_REMOTE = 1
     SCP_TO_LOCAL = 2
 
+    # Constants related to ipmi console interfaces
+    IPMI_SOL_ACTIVATE_TIME = 5
+    IPMI_SOL_DEACTIVATE_TIME = 10
+    IPMI_WAIT_FOR_TERMINATING_SESSION = 10
+    IPMI_CON_DELAY_BEFORE_SEND = 0.9
+
+    IPMI_SOL_CONSOLE_ACTIVATE_OUTPUT = ["[SOL Session operational.  Use ~? for help]\r\n", \
+        "Error: Unable to establish IPMI v2 / RMCP+ session", \
+        pexpect.TIMEOUT, pexpect.EOF]
+    IPMI_CONSOLE_EXPECT_ENTER_OUTPUT = ["login: ", "#", "/ #", "Petitboot", pexpect.TIMEOUT, pexpect.EOF]
+    IPMI_CONSOLE_EXPECT_LOGIN = 0
+    IPMI_CONSOLE_EXPECT_PASSWORD = 0
+    IPMI_CONSOLE_EXPECT_PETITBOOT = [2,3]
+    IPMI_CONSOLE_EXPECT_RANDOM_STATE = [4,5]
+    IPMI_LPAR_UNIQUE_PROMPT = "PS1=[pexpect]#"
+    IPMI_LPAR_EXPECT_PEXPECT_PROMPT = "[pexpect]#"
+    IPMI_LPAR_EXPECT_PEXPECT_PROMPT_LIST = [r"\[pexpect\]#$", pexpect.TIMEOUT]
+
+    # HMI Test case constants
+    HMI_PROC_RECV_DONE = 1
+    HMI_PROC_RECV_ERROR_MASKED = 2
+    HMI_MALFUNCTION_ALERT = 3
+    HMI_HYPERVISOR_RESOURCE_ERROR = 4
+    HMI_TEST_CASE_SLEEP_TIME = 30
+
+    # CPU sleep states constants
+    GET_CPU_SLEEP_STATE2 = "cat /sys/devices/system/cpu/cpu*/cpuidle/state2/disable"
+    GET_CPU_SLEEP_STATE1 = "cat /sys/devices/system/cpu/cpu*/cpuidle/state1/disable"
+    GET_CPU_SLEEP_STATE0 = "cat /sys/devices/system/cpu/cpu*/cpuidle/state0/disable"
+
+    DISABLE_CPU_SLEEP_STATE1 = "for i in /sys/devices/system/cpu/cpu*/cpuidle/state1/disable; do echo 1 > $i; done"
+    DISABLE_CPU_SLEEP_STATE2 = "for i in /sys/devices/system/cpu/cpu*/cpuidle/state2/disable; do echo 1 > $i; done"

--- a/common/OpTestLpar.py
+++ b/common/OpTestLpar.py
@@ -685,3 +685,79 @@ class OpTestLpar():
             l_msg = "hexdump failed for device %s" % i_dev
             print l_msg
             raise OpTestError(l_msg)
+
+    ##
+    # @brief It will clone latest skiboot git repository in i_dir directory
+    #
+    # @param i_dir @type string: directory where skiboot source will be cloned
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def lpar_clone_skiboot_source(self, i_dir):
+        l_msg = 'https://github.com/open-power/skiboot.git/'
+        l_cmd = "git clone %s %s" % (l_msg, i_dir)
+        self.lpar_run_command("git config --global http.sslverify false")
+        self.lpar_run_command("rm -rf %s" % i_dir)
+        self.lpar_run_command("mkdir %s" % i_dir)
+        try:
+            print l_cmd
+            l_res = self.lpar_run_command(l_cmd)
+            print l_res
+            return BMC_CONST.FW_SUCCESS
+        except:
+            l_msg = "Cloning skiboot git repository is failed"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief It will compile xscom-utils in the skiboot directory which was cloned in i_dir directory
+    #
+    # @param i_dir @type string: directory where skiboot source was cloned
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def lpar_compile_xscom_utilities(self, i_dir):
+        l_cmd = "cd %s/external/xscom-utils; make;" % i_dir
+        print l_cmd
+        l_res = self.lpar_run_command(l_cmd)
+        l_cmd = "test -f %s/external/xscom-utils/getscom; echo $?" % i_dir
+        l_res = self.lpar_run_command(l_cmd)
+        l_res = l_res.replace("\r\n", "")
+        if int(l_res) == 0:
+            print "Executable binary getscom is available"
+        else:
+            l_msg = "getscom bin file is not present after make"
+            print l_msg
+            raise OpTestError(l_msg)
+        l_cmd = "test -f %s/external/xscom-utils/putscom; echo $?" % i_dir
+        l_res = self.lpar_run_command(l_cmd)
+        l_res = l_res.replace("\r\n", "")
+        if int(l_res) == 0:
+            print "Executable binary putscom is available"
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "putscom bin file is not present after make"
+            print l_msg
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief It will compile gard utility in the skiboot directory which was cloned in i_dir directory
+    #
+    # @param i_dir @type string: directory where skiboot source was cloned
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def lpar_compile_gard_utility(self, i_dir):
+        l_cmd = "cd %s/external/gard; make;" % i_dir
+        print l_cmd
+        l_res = self.lpar_run_command(l_cmd)
+        l_cmd = "test -f %s/external/gard/gard; echo $?" % i_dir
+        l_res = self.lpar_run_command(l_cmd)
+        l_res = l_res.replace("\r\n", "")
+        if int(l_res) == 0:
+            print "Executable binary gard is available"
+            return BMC_CONST.FW_SUCCESS
+        else:
+            l_msg = "gard bin file is not present after make"
+            print l_msg
+            raise OpTestError(l_msg)

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -32,6 +32,9 @@
 
 import time
 import subprocess
+import pexpect
+import os
+import sys
 
 from OpTestBMC import OpTestBMC
 from OpTestIPMI import OpTestIPMI
@@ -618,3 +621,33 @@ class OpTestSystem():
             return self.cv_BMC.sys_execute_cmd_onto_bmc(i_cmd)
         except OpTestError as e:
             return BMC_CONST.FW_FAILED
+
+
+    ###########################################################################
+    # IPMI Console interfaces
+    ###########################################################################
+
+    ##
+    # @brief It will get the ipmi sol console
+    #
+    # @return l_con @type Object: it is a object of pexpect.spawn class or raise OpTestError
+    #
+    def sys_get_ipmi_console(self):
+        self.l_con = self.cv_IPMI.ipmi_get_console()
+        return self.l_con
+
+    ##
+    # @brief This function is used to close ipmi console
+    #
+    # @param i_con @type Object: it is a object of pexpect.spawn class
+    #                            this is the active ipmi sol console object
+    #
+    # @return BMC_CONST.FW_SUCCESS or return BMC_CONST.FW_FAILED
+    #
+    def sys_ipmi_close_console(self, i_con):
+        try:
+            l_con = i_con
+            self.cv_IPMI.ipmi_close_console(l_con)
+        except OpTestError as e:
+            return BMC_CONST.FW_FAILED
+        return BMC_CONST.FW_SUCCESS

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -1,0 +1,390 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestHMIHandling.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestHMIHandling
+#  HMI Handling package for OpenPower testing.
+#
+#  This class will test the functionality of following.
+#  1. HMI Non-recoverable errors - Core checkstop and Hypervisor resource error
+#  2. HMI Recoverable errors- proc_recv_done, proc_recv_error_masked and proc_recv_again
+
+import time
+import subprocess
+import re
+import sys
+import os
+import random
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestLpar import OpTestLpar
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestHMIHandling():
+    ## Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_lparIP The IP address of the LPAR
+    # @param i_lparuser The userid to log into the LPAR
+    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
+                 i_lparuser=None, i_lparPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_lparip, i_lparuser, i_lparPasswd)
+        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_lparip,
+                 i_lparuser, i_lparPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief This is a common function for all the hmi test cases. This will be executed before
+    #        any test case starts. Basically this provides below requirements.
+    #        1. Validates all required lpar commands
+    #        2. It will clone skiboot source repository
+    #        3. Compile the necessary tools xscom-utils and gard utility to test HMI.
+    #        4. Get the list Of Chips and cores in the form of dictionary.
+    #           Ex: [['00000000', ['4', '5', '6', 'c', 'd', 'e']], ['00000001', ['4', '5', '6', 'c', 'd', 'e']], ['00000010', ['4', '5', '6', 'c', 'd', 'e']]]
+    #        5. In-order to inject HMI errors on cpu's, cpu should be running,
+    #           so disabling the sleep states 1 and 2 of all CPU's.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_init(self):
+        # Get OS level
+        self.cv_LPAR.lpar_get_OS_Level()
+
+        # Check whether git and gcc commands are available on lpar
+        self.cv_LPAR.lpar_check_command("git")
+        self.cv_LPAR.lpar_check_command("gcc")
+
+        # It will clone skiboot source repository
+        l_dir = "/tmp/skiboot"
+        self.cv_LPAR.lpar_clone_skiboot_source(l_dir)
+        # Compile the necessary tools xscom-utils and gard utility
+        self.cv_LPAR.lpar_compile_xscom_utilities(l_dir)
+        self.cv_LPAR.lpar_compile_gard_utility(l_dir)
+
+        # Getting list of processor chip Id's(executing getscom -l to get chip id's)
+        l_res = self.cv_LPAR.lpar_run_command("cd %s/external/xscom-utils/; ./getscom -l" % l_dir)
+        l_res = l_res.splitlines()
+        l_chips = []
+        for line in l_res:
+            matchObj = re.search("(\d{8}).*processor", line)
+            if matchObj:
+                l_chips.append(matchObj.group(1))
+        if not l_chips:
+            l_msg = "Getscom failed to list processor chip id's"
+            raise OpTestError(l_msg)
+        l_chips.sort()
+        print l_chips # ['00000000', '00000001', '00000010']
+
+        # Currently getting the list of active core id's with respect to each chip is by using opal msg log
+        # TODO: Need to identify best way to get list of cores(If Opal msg log is empty)
+        l_cmd = "cat /sys/firmware/opal/msglog | grep -i CHIP"
+        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_cores = {}
+        self.l_dic = []
+        l_res = l_res.splitlines()
+        for line in l_res:
+            matchObj = re.search("Chip (\d{1,2}) Core ([a-z0-9])", line)
+            if matchObj:
+                if l_cores.has_key(int(matchObj.group(1))):
+                    (l_cores[int(matchObj.group(1))]).append(matchObj.group(2))
+                else:
+                    l_cores[int(matchObj.group(1))] = list(matchObj.group(2))
+        if not l_cores:
+            l_msg = "Failed in getting core id's information from OPAL msg log"
+            raise OpTestError(l_msg)
+
+        print l_cores # {0: ['4', '5', '6', 'c', 'd', 'e'], 1: ['4', '5', '6', 'c', 'd', 'e'], 10: ['4', '5', '6', 'c', 'd', 'e']}
+        l_cores = sorted(l_cores.iteritems())
+        print l_cores
+        i=0
+        for tup in l_cores:
+            new_list = [l_chips[i], tup[1]]
+            self.l_dic.append(new_list)
+            i+=1
+        print self.l_dic
+        # self.l_dic is a list of chip id's, core id's . and is of below format 
+        # [['00000000', ['4', '5', '6', 'c', 'd', 'e']], ['00000001', ['4', '5', '6', 'c', 'd', 'e']], ['00000010', ['4', '5', '6', 'c', 'd', 'e']]]
+
+        self.l_dir = l_dir
+        # In-order to inject HMI errors on cpu's, cpu should be running, so disabling the sleep states 1 and 2 of all CPU's
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE2)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE1)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE0)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.DISABLE_CPU_SLEEP_STATE1)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.DISABLE_CPU_SLEEP_STATE2)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE2)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE1)
+        self.cv_LPAR.lpar_run_command(BMC_CONST.GET_CPU_SLEEP_STATE0)
+
+    ##
+    # @brief This function is mainly used to clear hardware gard entries.
+    #        It will perform below steps
+    #           1. Reboot the system(Power off/on)
+    #           2. Clear any Hardware gard entries
+    #           3. Again reboot the system, to make use of garded Hardware.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def clearGardEntries(self):
+        # Power off and on the system.
+        self.cv_IPMI.ipmi_power_off()
+        self.cv_IPMI.ipmi_power_on()
+        if int(self.cv_SYSTEM.sys_ipl_wait_for_working_state()):
+            l_msg = "System failed to boot host OS"
+            raise OpTestError(l_msg)
+        time.sleep(BMC_CONST.LPAR_BRINGUP_TIME)
+
+        # Clearing gard entries after lpar comes up
+        self.cv_LPAR.lpar_get_OS_Level()
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_lpar_login(l_con)
+        self.cv_IPMI.ipmi_lpar_set_unique_prompt(l_con)
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("uname -a")
+        l_dir = "/tmp/skiboot"
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("cd %s/external/gard/;" % l_dir)
+        l_cmd = "./gard list; echo $?"
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+        l_cmd = "./gard clear all; echo $?"
+        l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+        if int(l_res[-1]):
+            l_msg = "Clearing gard entries through gard tool is failed"
+            raise OpTestError(l_msg)
+        l_cmd = "./gard list; echo $?"
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+
+        # Rebooting the system again to make use of garded hardware
+        self.cv_IPMI.ipmi_power_off()
+        self.cv_IPMI.ipmi_power_on()
+        if int(self.cv_SYSTEM.sys_ipl_wait_for_working_state()):
+            l_msg = "System failed to boot host OS"
+            raise OpTestError(l_msg)
+        time.sleep(BMC_CONST.LPAR_BRINGUP_TIME)
+        self.cv_LPAR.lpar_get_OS_Level()
+        self.cv_SYSTEM.sys_ipmi_close_console(l_con)
+
+    ##
+    # @brief This function executes HMI test case based on the i_test value, Before test starts
+    #        disabling kdump service to make sure system reboots, after injecting non-recoverable errors.
+    #
+    # @param i_test @type int: this is the type of test case want to execute
+    #                          BMC_CONST.HMI_PROC_RECV_DONE: Processor recovery done
+    #                          BMC_CONST.HMI_PROC_RECV_ERROR_MASKED: proc_recv_error_masked
+    #                          BMC_CONST.HMI_MALFUNCTION_ALERT: malfunction_alert
+    #                          BMC_CONST.HMI_HYPERVISOR_RESOURCE_ERROR: hypervisor resource error
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testHMIHandling(self, i_test):
+        l_test = i_test
+        self.test_init()
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_lpar_login(l_con)
+        self.cv_IPMI.ipmi_lpar_set_unique_prompt(l_con)
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("cat /etc/os-release")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("service kdump status")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("service kdump stop")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("service kdump status")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("cd %s/external/xscom-utils/;" % self.l_dir)
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("lscpu")
+        self.cv_IPMI.run_lpar_cmd_on_ipmi_console("dmesg -D")
+        if l_test == BMC_CONST.HMI_PROC_RECV_DONE:
+            self.test_proc_recv_done()
+        elif l_test == BMC_CONST.HMI_PROC_RECV_ERROR_MASKED:
+            self.test_proc_recv_error_masked()
+        elif l_test == BMC_CONST.HMI_MALFUNCTION_ALERT:
+            self.test_malfunction_allert()
+        elif l_test == BMC_CONST.HMI_HYPERVISOR_RESOURCE_ERROR:
+            self.test_hyp_resource_err()
+        else:
+            l_msg = "Please provide valid test case"
+            raise OpTestError(l_msg)
+        self.cv_SYSTEM.sys_ipmi_close_console(l_con)
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function is used to test HMI: processor recovery done
+    #        and also this function injecting error on all the cpus one by one and 
+    #        verify whether cpu is recovered or not.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_proc_recv_done(self):
+        for l_pair in self.l_dic:
+            l_chip = l_pair[0]
+            for l_core in l_pair[1]:
+                l_reg = "1%s013100" % l_core
+                l_cmd = "./putscom -c %s %s 0000000000100000; echo $?" % (l_chip, l_reg)
+
+                self.cv_IPMI.run_lpar_cmd_on_ipmi_console("dmesg -C")
+                time.sleep(10)
+                l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+                time.sleep(10)
+                if l_res[-1] == "0":
+                    print "Injected thread hang recoverable error"
+                else:
+                    if any("Kernel panic - not syncing" in line for line in l_res):
+                        l_msg = "Processor recovery failed: Kernel got panic"
+                    elif any("Petitboot" in line for line in l_res):
+                        l_msg = "System reached petitboot:Processor recovery failed"
+                    elif any("ISTEP" in line for line in l_res):
+                        l_msg = "System started booting: Processor recovery failed"
+                    else:
+                        l_msg = "Failed to inject thread hang recoverable error"
+                    print l_msg
+                    raise OpTestError(l_msg)
+
+                l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console("dmesg")
+                if any("Processor Recovery done" in line for line in l_res) and \
+                any("Harmless Hypervisor Maintenance interrupt [Recovered]" in line for line in l_res):
+                    print "Processor recovery done"
+                else:
+                    l_msg = "HMI handling failed to log message: for proc_recv_done"
+                    raise OpTestError(l_msg)
+                time.sleep(BMC_CONST.HMI_TEST_CASE_SLEEP_TIME)
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function is used to test HMI: proc_recv_error_masked
+    #        Processor went through recovery for an error which is actually masked for reporting
+    #        this function also injecting the error on all the cpu's one-by-one.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_proc_recv_error_masked(self):
+        for l_pair in self.l_dic:
+            l_chip = l_pair[0]
+            for l_core in l_pair[1]:
+                l_reg = "1%s013100" % l_core
+                l_cmd = "./putscom -c %s %s 0000000000080000; echo $?" % (l_chip, l_reg)
+                self.cv_IPMI.run_lpar_cmd_on_ipmi_console("dmesg -C")
+                time.sleep(10)
+                l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+                time.sleep(10)
+                if l_res[-1] == "0":
+                    print "Injected thread hang recoverable error"
+                else:
+                    if any("Kernel panic - not syncing" in line for line in l_res):
+                        l_msg = "Processor recovery failed: Kernel got panic"
+                    elif any("Petitboot" in line for line in l_res):
+                        l_msg = "System reached petitboot:Processor recovery failed"
+                    elif any("ISTEP" in line for line in l_res):
+                        l_msg = "System started booting: Processor recovery failed"
+                    else:
+                        l_msg = "Failed to inject thread hang recoverable error"
+                    print l_msg
+                    raise OpTestError(l_msg)
+
+                l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console("dmesg")
+                if any("Processor Recovery done" in line for line in l_res) and \
+                any("Harmless Hypervisor Maintenance interrupt [Recovered]" in line for line in l_res):
+                    print "Processor recovery done"
+                else:
+                    l_msg = "HMI handling failed to log message"
+                    raise OpTestError(l_msg)
+                time.sleep(BMC_CONST.HMI_TEST_CASE_SLEEP_TIME)
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function is used to test hmi malfunction alert:Core checkstop
+    #        A processor core in the system has to be checkstopped (failed recovery).
+    #        Injecting core checkstop on random core of random chip
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_malfunction_allert(self):
+        # Get random pair of chip vs cores
+        l_pair = random.choice(self.l_dic)
+        # Get random chip id
+        l_chip = l_pair[0]
+        # Get random core number
+        l_core = random.choice(l_pair[1])
+
+        l_reg = "1%s013100" % l_core
+        l_cmd = "./putscom -c %s %s 1000000000000000" % (l_chip, l_reg)
+
+        l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+        if any("Kernel panic - not syncing" in line for line in l_res):
+            print "Malfunction alert: kernel got panic"
+        elif any("login:" in line for line in l_res):
+            print "System booted to host OS without any kernel panic message"
+        elif any("Petitboot" in line for line in l_res):
+            print "System reached petitboot without any kernel panic message"
+        elif any("ISTEP" in line for line in l_res):
+            print "System started booting without any kernel panic message"
+        else:
+            l_msg = "HMI: Malfunction alert failed"
+            raise OpTestError(l_msg)
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function is used to test HMI: Hypervisor resource error
+    #        Injecting Hypervisor resource error on random core of random chip
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_hyp_resource_err(self):
+        # Get random pair of chip vs cores
+        l_pair = random.choice(self.l_dic)
+        # Get random chip id
+        l_chip = l_pair[0]
+        # Get random core number
+        l_core = random.choice(l_pair[1])
+
+        l_reg = "1%s013100" % l_core
+        l_cmd = "./putscom -c %s %s 0000000000008000" % (l_chip, l_reg)
+
+        l_res = self.cv_IPMI.run_lpar_cmd_on_ipmi_console(l_cmd)
+        if any("Kernel panic - not syncing" in line for line in l_res) and \
+        any("Hypervisor Resource error - core check stop" in line for line in l_res):
+            print "Hypervisor resource error: kernel got panic"
+        elif any("login:" in line for line in l_res):
+            print "System booted to host OS without any kernel panic message"
+        elif any("Petitboot" in line for line in l_res):
+            print "System reached petitboot without any kernel panic message"
+        elif any("ISTEP" in line for line in l_res):
+            print "System started booting without any kernel panic message"
+        else:
+            l_msg = "HMI: Hypervisor resource error failed"
+            raise OpTestError(l_msg)
+        return BMC_CONST.FW_SUCCESS


### PR DESCRIPTION
Added below test cases for HMI handling
    1. Core checkstop
    2. Hypervisor resource error
    3. processor recovery done
    4. proc_recv_err_masked
And also added ipmi console inetrafces in IPMI, SYSTEM and LPAR libraries.

Signed-off-by: pridhiviraj <ppaidipe@linux.vnet.ibm.com>