### PR TITLE
Perl cleanup: use modules and clean-up code

### DIFF
--- a/bvt/OPBVTXML.pm
+++ b/bvt/OPBVTXML.pm
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/bvt/run-op-bvt $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2016
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# Run OpenPower automated build verification test (BVT)
+#
+# Author: Stewart Smith
+
+package OPBVTXML;
+
+use XML::LibXML;
+
+sub bvt_xml_expand_all
+{
+    my ($xmlfile) = @_;
+
+    my $parser = XML::LibXML->new();
+    my $dom = XML::LibXML->load_xml(location => $xmlfile);
+    $parser->process_xincludes($dom);
+
+    for my $bvt_xml_node ($dom->findnodes('//*[local-name()="bvt-xml"]')) {
+        # We treat <bvt-xml> as an include
+        # so we grab the content of the file, insert it into the doc.
+        my $bvt_xml_file = XML::LibXML->load_xml(location => $bvt_xml_node->textContent);
+        $parser->process_xincludes($bvt_xml_file);
+        $bvt_xml_node->replaceNode($bvt_xml_file->documentElement());
+    }
+
+    return $dom;
+}
+
+# Validate the syntax of the specified XML file
+sub bvt_xml_is_valid
+{
+    my ($schemafn, $xmlfile) = @_;
+
+    my $dom = bvt_xml_expand_all($xmlfile);
+
+    # Validate the resulting XML
+    my $xmlschema = XML::LibXML::Schema->new(location => $schemafn);
+
+    return ! eval { $xmlschema->validate($dom) };
+}
+
+1;

--- a/bvt/OpTestInfra.pm
+++ b/bvt/OpTestInfra.pm
@@ -23,11 +23,11 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-                                                                                
+
 # OpTestInfra: Common perl functions for OpenPower IT/BVT test infrastructure
 #
 # Author: Alan Hlava
-                                                                                
+
 #use strict;
 use Fcntl qw(:DEFAULT :flock LOCK_EX LOCK_UN);
 
@@ -48,12 +48,11 @@ require Exporter;
 @EXPORT = qw(set_verbose is_verbose_enabled vprint set_failsumm_log clear_log_hist add_log_hist add_log_hist_file write_log_hist trim findRelFile);
 @EXPORT_OK = qw($verbose $verbose_file);
 
-                                                                                
 # set_verbose
 #    arg1 : 0=no verbose tracing, 1=verbose tracing to STDERRR
 #    arg2 : [optional] instead of STDERR append verbose output to this file
 #           (overrides arg1)
-                                                                                
+
 sub set_verbose
 {
     my ($vval, $vfile) = @_;
@@ -62,17 +61,11 @@ sub set_verbose
     $ppid = getppid();
 }
 
-                                                                                
-# is_verbose_enabled
-                                                                                
 sub is_verbose_enabled
 {
     return( $verbose || ($verbose_file ne "") );
 }
 
-                                                                                
-# vprint
-                                                                                
 sub vprint
 {
     my ($str) = @_;
@@ -110,11 +103,9 @@ sub vprint
 
 }
 
-                                                                                
 # set_failsumm_log
 #    arg1 : Fully qualiified name of fail summary file
 #    arg2 : [optional] Size of log history to print in the fail summary file
-                                                                                
 sub set_failsumm_log
 {
     my ($fn, $lim) = @_;
@@ -127,18 +118,12 @@ sub set_failsumm_log
     $ppid = getppid();
 }
 
-                                                                                
-# clear_log_hist
-                                                                                
 sub clear_log_hist
 {
     @log_hist = ();
     $log_hist_count = 0;
 }
 
-                                                                                
-# add_log_hist
-                                                                                
 sub add_log_hist
 {
     my ($msg) = @_;
@@ -153,9 +138,6 @@ sub add_log_hist
     }
 }
 
-                                                                                
-# add_log_hist_file
-                                                                                
 sub add_log_hist_file
 {
     my ($msg_file) = @_;
@@ -168,10 +150,8 @@ sub add_log_hist_file
     }
 }
 
-                                                                                
 # write_log_hist
 #    arg1 : Write history separator line? (blank=no, non-blank=yes, and use this text in it)
-                                                                                
 sub write_log_hist
 {
     my ($septitle) = @_;
@@ -213,9 +193,6 @@ sub write_log_hist
     clear_log_hist();
 }
 
-                                                                                
-# trim
-                                                                                
 sub trim
 {
     my ($str) = @_;

--- a/bvt/helloworld-include.xml
+++ b/bvt/helloworld-include.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-outofband-firmware-update.xml $           -->
+<!-- $Source: op-auto-test/bvt/helloworld.xml $                             -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->
@@ -24,45 +24,8 @@
 <!--                                                                        -->
 <!-- IBM_PROLOG_END_TAG                                                     -->
 
-<integrationtest>
-    <platform>
-
-        <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_PNOR_level()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_side_activated()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.cold_reset()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.preserve_network_setting()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.code_update()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-    </platform>
-</integrationtest>
+<test>
+  <testcase>
+    <cmd>echo "Hello, INCLUDED world!"</cmd>
+  </testcase>
+</test>

--- a/bvt/helloworld.xml
+++ b/bvt/helloworld.xml
@@ -26,6 +26,7 @@
 
 <integrationtest>
     <platform>
+        <xi:include href="helloworld-include.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
         <test>
             <testcase>
                 <cmd>echo "Hello, world!"</cmd>

--- a/bvt/helloworld2-bvt.xml
+++ b/bvt/helloworld2-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-outofband-firmware-update.xml $           -->
+<!-- $Source: op-auto-test/bvt/helloworld-bvt.xml $                         -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->
@@ -24,45 +24,12 @@
 <!--                                                                        -->
 <!-- IBM_PROLOG_END_TAG                                                     -->
 
-<integrationtest>
-    <platform>
+<bvts>
 
-        <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+<bvt>
+    <id>helloworld2</id>
+    <title>Hello2</title>
+    <bvt-xml>helloworld2.xml</bvt-xml>
+</bvt>
 
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_PNOR_level()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_side_activated()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.cold_reset()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.preserve_network_setting()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.code_update()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-    </platform>
-</integrationtest>
+</bvts>

--- a/bvt/helloworld2.xml
+++ b/bvt/helloworld2.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-outofband-firmware-update.xml $           -->
+<!-- $Source: op-auto-test/bvt/helloworld.xml $                             -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->
@@ -26,43 +26,10 @@
 
 <integrationtest>
     <platform>
-
-        <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
-
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_PNOR_level()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <cmd>echo "HELLO WORLD!"</cmd>
             </testcase>
         </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_side_activated()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.cold_reset()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.preserve_network_setting()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.code_update()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
     </platform>
 </integrationtest>

--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -28,7 +28,7 @@
 <integrationtest>
     <platform>
 
-        <include>op-ci-setup.xml</include>
+      <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
         <test>
             <testcase>

--- a/bvt/op-inbound-basic.xml
+++ b/bvt/op-inbound-basic.xml
@@ -27,7 +27,7 @@
 <integrationtest>
     <platform>
 
-        <include>op-ci-setup.xml</include>
+      <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
         <test>
             <testcase>

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -68,8 +68,6 @@ my $machine;
 my $xmldata;
 
 use File::Temp;
-my $tmperrfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-XXXXXX",
-				 SUFFIX => ".err");
 my $tmpxmlfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-XXXXXX",
 				 SUFFIX => ".xml");
 my $tmpbvtfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-bvtXXXXXX",
@@ -249,33 +247,13 @@ for my $bvt_xml_node ($dom->findnodes('//*[local-name()="bvt-xml"]')) {
 $dom->toFile($tmpxmlfile);
 
 # Validate the resulting XML
-$cmd = "which op-it-list";
-vprint "cmd: $cmd\n";
-$tmp = `which op-it-list`;
-$x = rindex($tmp, "/");
-$tmp = substr($tmp, 0, $x);
-$schemafile = "${tmp}/${schemafn}";
-if (! -e $schemafile)
-{
-    print STDERR "ERROR: could not find $schemafn in op-it-list dir ($schemafile).  Unable to do validation.\n";
-    exit(1);
-}
-
-$cmd = "xmllint --schema $schemafile --xinclude --noout $tmpxmlfile 2>$tmperrfile";
-vprint "cmd: $cmd\n";
-if (system($cmd) != 0)
-{
-    system("cat $tmperrfile >&2");
-    print STDERR "ERROR: $xmlfile contains XML errors.  See previous messages for details (expanded XML file: $tmpxmlfile)\n";
-    exit(1);
-}
+my $xmlschema = XML::LibXML::Schema->new(location => $schemafn);
+$xmlschema->validate($dom);
 
 if ($test_type eq "q")
 {
     exit(0);
 }
-system("cat $tmperrfile");
-unlink $tmperrfile;
 
 # Parse and process the XML
 vprint "Instantiating LibXML object...\n";

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -34,6 +34,7 @@ use FindBin;
 use lib "$FindBin::Bin";
 use OpTestInfra;
 use XML::LibXML;
+use Getopt::Long;
 
 my $version = "1.1";
 my $cmd;
@@ -196,26 +197,16 @@ $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 # Get arguments
 #-------------------------------------------------------------------------------
 
-# Parse the arguments
-my @argv = @ARGV;
-my $arg;
-while(@argv)
-{
-    $arg = shift(@argv);
+my $help = 0;
+GetOptions("help|h|?" => \$help,
+	   "list" => sub { $test_type = "list"; },
+	   "q" => sub { $test_type = "q"; },
+	   "verbose" => sub { set_verbose(1); $verbose_str = "--verbose"; },
+	   "fverbose:s" => sub { $fvfile = shift; set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; },
+	   "<>" => sub { $xmlfile_arg = shift }
+    ) or syntax();
 
-    if ($arg eq "-?") { syntax(); }
-    if ($arg eq "--help") { syntax(); }
-    if ($arg eq "-h") { syntax(); }
-
-    if ($arg eq "--list") { $test_type = "list"; next; }
-    if ($arg eq "--q") { $test_type = "q"; next; }
-    if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
-    if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
-
-    if ($arg =~ /^\-/) { print STDERR "ERROR: unrecognized option: $arg\n"; exit(1); }
-
-    $xmlfile_arg = $arg;
-}
+syntax() if $help;
 
 push(@tmpfiles, $tmperrfile);
 push(@tmpfiles, $tmpxmlfile);

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -234,23 +234,19 @@ else
 # Do the test
 #-------------------------------------------------------------------------------
 # Pre-process: treat all <bvt-xml> tags like <include> tags for complete checking/listing
-$cmd = "cat $xmlfile | sed 's/bvt-xml/include/g' >$tmpbvtfile";
-vprint "cmd: $cmd\n";
-if (system($cmd))
-{
-    print STDERR "ERROR: BVT preprocessing failure\n";
-    exit(1);
+my $parser = XML::LibXML->new();
+my $dom = XML::LibXML->load_xml(location => $xmlfile);
+$parser->process_xincludes($dom);
+
+for my $bvt_xml_node ($dom->findnodes('//*[local-name()="bvt-xml"]')) {
+    # We treat <bvt-xml> as an include
+    # so we grab the content of the file, insert it into the doc.
+    my $bvt_xml_file = XML::LibXML->load_xml(location => $bvt_xml_node->textContent);
+    $parser->process_xincludes($bvt_xml_file);
+    $bvt_xml_node->replaceNode($bvt_xml_file->documentElement());
 }
 
-# Pre-process: expand all <include> tags and do %% variable substitution
-$cmd = "./read-op-xml-it ${verbose_str} $tmpbvtfile >$tmpxmlfile";
-vprint "cmd: $cmd\n";
-if (system($cmd))
-{
-    print STDERR "ERROR: read-op-xml-it failure\n";
-    exit(1);
-}
-unlink $tmpbvtfile;
+$dom->toFile($tmpxmlfile);
 
 # Validate the resulting XML
 $cmd = "which op-it-list";

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -36,7 +36,6 @@ use OpTestInfra;
 use XML::LibXML;
 use Getopt::Long;
 
-my $version = "1.1";
 my $cmd;
 my $tmp;
 my @flds;
@@ -44,7 +43,7 @@ my $verbose_str = "";
 my $fvfile = "";
 my $x;
 
-my $usage = "Syntax-check and list major elements in a OpenPower IT/BVT XML file ($version).
+my $usage = "Syntax-check and list major elements in a OpenPower IT/BVT XML file.
 
 Syntax: op-it-list [OPTIONS] filename.xml
 
@@ -212,7 +211,7 @@ push(@tmpfiles, $tmperrfile);
 push(@tmpfiles, $tmpxmlfile);
 push(@tmpfiles, $tmpbvtfile);
 
-vprint "Running op-it-list ($version)...\n";
+vprint "Running op-it-list...\n";
 
 if ($xmlfile_arg eq "")
 {

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -35,6 +35,7 @@ use lib "$FindBin::Bin";
 use OpTestInfra;
 use XML::LibXML;
 use Getopt::Long;
+use OPBVTXML;
 
 my $cmd;
 my $tmp;
@@ -232,18 +233,7 @@ else
 # Do the test
 #-------------------------------------------------------------------------------
 # Pre-process: treat all <bvt-xml> tags like <include> tags for complete checking/listing
-my $parser = XML::LibXML->new();
-my $dom = XML::LibXML->load_xml(location => $xmlfile);
-$parser->process_xincludes($dom);
-
-for my $bvt_xml_node ($dom->findnodes('//*[local-name()="bvt-xml"]')) {
-    # We treat <bvt-xml> as an include
-    # so we grab the content of the file, insert it into the doc.
-    my $bvt_xml_file = XML::LibXML->load_xml(location => $bvt_xml_node->textContent);
-    $parser->process_xincludes($bvt_xml_file);
-    $bvt_xml_node->replaceNode($bvt_xml_file->documentElement());
-}
-
+my $dom = OPBVTXML::bvt_xml_expand_all($xmlfile);
 $dom->toFile($tmpxmlfile);
 
 # Validate the resulting XML

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -190,7 +190,6 @@ sub printBVT
     vprint "<printBVT()\n";
 }
 
-sub main() { }
 $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 
 #-------------------------------------------------------------------------------

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -66,20 +66,18 @@ my $test_name;
 my $machine;
 #my $parser;
 my $xmldata;
-my $tmperrfile = "/tmp/fips-it-test-$$.err";
-my $tmpxmlfile = "/tmp/fips-it-test-$$.xml";
-my $tmpbvtfile = "/tmp/fips-it-test-bvt-$$.xml";
-my @tmpfiles;
 
+use File::Temp;
+my $tmperrfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-XXXXXX",
+				 SUFFIX => ".err");
+my $tmpxmlfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-XXXXXX",
+				 SUFFIX => ".xml");
+my $tmpbvtfile = File::Temp->new(TEMPLATE => "/tmp/fips-it-test-bvtXXXXXX",
+				 SUFFIX => ".xml");
 sub syntax()
 {
     print "$usage";
     exit(1);
-}
-
-sub cleanTempFiles
-{
-    unlink @tmpfiles;
 }
 
 my @cmdelmts =
@@ -207,16 +205,11 @@ GetOptions("help|h|?" => \$help,
 
 syntax() if $help;
 
-push(@tmpfiles, $tmperrfile);
-push(@tmpfiles, $tmpxmlfile);
-push(@tmpfiles, $tmpbvtfile);
-
 vprint "Running op-it-list...\n";
 
 if ($xmlfile_arg eq "")
 {
     print STDERR "ERROR: you must specify an XML file to test\n";
-    cleanTempFiles();
     exit(1);
 }
 
@@ -233,7 +226,6 @@ else
     if ($xmlfile eq "")
     {
         print STDERR "ERROR: could not find $xmlfile_arg relative to op-it-list dir\n";
-        cleanTempFiles();
         exit(1);
     }
 }
@@ -247,7 +239,6 @@ vprint "cmd: $cmd\n";
 if (system($cmd))
 {
     print STDERR "ERROR: BVT preprocessing failure\n";
-    cleanTempFiles();
     exit(1);
 }
 
@@ -257,7 +248,6 @@ vprint "cmd: $cmd\n";
 if (system($cmd))
 {
     print STDERR "ERROR: read-op-xml-it failure\n";
-    cleanTempFiles();
     exit(1);
 }
 unlink $tmpbvtfile;
@@ -272,7 +262,6 @@ $schemafile = "${tmp}/${schemafn}";
 if (! -e $schemafile)
 {
     print STDERR "ERROR: could not find $schemafn in op-it-list dir ($schemafile).  Unable to do validation.\n";
-    cleanTempFiles();
     exit(1);
 }
 
@@ -282,13 +271,11 @@ if (system($cmd) != 0)
 {
     system("cat $tmperrfile >&2");
     print STDERR "ERROR: $xmlfile contains XML errors.  See previous messages for details (expanded XML file: $tmpxmlfile)\n";
-    cleanTempFiles();
     exit(1);
 }
 
 if ($test_type eq "q")
 {
-    cleanTempFiles();
     exit(0);
 }
 system("cat $tmperrfile");
@@ -320,4 +307,3 @@ else
         printBVT($bvt);
     }
 }
-cleanTempFiles();

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -23,11 +23,11 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-                                                                                
+
 # Syntax-check and list major elements in a OpenPower IT/BVT XML file.
 #
 # Author: Alan Hlava
-                                                                                
+
 use strict;
 
 use FindBin;
@@ -71,18 +71,12 @@ my $tmpxmlfile = "/tmp/fips-it-test-$$.xml";
 my $tmpbvtfile = "/tmp/fips-it-test-bvt-$$.xml";
 my @tmpfiles;
 
-                                                                                
-# syntax
-                                                                                
 sub syntax()
 {
     print "$usage";
     exit(1);
 }
 
-                                                                                
-# cleanTempFiles
-                                                                                
 sub cleanTempFiles
 {
     unlink @tmpfiles;
@@ -92,9 +86,7 @@ my @cmdelmts =
 (
     "cmd",
 );
-                                                                                
-# printTestcase
-                                                                                
+
 sub printTestcase
 {
     vprint ">printTestcase()\n";
@@ -122,9 +114,6 @@ sub printTestcase
     vprint "<printTestcase()\n";
 }
 
-                                                                                
-# getNameOrTitle
-                                                                                
 sub getNameOrTitle
 {
     my ($node) = @_;
@@ -140,9 +129,6 @@ sub getNameOrTitle
     return $name;
 }
 
-                                                                                
-# printIntegrationTest
-                                                                                
 sub printIntegrationTest
 {
     vprint ">printIntegraionTest()\n";
@@ -185,9 +171,6 @@ sub printIntegrationTest
     vprint "<printIntegraionTest()\n";
 }
 
-                                                                                
-# printBVT
-                                                                                
 sub printBVT
 {
     vprint ">printBVT()\n";
@@ -200,16 +183,13 @@ sub printBVT
     my @its = $bvt->findnodes('./integrationtest');
     foreach my $it (@its)
     {
-        printIntegrationTest($it);    
+        printIntegrationTest($it);
     }
     $test_indent = substr($test_indent, 3);
-    
+
     vprint "<printBVT()\n";
 }
-    
-                                                                                
-#                            main
-                                                                                
+
 sub main() { }
 $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 
@@ -227,12 +207,12 @@ while(@argv)
     if ($arg eq "-?") { syntax(); }
     if ($arg eq "--help") { syntax(); }
     if ($arg eq "-h") { syntax(); }
-    
+
     if ($arg eq "--list") { $test_type = "list"; next; }
     if ($arg eq "--q") { $test_type = "q"; next; }
     if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
     if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
-    
+
     if ($arg =~ /^\-/) { print STDERR "ERROR: unrecognized option: $arg\n"; exit(1); }
 
     $xmlfile_arg = $arg;
@@ -247,7 +227,7 @@ vprint "Running op-it-list ($version)...\n";
 if ($xmlfile_arg eq "")
 {
     print STDERR "ERROR: you must specify an XML file to test\n";
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(1);
 }
 
@@ -264,7 +244,7 @@ else
     if ($xmlfile eq "")
     {
         print STDERR "ERROR: could not find $xmlfile_arg relative to op-it-list dir\n";
-        cleanTempFiles();    
+        cleanTempFiles();
         exit(1);
     }
 }
@@ -278,7 +258,7 @@ vprint "cmd: $cmd\n";
 if (system($cmd))
 {
     print STDERR "ERROR: BVT preprocessing failure\n";
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(1);
 }
 
@@ -288,7 +268,7 @@ vprint "cmd: $cmd\n";
 if (system($cmd))
 {
     print STDERR "ERROR: read-op-xml-it failure\n";
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(1);
 }
 unlink $tmpbvtfile;
@@ -303,7 +283,7 @@ $schemafile = "${tmp}/${schemafn}";
 if (! -e $schemafile)
 {
     print STDERR "ERROR: could not find $schemafn in op-it-list dir ($schemafile).  Unable to do validation.\n";
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(1);
 }
 
@@ -313,13 +293,13 @@ if (system($cmd) != 0)
 {
     system("cat $tmperrfile >&2");
     print STDERR "ERROR: $xmlfile contains XML errors.  See previous messages for details (expanded XML file: $tmpxmlfile)\n";
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(1);
 }
 
 if ($test_type eq "q")
 {
-    cleanTempFiles();    
+    cleanTempFiles();
     exit(0);
 }
 system("cat $tmperrfile");
@@ -333,7 +313,7 @@ $xmldata = $xml->parse_file("${tmpxmlfile}");
 #vprint "Doing process_xincludes()...\n";
 #$xml->process_xincludes($xmldata);
 unlink $tmpxmlfile;
-    
+
 my @bvts = $xmldata->findnodes('/bvts/bvt');
 my $bvtcount = @bvts;
 if ($bvtcount == 0)
@@ -341,7 +321,7 @@ if ($bvtcount == 0)
     my @its = $xmldata->findnodes('/integrationtest');
     foreach my $it (@its)
     {
-        printIntegrationTest($it);    
+        printIntegrationTest($it);
     }
 }
 else
@@ -351,4 +331,4 @@ else
         printBVT($bvt);
     }
 }
-cleanTempFiles();    
+cleanTempFiles();

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -23,11 +23,11 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-                                                                                
+
 # Read integration test XML file to stdout and expand include nesting
 #
 # Author: Alan Hlava
-                                                                                
+
 use strict;
 
 use FindBin;
@@ -45,9 +45,6 @@ my $x;
 my $include_count = 1;
 my $processing_include = 0; # Internal flag to indicate we're processing an <include> rather than the outermost XML file
 
-                                                                                
-# syntax
-                                                                                
 sub syntax()
 {
     print "Read integration test XML file to stdout and expand include nesting (v${version})\n\n";
@@ -60,10 +57,6 @@ sub syntax()
     exit(1);
 }
 
-                                                                                
-#                            main
-                                                                                
-
 #-------------------------------------------------------------------------------
 # parse the arguments
 #-------------------------------------------------------------------------------
@@ -73,13 +66,13 @@ my $arg;
 while(@argv)
 {
     $arg = shift(@argv);
-    
+
     if (($arg eq "-?") || ($arg eq "-h") || ($arg eq "--help")) { syntax(); }
-    
+
     if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
     if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
     if ($arg eq "--include") { $processing_include = 1; next; }
-    
+
     $filename = $arg;
 }
 
@@ -150,7 +143,7 @@ while(defined($line = <INF>))
         print "$line\n";
         next;
     }
-    
+
     # Get the count, if any
     $x = index($line, "count=");
     if ($x != -1)
@@ -161,7 +154,7 @@ while(defined($line = <INF>))
         if ($x == -1)
         {
             print STDERR "ERROR: read-op-xml-it: unable to parse XML include count= attribute: $line\n";
-            exit(1);            
+            exit(1);
         }
         $include_count = substr($tmp, 0, $x);
         vprint "include_count set to $include_count\n";
@@ -182,7 +175,7 @@ while(defined($line = <INF>))
         if ($x == -1)
         {
             print STDERR "ERROR: read-op-xml-it: unable to parse XML include xmlvars= attribute: $line\n";
-            exit(1);            
+            exit(1);
         }
         vprint "tmp=\"$tmp\", x=$x\n";
         $incxmlvars = substr($tmp, 0, $x);
@@ -197,7 +190,7 @@ while(defined($line = <INF>))
             $ENV{"incxmlvar_$newkey"} = $newval;
         }
     }
-    
+
     # Get the included filename
     $x = index($line, ">");
     $incfilename = trim(substr($line, ($x + 1)));
@@ -235,7 +228,6 @@ while(defined($line = <INF>))
         }
     }
 
-    
     # Expand the file in place of the <include> line(s)
     vprint "include_count set to $include_count\n";
     delete $ENV{xmlvars_include_i};

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -32,6 +32,7 @@ use strict;
 
 use FindBin;
 use lib "$FindBin::Bin";
+use Getopt::Long;
 use OpTestInfra;
 
 my $fvfile = "";
@@ -57,24 +58,16 @@ sub syntax()
     exit(1);
 }
 
-#-------------------------------------------------------------------------------
-# parse the arguments
-#-------------------------------------------------------------------------------
-my @argv = @ARGV;
-my $arg;
+my $help = 0;
 
-while(@argv)
-{
-    $arg = shift(@argv);
+GetOptions("help|h|?" => \$help,
+	   "verbose" => sub { set_verbose(1); $verbose_str = "--verbose"; },
+	   "fverbose:s" => sub { $fvfile = shift; set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile" },
+	   "include" => sub { $processing_include = 1; },
+	   "<>" => sub { $filename = shift; }
+    ) or syntax();
 
-    if (($arg eq "-?") || ($arg eq "-h") || ($arg eq "--help")) { syntax(); }
-
-    if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
-    if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
-    if ($arg eq "--include") { $processing_include = 1; next; }
-
-    $filename = $arg;
-}
+syntax() if $help;
 
 if ($filename eq "")
 {

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -34,6 +34,7 @@ use FindBin;
 use lib "$FindBin::Bin";
 use Getopt::Long;
 use OpTestInfra;
+use XML::LibXML;
 
 my $fvfile = "";
 my $verbose_str = "";
@@ -78,148 +79,8 @@ vprint "Starting read-op-xml-it\n";
 vprint "processing_include: $processing_include\n";
 
 $infilename = findRelFile($filename);
-open(INF, "<$infilename") || die "ERROR: read-op-xml-it: unable to open $infilename: $!";
-my $line;
-my $incxmlvars = "";
-while(defined($line = <INF>))
-{
-    chomp($line);
-    if ($processing_include)
-    {
-        # Do any xmlvars= substitution from the including XML
-        foreach my $key (keys(%ENV))
-        {
-            #vprint "check env var: \"$key\"\n";
-            if ($key =~ /^incxmlvar_(.*)/)
-            {
-                my $subkey = substr($key, 10);
-                vprint "found incxmlvars_ env var: $key\n";
-                $line =~ s/\%\%${subkey}\%\%/$ENV{$key}/g;
-            }
-        }
-    }
-
-    $x = index($line, "<include");
-    if ($x == -1)
-    {
-        # Fix nested "<?xml" lines so final expanded file passes validation
-        if ($processing_include)
-        {
-            $line =~ s/\<\?xml/\<!-- xml/;
-            $line =~ s/\?\>/ --\>/;
-        }
-        if (defined($ENV{xmlvars_include_i}))
-        {
-            $line =~ s/\%\%include_i\%\%/$ENV{xmlvars_include_i}/g;
-        }
-        if (defined($ENV{CONTEXT}))
-        {
-            $line =~ s/\%\%context\%\%/$ENV{CONTEXT}/g;
-        }
-        print "$line\n";
-        next;
-    }
-
-    # Get the count, if any
-    $x = index($line, "count=");
-    if ($x != -1)
-    {
-        vprint "found count in <include>\n";
-        my $tmp = substr($line, ($x + 6));
-        $x = index($tmp, ">");
-        if ($x == -1)
-        {
-            print STDERR "ERROR: read-op-xml-it: unable to parse XML include count= attribute: $line\n";
-            exit(1);
-        }
-        $include_count = substr($tmp, 0, $x);
-        vprint "include_count set to $include_count\n";
-    }
-    else
-    {
-        $include_count = 1;
-    }
-
-    # Process the xmlvars= attribute (if any)
-    $incxmlvars = "";
-    $x = index($line, "xmlvars=\"");
-    if ($x != -1)
-    {
-        vprint "found xmlvars in <include>\n";
-        my $tmp = substr($line, ($x + 9));
-        $x = index($tmp, "\"");
-        if ($x == -1)
-        {
-            print STDERR "ERROR: read-op-xml-it: unable to parse XML include xmlvars= attribute: $line\n";
-            exit(1);
-        }
-        vprint "tmp=\"$tmp\", x=$x\n";
-        $incxmlvars = substr($tmp, 0, $x);
-        vprint "incxmlvars set to \"$incxmlvars\"\n";
-
-        # Store in env var so passed down to nested read-op-xml-it
-        my @ixvs = split(/ /, $incxmlvars);
-        foreach my $ixv (@ixvs)
-        {
-            my ($newkey, $newval) = split(/\=/, $ixv);
-            vprint "setting env var incxmlvar_${newkey}=$newval\n";
-            $ENV{"incxmlvar_$newkey"} = $newval;
-        }
-    }
-
-    # Get the included filename
-    $x = index($line, ">");
-    $incfilename = trim(substr($line, ($x + 1)));
-    if ($incfilename eq "")
-    {
-        # Must have put the filename on the next line
-        $incfilename = <INF>;
-        chomp($incfilename);
-    }
-    $x = index($incfilename, "</include>");
-    if ($x == -1)
-    {
-        # See if the ending tag is on the next line
-        $line = <INF>;
-        chomp($line);
-        $x = index($line,  "</include>");
-        if ($x == -1)
-        {
-            print STDERR "ERROR: read-op-xml-it: unable to parse XML include line: $line\n";
-            exit(1);
-        }
-    }
-    else
-    {
-        $incfilename = substr($incfilename, 0, $x);
-    }
-
-    # Substitute %%variable%%'s in the filename and loop count in this <include> tag
-    foreach my $key (keys(%ENV))
-    {
-        if (my ($xmlvars_key) = $key =~ /^xmlvars_(.*)/)
-        {
-            $incfilename =~ s/\%\%${xmlvars_key}\%\%/$ENV{$key}/g;
-            $include_count =~ s/\%\%${xmlvars_key}\%\%/$ENV{$key}/g;
-        }
-    }
-
-    # Expand the file in place of the <include> line(s)
-    vprint "include_count set to $include_count\n";
-    delete $ENV{xmlvars_include_i};
-    for(my $i = 0; $i < $include_count; ++$i)
-    {
-        if ($include_count > 1)
-        {
-            $ENV{xmlvars_include_i} = $i + 1;
-        }
-        vprint "cmd: read-op-xml-it ${verbose_str} --include $incfilename\n";
-        if (system("read-op-xml-it ${verbose_str} --include $incfilename"))
-        {
-            print STDERR "ERROR: read-op-xml-it: failed reading $incfilename\n";
-            exit(1);
-        }
-    }
-}
-close(INF);
+my $parser = XML::LibXML->new();
+my $dom = XML::LibXML->load_xml(location => $infilename);
+$parser->process_xincludes($dom);
+print $dom->serialize;
 exit(0);

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -37,7 +37,6 @@ use OpTestInfra;
 
 my $fvfile = "";
 my $verbose_str = "";
-my $version = "1.1";
 
 my $filename = "";
 my $infilename = "";
@@ -48,7 +47,7 @@ my $processing_include = 0; # Internal flag to indicate we're processing an <inc
 
 sub syntax()
 {
-    print "Read integration test XML file to stdout and expand include nesting (v${version})\n\n";
+    print "Read integration test XML file to stdout and expand include nesting\n\n";
     print "Syntax: read-op-xml-it [OPTIONS] file.xml\n";
     print "   file.xml : the test definition file\n";
     print "\nWhere OPTIONS is one or more of:\n";
@@ -79,7 +78,7 @@ if ($filename eq "")
 # set vars representing execution environment
 #-------------------------------------------------------------------------------
 
-vprint "Starting read-op-xml-it v${version}\n";
+vprint "Starting read-op-xml-it\n";
 vprint "processing_include: $processing_include\n";
 
 #------------------------------------------------------------------------------

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -82,15 +82,6 @@ if ($filename eq "")
 vprint "Starting read-op-xml-it v${version}\n";
 vprint "processing_include: $processing_include\n";
 
-# read any %%variable%%'s set by run-fsp-it
-foreach my $key (keys %ENV)
-{
-    if ($key =~ /^xmlvars_/) {
-        vprint "$key: $ENV{$key}\n";
-    }
-
-}
-
 #------------------------------------------------------------------------------
 # Read the XML file and write to STDOUT
 #------------------------------------------------------------------------------

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -74,16 +74,9 @@ if ($filename eq "")
     exit(9);
 }
 
-#-------------------------------------------------------------------------------
-# set vars representing execution environment
-#-------------------------------------------------------------------------------
-
 vprint "Starting read-op-xml-it\n";
 vprint "processing_include: $processing_include\n";
 
-#------------------------------------------------------------------------------
-# Read the XML file and write to STDOUT
-#------------------------------------------------------------------------------
 $infilename = findRelFile($filename);
 open(INF, "<$infilename") || die "ERROR: read-op-xml-it: unable to open $infilename: $!";
 my $line;

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -32,12 +32,8 @@ use strict;
 
 use Getopt::Long;
 
-my $cmd;
-my $tmp;
-my @flds;
 my $verbose = 0;
 my $vp_indent = "";
-my $x;
 my $bmcip = "";
 my $bmcuser = "";
 my $bmcpwd = "";
@@ -161,7 +157,7 @@ printf OUTF $cfgfile_fmt,
 close(OUTF);
 if ($verbose)
 {
-        $tmp = `cat ${cfgfiledir}/${cfgfile}`;
+        my $tmp = `cat ${cfgfiledir}/${cfgfile}`;
         vprint "Config file ${cfgfiledir}/${cfgfile} written:\n";
         vprint $tmp;
 }

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -91,18 +91,12 @@ hpmimage = %s
 
 ";
 
-################################################################################
-# syntax
-################################################################################
 sub syntax()
 {
         print "$usage";
         exit(1);
 }
 
-################################################################################
-# vprint
-################################################################################
 sub vprint
 {
         my ($str) = @_;
@@ -122,12 +116,7 @@ sub vprint
 
 $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 
-#-------------------------------------------------------------------------------
-# Get arguments
-#-------------------------------------------------------------------------------
-
 # Parse the arguments
-
 my $help = 0;
 GetOptions("help|?|h" => \$help,
 	   "verbose" => \$verbose,
@@ -154,9 +143,7 @@ vprint "Starting run-bvt-setup\n";
 if ($ffdcdir !~ /\/$/) { $ffdcdir .= "/"; }
 if ($imagedir !~ /\/$/) { $imagedir .= "/"; }
 
-#-------------------------------------------------------------------------------
 # Write the config file
-#-------------------------------------------------------------------------------
 open(OUTF, ">${cfgfiledir}/${cfgfile}") || die "ERROR: unable to open ${cfgfiledir}/${cfgfile} for output: $!";
 printf OUTF $cfgfile_fmt,
         $bmcip,

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -30,6 +30,8 @@
 ################################################################################
 use strict;
 
+use Getopt::Long;
+
 my $version = "1.1";
 my @argv = @ARGV;
 my $arg;
@@ -121,30 +123,6 @@ sub vprint
         }
 }
 
-################################################################################
-# setArg
-################################################################################
-sub setArg
-{
-        my ($argname, $argval_ref) = @_;
-        my $rc = 0;
-        if ($arg eq "$argname")
-        {
-                if (($argv[0] !~ /^\-\-/) &&
-                    ($argv[0] !~ /^\%\%/))
-                {
-                        $$argval_ref = shift(@argv);
-                        $rc = 1;
-                }
-                if ($argv[0] =~ /^\%\%/) { shift(@argv); $rc = 1; }
-        }
-        return($rc);
-}
-
-################################################################################
-#                            main
-################################################################################
-sub main() { }
 $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 
 #-------------------------------------------------------------------------------
@@ -152,78 +130,28 @@ $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)
 #-------------------------------------------------------------------------------
 
 # Parse the arguments
-while(@argv)
-{
-        $arg = shift(@argv);
 
-        if ($arg eq "-?") { syntax(); }
-        if ($arg eq "--help") { syntax(); }
-        if ($arg eq "-h") { syntax(); }
+my $help = 0;
+GetOptions("help|?|h" => \$help,
+	   "verbose" => \$verbose,
+	   "bmcip=s" => \$bmcip,
+	   "bmcuser:s" => \$bmcuser,
+	   "bmcpwd=s" => \$bmcpwd,
+	   "usernameipmi=s" => \$usernameipmi,
+	   "passwordipmi=s" => \$passwordipmi,
+	   "lparip=s" => \$lparip,
+	   "lparuser=s" => \$lparuser,
+	   "lparPasswd=s" => \$lparPasswd,
+	   "hpmimage:s" => \$hpmimage,
+	   "ffdcdir:s" => \$ffdcdir,
+	   "cfgfiledir:s" => \$cfgfiledir,
+	   "imagedir:s" => \$imagedir,
+	   "imagename:s" => \$imagename,
+    ) or syntax();
 
-        if ($arg eq "--verbose") { $verbose = 1; next; }
-
-        if (setArg("--bmcip", \$bmcip)) { next; }
-        if (setArg("--bmcuser", \$bmcuser)) { next; }
-        if (setArg("--bmcpwd", \$bmcpwd)) { next; }
-        if (setArg("--usernameipmi", \$usernameipmi)) { next; }
-        if (setArg("--passwordipmi", \$passwordipmi)) { next; }
-        if (setArg("--lparip", \$lparip)) { next; }
-        if (setArg("--lparuser", \$lparuser)) { next; }
-        if (setArg("--lparPasswd", \$lparPasswd)) { next; }
-        if (setArg("--hpmimage", \$hpmimage)) { next; }
-        if (setArg("--ffdcdir", \$ffdcdir)) { next; }
-        if (setArg("--cfgfiledir", \$cfgfiledir)) { next; }
-        if (setArg("--imagedir", \$imagedir)) { next; }
-        if (setArg("--imagename", \$imagename)) { next; }
-
-        if ($arg =~ /^\-/) { print STDERR "ERROR: unrecognized option: $arg\n"; exit(1); }
-
-        print STDERR "ERROR: unrecognized option: $arg\n";
-        exit(1);
-}
+syntax() if $help;
 
 vprint "Starting run-bvt-setup (v${version})\n";
-
-if ($bmcip eq "")
-{
-        print STDERR "ERROR: missing required argument --bmcip\n";
-        exit(1);
-}
-if ($bmcpwd eq "")
-{
-        print STDERR "ERROR: missing required argument --bmcpwd\n";
-        exit(1);
-}
-if ($usernameipmi eq "")
-{
-        print STDERR "ERROR: missing required argument --usernameipmi\n";
-        exit(1);
-}
-if ($passwordipmi eq "")
-{
-        print STDERR "ERROR: missing required argument --passwordipmi\n";
-        exit(1);
-}
-if ($lparip eq "")
-{
-        print STDERR "ERROR: missing required argument --lparip\n";
-        exit(1);
-}
-if ($lparuser eq "")
-{
-        print STDERR "ERROR: missing required argument --lparuser\n";
-        exit(1);
-}
-if ($lparPasswd eq "")
-{
-        print STDERR "ERROR: missing required argument --lparPasswd\n";
-        exit(1);
-}
-if ($hpmimage eq "")
-{
-        print STDERR "ERROR: missing required argument --hpmimage\n";
-        exit(1);
-}
 
 # The OP CI tools want dirs to end in slash...
 if ($ffdcdir !~ /\/$/) { $ffdcdir .= "/"; }

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -145,7 +145,8 @@ printf OUTF $cfgfile_fmt,
 close(OUTF);
 if ($verbose)
 {
-        my $tmp = `cat ${cfgfiledir}/${cfgfile}`;
         vprint "Config file ${cfgfiledir}/${cfgfile} written:\n";
-        vprint $tmp;
+	open(my $t, "< ${cfgfiledir}/${cfgfile}")
+	    or die "Cannot open < ${cfgfiledir}/${cfgfile}";
+	vprint <$t>;
 }

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -95,19 +95,7 @@ sub syntax()
 
 sub vprint
 {
-        my ($str) = @_;
-        if ($verbose)
-        {
-                if ($str =~ /^\</)
-                {
-                        $vp_indent = substr($vp_indent, 3);
-                }
-                print STDERR "${vp_indent}${str}";
-                if ($str =~ /^\>/)
-                {
-                        $vp_indent .= "   ";
-                }
-        }
+    print @_ if $verbose;
 }
 
 $| = 1; # Force STDOUT to be unbuffered (flush after every print statement)

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -32,7 +32,6 @@ use strict;
 
 use Getopt::Long;
 
-my $version = "1.1";
 my @argv = @ARGV;
 my $arg;
 my $cmd;
@@ -55,7 +54,7 @@ my $lparuser = "";
 my $lparPasswd = "";
 my $hpmimage = "";
 
-my $usage = "Setup an OP CI BVT test config file per the passed arguments (v${version})
+my $usage = "Setup an OP CI BVT test config file per the passed arguments
 
 Syntax: run-bvt-setup --bmcip x.x.x.x --bmcpwd xxx --usernameipmi xxx --passwordipmi xxx [OPTIONS]
 
@@ -151,7 +150,7 @@ GetOptions("help|?|h" => \$help,
 
 syntax() if $help;
 
-vprint "Starting run-bvt-setup (v${version})\n";
+vprint "Starting run-bvt-setup\n";
 
 # The OP CI tools want dirs to end in slash...
 if ($ffdcdir !~ /\/$/) { $ffdcdir .= "/"; }

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -32,8 +32,6 @@ use strict;
 
 use Getopt::Long;
 
-my @argv = @ARGV;
-my $arg;
 my $cmd;
 my $tmp;
 my @flds;

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -357,6 +357,11 @@ sub mergeBvtInputFiles
 	}
     }
 
+    # We process XIncludes now, as we're going to save the result to
+    # a temporary file, which will mess up XInclude paths.
+    my $parser = XML::LibXML->new();
+    $parser->process_xincludes($merged_doc);
+
     return $merged_doc->serialize;
 }
 

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -43,8 +43,7 @@ my $fvfile = "";
 my $commandline;
 
 # Environment
-my $userid = `whoami`;
-chomp($userid);
+my $userid = $ENV{USER};
 
 # Files and directories
 my $resdir = "$ENV{HOME}/run-op-bvt";

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -38,7 +38,6 @@ use File::Path;
 use Getopt::Long qw(:config pass_through);
 use OpTestInfra;
 
-my $version = "1.1";
 my $verbose_str = "";
 my $fvfile = "";
 my $commandline;
@@ -91,7 +90,7 @@ my $test_env = "hw";
 my $restrict_env = "";
 my $test_systems = 0; # "Hidden" option to not run tests, just test --systems dispatching code
 
-my $usage = "Run OpenPower Build Verification Test (BVT) ($version)
+my $usage = "Run OpenPower Build Verification Test (BVT)
 
 Syntax: run-op-bvt [OPTIONS] bvtfile.xml [bvtfile2.xml ...]
 
@@ -412,7 +411,7 @@ if (! -e $fullbvtxmlfile)
     exit(9);
 }
 
-vprint "run-op-bvt ($version)\n";
+vprint "run-op-bvt\n";
 vprint "xmlvars{machine}: $xmlvars{machine}\n";
 vprint "bvtxmlfile: $bvtxmlfile\n";
 vprint "savedir: $savedir\n";

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -34,6 +34,7 @@ use FindBin;
 use lib "$FindBin::Bin";
 use XML::LibXML;
 use File::Path;
+use Getopt::Long qw(:config pass_through);
 use OpTestInfra;
 
 my $version = "1.1";
@@ -395,24 +396,20 @@ sub cleanUp
 #-----------------------------------------------------------------------------
 # parse the arguments
 #-----------------------------------------------------------------------------
-my @argv = @ARGV;
-my $arg;
 $| = 1; # Force STDOUT to be unbuffered so we get output in the right order
 
+my $help = 0;
 $commandline = $0 . " ". (join " ", @ARGV);
+GetOptions('help|?|h' => \$help,
+	   'noclrfailsumm' => sub { $clear_failsumm = 0;},
+	   'verbose' => sub { set_verbose(1); $verbose_str = "--verbose"; },
+	   'fverbose=s' => sub { $fvfile = "$_"; set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile" ;},
+	   'savedir=s' => \$savedir,
+    ) or syntax();
 
-while(@argv)
+my @argv = @ARGV;
+while (my $arg = shift @argv)
 {
-    $arg = shift(@argv);
-
-    if (($arg eq "-?") || ($arg eq "-h") || ($arg eq "--help")) { syntax(); }
-
-    if ($arg eq "--noclrfailsumm") { $clear_failsumm = 0; next; }
-    if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
-    if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
-
-    if ($arg eq "--savedir") { $savedir = shift(@argv); next; }
-
     # Arguments representing XML substitution variables...
     if ($arg =~ /^\-\-/)
     {
@@ -430,9 +427,10 @@ while(@argv)
         else { $xmlvars_it .= " --$arg $xmlvars{$arg}"; }
         next;
     }
-
-    push(@bvtxmlfiles, $arg);
+    push @bvtxmlfiles, $arg;
 }
+
+syntax() if $help;
 
 # Setup savedir
 if ($savedir eq "")

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -30,6 +30,7 @@
 
 use strict;
 
+use File::Copy;
 use FindBin;
 use lib "$FindBin::Bin";
 use XML::LibXML;
@@ -363,26 +364,21 @@ sub runTest
     vprint "<runTest($test_id, \"$title\", $mach, $relxmlfile)\n";
 }
 
-sub cleanUp
+END
 {
-    my ($errorterm) = @_;
-
-    vprint ">run-op-bvt cleanUp($errorterm)\n";
+    vprint ">run-op-bvt cleanUp($?)\n";
 
     if ($tmp_bvtxmlfile)
     {
         unlink $bvtxmlfile;
     }
 
-    if ($errorterm)
+    if ($?)
     {
-        $cmd = "cp $logfile ${savedir}/";
-        vprint "cmd: $cmd\n";
-        system($cmd);
-
+        copy($logfile, "${savedir}/");
         print "All logs and FFDC saved under $savedir\n";
     }
-    vprint "<run-op-bvt cleanUp($errorterm)\n";
+    vprint "<run-op-bvt cleanUp($?)\n";
 }
 
 #-----------------------------------------------------------------------------
@@ -521,7 +517,6 @@ foreach my $bvt ( $xmldata->findnodes('/bvts/bvt') )
 #------------------------------------------------------------------------------
 # Cleanup and exit
 #------------------------------------------------------------------------------
-cleanUp(0);
 $tmp = `date +'%Y-%B-%d'`;
 chomp($tmp);
 if ($totalrc == 0)

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -435,6 +435,8 @@ if ($clear_failsumm)
 
 logprint "Command line: $commandline\n";
 
+File::Path::make_path($savedir);
+
 mergeBvtInputFiles();
 if ($bvtxmlfile eq "")
 {
@@ -446,8 +448,6 @@ if ($bvtxmlfile eq "")
 #-------------------------------------------------------------------------------
 # set vars representing execution environment
 #-------------------------------------------------------------------------------
-File::Path::make_path($savedir);
-
 set_failsumm_log("${savedir}/failsumm.log");
 $ENV{OP_TEST_FAILSUMM_LOG} = "${savedir}/failsumm.log"; # Set so lower-level tools can find it
 

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -33,6 +33,7 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin";
 use XML::LibXML;
+use File::Path;
 use OpTestInfra;
 
 my $version = "1.1";
@@ -503,35 +504,14 @@ if ($bvtxmlfile eq "")
 #-------------------------------------------------------------------------------
 # set vars representing execution environment
 #-------------------------------------------------------------------------------
-system("mkdir -p $savedir") && die "ERROR: unable to create save directory $savedir: $!";
+File::Path::make_path($savedir);
+
 set_failsumm_log("${savedir}/failsumm.log");
 $ENV{OP_TEST_FAILSUMM_LOG} = "${savedir}/failsumm.log"; # Set so lower-level tools can find it
 
-# Ensure all other needed direectories exist
-if (! -d "${resdir}")
-{
-    if (system("mkdir -p ${resdir}"))
-    {
-        print STDERR "ERROR: unable to create $resdir\n";
-        exit(9);
-    }
-}
-if (! -d "${tmpdir}")
-{
-    if (system("mkdir -p ${tmpdir}"))
-    {
-        print STDERR "ERROR: unable to create $tmpdir\n";
-        exit(9);
-    }
-}
-if (! -d "${logdir}")
-{
-    if (system("mkdir -p ${logdir}"))
-    {
-        print STDERR "ERROR: unable to create $logdir\n";
-        exit(9);
-    }
-}
+File::Path::make_path($resdir) if (! -d "${resdir}");
+File::Path::make_path($tmpdir) if (! -d "${tmpdir}");
+File::Path::make_path($logdir) if (! -d "${logdir}");
 
 # Open the log file and print the startup message
 open($logf, ">$logfile") || die "ERROR: unable to open $logfile for write:$!";

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -466,9 +466,7 @@ else
     errprint "ERROR: Finished BVT tests on $tmp with $totalrc testcase failures.\n";
 }
 
-$cmd = "cp $logfile ${savedir}/";
-vprint "cmd: $cmd\n";
-system($cmd);
+copy($logfile, "${savedir}/");
 print "All logs and FFDC saved under $savedir\n";
 if ($totalrc)
 {

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -36,6 +36,7 @@ use lib "$FindBin::Bin";
 use XML::LibXML;
 use File::Path;
 use Getopt::Long qw(:config pass_through);
+use Time::localtime;
 use OpTestInfra;
 
 my $verbose_str = "";
@@ -133,8 +134,7 @@ sub runCmd
 sub logprint
 {
     my ($msg, $err) = @_;
-    $timestamp = `date +'%H:%M:%S'`;
-    chomp($timestamp);
+    $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
 
     if (defined($logf))
     {
@@ -319,8 +319,8 @@ syntax() if $help;
 if ($savedir eq "")
 {
     $savedir = "/tmp/${userid}/bvt/";
-    $tmp = `date '+\%F'`;
-    chomp($tmp);
+    $tmp = sprintf("%d-%02d-%02d", localtime->year + 1900,
+		   localtime->mon + 1, localtime->mday);
     $savedir .= "${tmp}-$$";
 }
 if ($clear_failsumm)
@@ -394,8 +394,8 @@ File::Path::make_path($logdir) if (! -d "${logdir}");
 
 # Open the log file and print the startup message
 open($logf, ">$logfile") || die "ERROR: unable to open $logfile for write:$!";
-$tmp = `date +'%Y-%B-%d'`;
-chomp($tmp);
+$tmp = sprintf("%d-%02d-%02d", localtime->year + 1900,
+	       localtime->mon + 1 , localtime->mday);
 logprint "Starting BVT ($bvtxmlfile) on $tmp...\n";
 logprint "Log file: $logfile\n";
 
@@ -454,8 +454,8 @@ foreach my $bvt ( $xmldata->findnodes('/bvts/bvt') )
 #------------------------------------------------------------------------------
 # Cleanup and exit
 #------------------------------------------------------------------------------
-$tmp = `date +'%Y-%B-%d'`;
-chomp($tmp);
+$tmp = sprintf("%d-%02d-%02d", localtime->year + 1900,
+	       localtime->mon + 1 , localtime->mday);
 if ($totalrc == 0)
 {
     logprint "OK: Finished BVT tests on $tmp with no testcase errors.\n";

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -23,11 +23,11 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-                                                                                
+
 # Run OpenPower automated build verification test (BVT)
 #
 # Author: Alan Hlava
-                                                                                
+
 use strict;
 
 use FindBin;
@@ -116,18 +116,12 @@ Where OPTIONS is zero or more of:
              tests.
 \n";
 
-                                                                                
-# syntax
-                                                                                
 sub syntax()
 {
     print "$usage";
     exit(1);
 }
 
-                                                                                
-# trim
-                                                                                
 sub trim
 {
     my ($str) = @_;
@@ -136,9 +130,6 @@ sub trim
     return $str;
 }
 
-                                                                                
-# runCmd
-                                                                                
 sub runCmd
 {
     my ($l_cmd) = @_;
@@ -148,9 +139,6 @@ sub runCmd
     return $rc;
 }
 
-                                                                                
-# logprint
-                                                                                
 sub logprint
 {
     my ($msg, $err) = @_;
@@ -173,9 +161,6 @@ sub logprint
     add_log_hist("${timestamp} :: $msg");
 }
 
-                                                                                
-# errprint
-                                                                                
 sub errprint
 {
     my ($msg) = @_;
@@ -183,13 +168,10 @@ sub errprint
     write_log_hist("Failure summary from run-op-bvt running $bvtxmlfile");
 }
 
-                                                                                
-# doVarSub
-                                                                                
 sub doVarSub
 {
     my ($value) = @_;
-    
+
     # Do substitution for any xmlvar keys
     foreach my $key (keys %xmlvars)
     {
@@ -198,9 +180,6 @@ sub doVarSub
     return $value;
 }
 
-                                                                                
-# getFileName
-                                                                                
 sub getFileName
 {
     my ($fullpath) = @_;
@@ -213,9 +192,6 @@ sub getFileName
     return $fn;
 }
 
-                                                                                
-# getXMLFilePath
-                                                                                
 sub getXMLFilePath
 {
     my ($inxmlfile) = @_;
@@ -244,9 +220,6 @@ sub getXMLFilePath
     return $outxmlfile;
 }
 
-                                                                                
-# mergeBvtFile
-                                                                                
 sub mergeBvtFile
 {
     my ($fromfile, $tofile) = @_;
@@ -304,9 +277,6 @@ sub mergeBvtFile
     vprint "<mergeBvtFile($fromfile, $tofile)\n";
 }
 
-                                                                                
-# mergeBvtInputFiles
-                                                                                
 sub mergeBvtInputFiles
 {
     vprint ">mergeBvtInputFiles()\n";
@@ -352,9 +322,6 @@ sub mergeBvtInputFiles
     vprint "<mergeBvtInputFiles() set bvtxmlfile to $bvtxmlfile\n";
 }
 
-                                                                                
-# checkSkipTest
-                                                                                
 sub checkSkipTest
 {
     my ($bvt_node) = @_;
@@ -370,9 +337,6 @@ sub checkSkipTest
     return $rc;
 }
 
-                                                                                
-# runTest
-                                                                                
 sub runTest
 {
     my ($test_id, $title, $mach, $relxmlfile) = @_;
@@ -406,9 +370,6 @@ sub runTest
     vprint "<runTest($test_id, \"$title\", $mach, $relxmlfile)\n";
 }
 
-                                                                                
-# cleanUp
-                                                                                
 sub cleanUp
 {
     my ($errorterm) = @_;
@@ -431,14 +392,9 @@ sub cleanUp
     vprint "<run-op-bvt cleanUp($errorterm)\n";
 }
 
-                                                                                
-#                            main
-                                                                                
-sub main { }
-
-#-------------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # parse the arguments
-#-------------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 my @argv = @ARGV;
 my $arg;
 $| = 1; # Force STDOUT to be unbuffered so we get output in the right order
@@ -448,9 +404,9 @@ $commandline = $0 . " ". (join " ", @ARGV);
 while(@argv)
 {
     $arg = shift(@argv);
-    
+
     if (($arg eq "-?") || ($arg eq "-h") || ($arg eq "--help")) { syntax(); }
-    
+
     if ($arg eq "--noclrfailsumm") { $clear_failsumm = 0; next; }
     if ($arg eq "--verbose") { set_verbose(1); $verbose_str = "--verbose"; next; }
     if ($arg eq "--fverbose") { $fvfile = shift(@argv); set_verbose(1, $fvfile); $verbose_str = "--fverbose $fvfile"; next; }
@@ -459,7 +415,7 @@ while(@argv)
 
     # Arguments representing XML substitution variables...
     if ($arg =~ /^\-\-/)
-    {    
+    {
         $arg = substr($arg, 2);
         $xmlvars{$arg} = shift(@argv);
         if ($arg eq "machine") { $def_machine = $xmlvars{$arg}; }
@@ -467,7 +423,7 @@ while(@argv)
         next;
     }
     if ($arg =~ /^\-/)
-    {    
+    {
         $arg = substr($arg, 1);
         $xmlvars{$arg} = shift(@argv);
         if ($arg eq "machine") { $def_machine = $xmlvars{$arg}; }
@@ -482,7 +438,7 @@ while(@argv)
 if ($savedir eq "")
 {
     $savedir = "/tmp/${userid}/bvt/";
-    $tmp = `date '+\%F'`;    
+    $tmp = `date '+\%F'`;
     chomp($tmp);
     $savedir .= "${tmp}-$$";
 }
@@ -549,7 +505,7 @@ if (system($cmd))
 #------------------------------------------------------------------------------
 $xml = XML::LibXML->new();
 $xmldata = $xml->parse_file("${fullbvtxmlfile}");
-                
+
 #------------------------------------------------------------------------------
 # Run all the tests
 #------------------------------------------------------------------------------

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -62,7 +62,6 @@ my $xmlvars_it = "";
 
 # Working variables
 my $timestamp;
-my $x;
 my $def_machine = "";
 my $machine;
 my $xml;

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -38,6 +38,7 @@ use File::Path;
 use Getopt::Long qw(:config pass_through);
 use Time::localtime;
 use OpTestInfra;
+use OPBVTXML;
 
 my $verbose_str = "";
 my $fvfile = "";
@@ -413,10 +414,8 @@ vprint "xmlvars{machine}: $xmlvars{machine}\n";
 vprint "bvtxmlfile: $bvtxmlfile\n";
 vprint "savedir: $savedir\n";
 
-# Validate the syntax of the specified XML file
-$cmd = "op-it-list $verbose_str --q $fullbvtxmlfile";
-vprint "cmd: $cmd\n";
-if (system($cmd))
+
+if (! OPBVTXML::bvt_xml_is_valid("op-it.xsd", $fullbvtxmlfile))
 {
     errprint "ERROR: XML file failed validity checking\n";
     exit(9);

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -123,14 +123,6 @@ sub syntax()
     exit(1);
 }
 
-sub trim
-{
-    my ($str) = @_;
-    $str =~ s/^\s+//;
-    $str =~ s/\s+$//;
-    return $str;
-}
-
 sub runCmd
 {
     my ($l_cmd) = @_;

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -214,108 +214,6 @@ sub getXMLFilePath
     return $outxmlfile;
 }
 
-sub mergeBvtFile
-{
-    my ($fromfile, $tofile) = @_;
-    my $tmpfile1 = "/tmp/merge-bvt-file1-$$.xml";
-    my $tmpfile2 = "/tmp/merge-bvt-file2-$$.xml";
-
-    vprint ">mergeBvtFile($fromfile, $tofile)\n";
-
-    # Remove the front/back-matter from the from XML file
-    $cmd = "grep -v '<?xml' $fromfile | grep -v '<bvts' | grep -v '</bvts' >$tmpfile1";
-    vprint "cmd: $cmd\n";
-    if (system($cmd))
-    {
-        errprint "ERROR: comand failed: $cmd\n";
-        exit(9);
-    }
-
-    # Remove the end element from the to XML file
-    $cmd = "grep -v '</bvts' $tofile >$tmpfile2";
-    vprint "cmd: $cmd\n";
-    if (system($cmd))
-    {
-        errprint "ERROR: comand failed: $cmd\n";
-        exit(9);
-    }
-
-    # Assemble the parts
-    $cmd = "cp $tmpfile2 $tofile";
-    vprint "cmd: $cmd\n";
-    if (system($cmd))
-    {
-        errprint "ERROR: comand failed: $cmd\n";
-        exit(9);
-    }
-    $cmd = "cat $tmpfile1 >>$tofile";
-    vprint "cmd: $cmd\n";
-    if (system($cmd))
-    {
-        errprint "ERROR: comand failed: $cmd\n";
-        exit(9);
-    }
-
-    # Add back the end element in the to XML file
-    $cmd = "echo '</bvts>' >>$tofile";
-    vprint "cmd: $cmd\n";
-    if (system($cmd))
-    {
-        errprint "ERROR: comand failed: $cmd\n";
-        exit(9);
-    }
-
-    # Clean up
-    unlink $tmpfile1, $tmpfile2;
-
-    vprint "<mergeBvtFile($fromfile, $tofile)\n";
-}
-
-sub mergeBvtInputFiles
-{
-    vprint ">mergeBvtInputFiles()\n";
-    my $filepath;
-    $bvtxmlfile = "";
-    my $file_count = @bvtxmlfiles;
-    if ($file_count == 1)
-    {
-        $bvtxmlfile = $bvtxmlfiles[0];
-    }
-    elsif ($file_count > 1)
-    {
-        # Merge the input files into a single temporary XML file.  This
-        # keeps the logic in the rest of the tool simple AND allows us to
-        # to intelligently schedule the complete set of tests (rather than
-        # treat them sequentially).
-
-        # Prime the temp XML file with the first one from the list
-        $bvtxmlfile = "${savedir}/merged-bvt-$$.xml";
-        $filepath = getXMLFilePath($bvtxmlfiles[0]);
-        if (! -e $filepath)
-        {
-            errprint "ERROR: $filepath does not exist or is not accessible\n";
-            exit(9);
-        }
-        $cmd = "cp $filepath $bvtxmlfile";
-        vprint "cmd: $cmd\n";
-        system($cmd) && die "ERROR: command failed: $cmd\n";
-
-        # Merge in all the other files on the list
-        for(my $i = 1; $i < $file_count; ++$i)
-        {
-            $filepath = getXMLFilePath($bvtxmlfiles[$i]);
-            if (! -e $filepath)
-            {
-                errprint "ERROR: $filepath does not exist or is not accessible\n";
-                exit(9);
-            }
-            mergeBvtFile($filepath, $bvtxmlfile);
-        }
-        $tmp_bvtxmlfile = 1;
-    }
-    vprint "<mergeBvtInputFiles() set bvtxmlfile to $bvtxmlfile\n";
-}
-
 sub checkSkipTest
 {
     my ($bvt_node) = @_;
@@ -437,8 +335,45 @@ logprint "Command line: $commandline\n";
 
 File::Path::make_path($savedir);
 
-mergeBvtInputFiles();
-if ($bvtxmlfile eq "")
+# Merging input files
+# This takes all the bvt nodes from input files and
+# inserts them before the first test of the final input file.
+# this can preserve order.
+sub mergeBvtInputFiles
+{
+    my (@files) = @_;
+    my @docs;
+
+    foreach my $f (@files) {
+	push @docs, XML::LibXML->load_xml(location => $f);
+    }
+
+    my $merged_doc = pop @docs;
+
+    foreach my $d (@docs) {
+	my ($bvt_node) = $merged_doc->findnodes('//*[local-name()="bvt"]');
+	for my $t ($d->findnodes('//*[local-name()="bvt"]')) {
+	    $bvt_node->parentNode->insertBefore($t, $bvt_node);
+	}
+    }
+
+    return $merged_doc->serialize;
+}
+
+if (@bvtxmlfiles > 1)
+{
+    my $bvtxml = mergeBvtInputFiles(@bvtxmlfiles);
+    $bvtxmlfile = "${savedir}/merged-bvt-$$.xml";
+    open(my $f, "> $bvtxmlfile")
+	or die "Cannot open merged bvt XML: $bvtxmlfile";
+    print $f $bvtxml;
+    close $f;
+}
+elsif (@bvtxmlfiles == 1)
+{
+    $bvtxmlfile = shift @bvtxmlfiles;
+}
+else
 {
     errprint "ERROR: you must specify the master BVT XML file\n";
     exit(9);

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -41,7 +41,6 @@ use OpTestInfra;
 my $verbose_str = "";
 my $fvfile = "";
 my $commandline;
-my $mypid = $$;
 
 # Environment
 my $userid = `whoami`;

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -140,9 +140,6 @@ sub sigtermHandler
 {
     print "\nrun-op-it received SIGTERM, so terminating!\n";
 
-    # Try to clean up gracefully
-    cleanUp(1);
-
     # Clean up all child processes that may be left-over
     killtree($$, "SIGTERM");
 
@@ -317,7 +314,6 @@ sub getAttrs
         if ($x == -1)
         {
             printErrorMsg("ERROR: XML syntax error: no equal sign found in attribute area: $saveattrstr\n");
-            cleanUp(1);
             exit(1);
         }
         $attr = substr($attrstr, 0, $x);
@@ -327,7 +323,6 @@ sub getAttrs
         if ( !($attrstr =~ /^\"/))
         {
             printErrorMsg("ERROR: XML syntax error: all attribute values must start with a double-quote: $saveattrstr\n");
-            cleanUp(1);
             exit(1);
         }
         $attrstr = substr($attrstr, 1);
@@ -337,7 +332,6 @@ sub getAttrs
         if ($x == -1)
         {
             printErrorMsg("ERROR: XML syntax error: all attribute values must end with a double-quote: $saveattrstr\n");
-            cleanUp(1);
             exit(1);
         }
         $val = substr($attrstr, 0, $x);
@@ -536,17 +530,12 @@ sub matchstr
     return $outstr;
 }
 
-sub cleanUp
+END
 {
-    my ($errorterm) = @_;
-    vprint ">cleanUp\n";
-
-    if ($errorterm && ($logfile ne ""))
+    if ($? && ($logfile ne ""))
     {
         print "${logpfxstr}Output from this test saved in $logfile\n";
     }
-
-    vprint "<cleanUp\n";
 }
 
 sub runAllTests
@@ -590,7 +579,6 @@ sub runAllTests
         if ($x == -1)
         {
             my $tmpmsg = sprintf("ERROR: XML syntax error: unterminated comment found starting with \"<--%s\"\n", substr($tmp, 0, 10));
-            cleanUp(1);;
             printErrorMsg($tmpmsg);
             exit(1);
         }
@@ -622,7 +610,6 @@ sub runAllTests
             $x = index($tmp, "<name>");
             if ($x == -1)
             {
-                cleanUp(1);;
                 printErrorMsg("ERROR: XML syntax error: no name found in <subtest>\n");
                 exit(1);
             }
@@ -630,7 +617,6 @@ sub runAllTests
             $x = index($tmp, "</name>");
             if ($x == -1)
             {
-                cleanUp(1);;
                 printErrorMsg("ERROR: XML syntax error: no end-name element found in <subtest>\n");
                 exit(1);
             }
@@ -655,7 +641,6 @@ sub runAllTests
                 $x = index($tmp, "</subtest>");
                 if ($x == -1)
                 {
-                    cleanUp(1);;
                     printErrorMsg("ERROR: XML syntax error: missing </subtest>\n");
                     exit(1);
                 }
@@ -683,7 +668,6 @@ sub runAllTests
     #------------------------------------------------------------------------------
     if (! findNextKey("integrationtest", "integrationtest"))
     {
-        cleanUp(1);;
         printErrorMsg("ERROR: could not find <integrationtest> in XML file\n");
         exit(1);
     }
@@ -780,7 +764,6 @@ sub runAllTests
                     }
                     else
                     {
-                        cleanUp(1);;
                         printErrorMsg("ERROR: unrecognized value in <exitonerror>: $tmp\n");
                         exit(1);
                     }
@@ -826,7 +809,6 @@ sub runAllTests
                     # Clean up and terminate if requested
                     if ($exitonerror)
                     {
-                        cleanUp(1);
                         printErrorMsg("ERROR: terminating test\n");
                         exit(1);
                     }
@@ -835,9 +817,6 @@ sub runAllTests
 
             printMsg("Finished Test: $testgrp\n");
         }
-
-        # Stop simics and simics server
-        cleanUp(0);
     }
 }
 

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -534,12 +534,6 @@ sub runAllTests
         $xmldata =~ s/\%\%${key}\%\%/$xmlvars{$key}/g;
     }
 
-    # If we're just debugging XML, then display it and we're done
-    if ($debug eq "xml")
-    {
-        print "$xmldata\n";
-        exit(0);
-    }
     if (is_verbose_enabled()) { vprint "xmldata:\n"; vprint "$xmldata\n"; }
 
     #------------------------------------------------------------------------------

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -271,25 +271,14 @@ sub runCmdTest
     vprint "<runCmdTest (testrc: $testrc   totalrc: $totalrc)\n";
 }
 
-my $tmpxmlfile = "/tmp/run-op-it-temp-$$.xml";
-
 sub readXml
 {
     my ($xml_path) = @_;
-    my $outstr = "";
-    my $cmd;
 
-    $cmd = "read-op-xml-it $xml_path >$tmpxmlfile";
+    open(my $xml_in, "read-op-xml-it $xml_path |")
+	or die "couldn't run reda-op-xml-it for $xml_path";
 
-    my $rc = system($cmd);
-    $outstr = `cat $tmpxmlfile 2>/dev/null`;
-    system("rm -f $tmpxmlfile");
-    if ($rc)
-    {
-        exit(9);
-    }
-
-    return $outstr;
+    return join '', <$xml_in>;
 }
 
                                                                             ###

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -520,13 +520,12 @@ sub runAllTests
     #--------------------------------------------------------------------------
     # Read in the XML file and treat as one big string
     #--------------------------------------------------------------------------
-    $tmp = readXml("$filename");
-    if ($tmp eq "")
+    $xmldata = readXml("$filename");
+    if ($xmldata eq "")
     {
         printErrorMsg("ERROR: unable to read XML file $filename\n");
         exit(1);
     }
-    #$tmp =~ s/\n/ /g; <- messes up <fspscript> values
 
     #--------------------------------------------------------------------------
     # Do the template variable substitution, if any
@@ -536,27 +535,6 @@ sub runAllTests
         vprint "substituting template variable: \%\%${key}\%\% -> $xmlvars{$key}\n";
         $tmp =~ s/\%\%${key}\%\%/$xmlvars{$key}/g;
     }
-
-    #--------------------------------------------------------------------------
-    # Strip out all comments
-    #--------------------------------------------------------------------------
-    $xmldata = "";
-    my $x = index($tmp, "<!--");
-    while($x != -1)
-    {
-        $xmldata .= substr($tmp, 0, $x);
-        $tmp = substr($tmp, ($x + 4));
-        $x = index($tmp, "-->");
-        if ($x == -1)
-        {
-            my $tmpmsg = sprintf("ERROR: XML syntax error: unterminated comment found starting with \"<--%s\"\n", substr($tmp, 0, 10));
-            printErrorMsg($tmpmsg);
-            exit(1);
-        }
-        $tmp = substr($tmp, ($x + 3));
-        $x = index($tmp, "<!--");
-    }
-    $xmldata .= $tmp;
 
     #--------------------------------------------------------------------------
     # Strip out any excluded subtests
@@ -570,7 +548,7 @@ sub runAllTests
 
         $tmp = $xmldata;
         $xmldata = "";
-        $x = index($tmp, "<subtest>");
+        my $x = index($tmp, "<subtest>");
         while($x != -1)
         {
             # Add the data up to the next subtest start

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -89,12 +89,7 @@ use OPBVTXML;
 
                                                                             ###
 my $filename = "";
-my $x;
-my $y;
 my $cmd;
-my $cmd_timeout;
-my $timestamp = "";
-my $tmpscriptname = "tmpscript-$$";
 my $rc = 0;
 my $xmldata;
 my $cmd_line_machine;
@@ -161,7 +156,7 @@ sub printMsg
     my ($msg) = @_;
     if (! $quiet && ($debug ne "xml"))
     {
-        $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
+        my $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
         print "${timestamp} :: ${logpfxstr}${msg}";
         vprint "${timestamp} :: ${logpfxstr}${msg}";
         add_log_hist("${timestamp} :: ${logpfxstr}${msg}");
@@ -177,7 +172,7 @@ sub printMsg
 sub printErrorMsg
 {
     my ($msg) = @_;
-    $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
+    my $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
     print STDERR "${timestamp} :: ${logpfxstr}${msg}";
     vprint "${timestamp} :: ${logpfxstr}${msg}";
     add_log_hist("${timestamp} :: ${logpfxstr}${msg}");
@@ -319,7 +314,7 @@ sub getAttrs
         $attrstr = substr($attrstr, 1);
 
         # Get the value string
-        $x = index($attrstr, "\"");
+        my $x = index($attrstr, "\"");
         if ($x == -1)
         {
             printErrorMsg("ERROR: XML syntax error: all attribute values must end with a double-quote: $saveattrstr\n");
@@ -546,7 +541,7 @@ sub runAllTests
     # Strip out all comments
     #--------------------------------------------------------------------------
     $xmldata = "";
-    $x = index($tmp, "<!--");
+    my $x = index($tmp, "<!--");
     while($x != -1)
     {
         $xmldata .= substr($tmp, 0, $x);

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -48,8 +48,6 @@ OPTIONS is one or more of:
    --debug xml | cmd : instead of running the test, do the specified debug:
           xml : just display the resulting XML after include processing and variable substitution
           cmd : just display all commands instead of running them
-   --outrc yyyy : the name of a file in which to store the exit code of this process.
-          This can be useful in managing multiple run-op-it programs running concurrently.
    --logpfx xxxx : the string with which to prefix all log messages (this can be useful
           if running multiple concurrent run-op-it commands to the same common log)
    --testenv xxx : is this test to run only in specific environment with this tag
@@ -112,7 +110,6 @@ my %keyattrs;
 my $debug = "";
 my $title_text = "Integration Test";
 my $testcaseid = "";
-my $outrc = "";
 my @tcs;
 
 my $cleanup_old_signal = "";
@@ -561,10 +558,6 @@ sub cleanUp
 sub doExit
 {
     my ($exitcode) = @_;
-    if ($outrc ne "")
-    {
-        system("echo $exitcode >$outrc");
-    }
     exit($exitcode);
 }
 
@@ -913,7 +906,6 @@ while(@argv)
         $xmlvars{fverbose} = "--fverbose $fvfile";
         next;
     }
-    if ($arg eq "--outrc") { $outrc = shift(@argv); next; }
     if ($arg eq "--cleanup")
     {
         $cleanup_old_signal = shift(@argv);

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -44,7 +44,6 @@ Syntax:
    file.xml : the test definition file
 
 OPTIONS is one or more of:
-   --subtest \"tst1[,tst2...]\" : list of <subtest> names to run (default is to run all)
    --debug xml | cmd : instead of running the test, do the specified debug:
           xml : just display the resulting XML after include processing and variable substitution
           cmd : just display all commands instead of running them
@@ -103,7 +102,6 @@ my $testrc = 0;
 my $totalrc = 0;
 my $tmp;
 my %xmlvars;
-my @subtests;
 my %keyattrs;
 my $debug = "";
 my $title_text = "Integration Test";
@@ -533,75 +531,7 @@ sub runAllTests
     foreach my $key (keys(%xmlvars))
     {
         vprint "substituting template variable: \%\%${key}\%\% -> $xmlvars{$key}\n";
-        $tmp =~ s/\%\%${key}\%\%/$xmlvars{$key}/g;
-    }
-
-    #--------------------------------------------------------------------------
-    # Strip out any excluded subtests
-    #--------------------------------------------------------------------------
-    my $subtest_count = @subtests;
-    if ($subtest_count)
-    {
-        my $subtest_requested = 0;
-        my $subtest_name;
-        my $req_subtest_name;
-
-        $tmp = $xmldata;
-        $xmldata = "";
-        my $x = index($tmp, "<subtest>");
-        while($x != -1)
-        {
-            # Add the data up to the next subtest start
-            $xmldata .= substr($tmp, 0, $x);
-
-            # Parse out the subtest name
-            $tmp = substr($tmp, ($x + 9));
-            $x = index($tmp, "<name>");
-            if ($x == -1)
-            {
-                printErrorMsg("ERROR: XML syntax error: no name found in <subtest>\n");
-                exit(1);
-            }
-            $tmp = substr($tmp, ($x + 6));
-            $x = index($tmp, "</name>");
-            if ($x == -1)
-            {
-                printErrorMsg("ERROR: XML syntax error: no end-name element found in <subtest>\n");
-                exit(1);
-            }
-            $subtest_name = substr($tmp, 0, $x);
-            $tmp = substr($tmp, ($x + 7));
-
-            # See if this is one we want
-            $subtest_requested = 0;
-            foreach $req_subtest_name (@subtests)
-            {
-                if ($subtest_name eq $req_subtest_name)
-                {
-                    $subtest_requested = 1;
-                    last;
-                }
-            }
-
-            # Include it or skip it
-            if (!$subtest_requested)
-            {
-                vprint "Skipping subtest $subtest_name\n";
-                $x = index($tmp, "</subtest>");
-                if ($x == -1)
-                {
-                    printErrorMsg("ERROR: XML syntax error: missing </subtest>\n");
-                    exit(1);
-                }
-                $tmp = substr($tmp, ($x + 10));
-            }
-
-            $x = index($tmp, "<subtest>");
-        }
-        $xmldata .= $tmp;
-
-        $xmldata =~ s/\<\/subtest\>//; # Might be some leftovers
-        vprint "XML after processing requested subtests:\n$xmldata\n";
+        $xmldata =~ s/\%\%${key}\%\%/$xmlvars{$key}/g;
     }
 
     # If we're just debugging XML, then display it and we're done
@@ -821,12 +751,6 @@ while(@argv)
         $xmlvars{fverbose} = "--fverbose $fvfile";
         next;
     }
-    if ($arg eq "--subtest")
-    {
-        $arg = shift(@argv);
-        @subtests = split(/\,/, $arg);
-        next;
-    }
     if ($arg eq "--debug")
     {
         $debug = shift(@argv);
@@ -898,7 +822,6 @@ if ($xmlvars{machine} ne "")
 
 if (is_verbose_enabled())
 {
-    vprint "subtests: @subtests\n";
     vprint "xmlvars{machine}: $xmlvars{machine}\n";
     vprint "test_env: $test_env\n";
     vprint "OP_TEST env vars:\n";

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -70,6 +70,8 @@ my $verbose_str = "";
                                                                             ###
 package Testcase;
                                                                             ###
+use Time::localtime;
+
 use Class::Struct;
 struct (
 id => '$',
@@ -158,8 +160,7 @@ sub printMsg
     my ($msg) = @_;
     if (! $quiet && ($debug ne "xml"))
     {
-        $timestamp = `date +'%H:%M:%S'`;
-        chomp($timestamp);
+        $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
         print "${timestamp} :: ${logpfxstr}${msg}";
         vprint "${timestamp} :: ${logpfxstr}${msg}";
         add_log_hist("${timestamp} :: ${logpfxstr}${msg}");
@@ -175,8 +176,7 @@ sub printMsg
 sub printErrorMsg
 {
     my ($msg) = @_;
-    $timestamp = `date +'%H:%M:%S'`;
-    chomp($timestamp);
+    $timestamp = sprintf "%02d:%02d:%02d", localtime->hour, localtime->min, localtime->sec;
     print STDERR "${timestamp} :: ${logpfxstr}${msg}";
     vprint "${timestamp} :: ${logpfxstr}${msg}";
     add_log_hist("${timestamp} :: ${logpfxstr}${msg}");
@@ -654,8 +654,7 @@ sub runAllTests
         $title_text = $chk_title;
     }
 
-    $tmp = `date +'%Y-%B-%d'`;
-    chomp($tmp);
+    $tmp = sprintf("%d-%02d-%02d", localtime->year + 1900, localtime->mon + 1, localtime->mday);
     printMsg("Starting $title_text on $tmp...\n");
 
     # Process each platform
@@ -955,8 +954,8 @@ runAllTests();
 #------------------------------------------------------------------------------
 # Cleanup and exit
 #------------------------------------------------------------------------------
-$tmp = `date +'%Y-%B-%d'`;
-chomp($tmp);
+$tmp = sprintf("%d-%02d-%02d", localtime->year + 1900,
+		   localtime->mon + 1, localtime->mday);
 if ($totalrc == 0)
 {
     printMsg("OK: Finished tests on $tmp with no testcase errors.\n");

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -505,21 +505,6 @@ sub getNextKey
     return $outstr;
 }
 
-                                                                            ###
-# matchstr
-                                                                            ###
-sub matchstr
-{
-    my ($tstr, $regex) = @_;
-    my $outstr = "";
-    if ($tstr =~ /$regex$/)
-    {
-        $outstr = substr($tstr, $-[0]);
-    }
-    vprint "matchstr(\"$tstr\", \"$regex\") returning \"$outstr\"\n";
-    return $outstr;
-}
-
 END
 {
     if ($? && ($logfile ne ""))

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -33,10 +33,9 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin";
 
-my $version = "1.1";
 my $test_env = "";
 
-my $usage = "Run OpenPower Automated Integration Test (Version ${version})
+my $usage = "Run OpenPower Automated Integration Test
 
 Syntax:
    1) Run test:                         run-op-it [OPTIONS] file.xml
@@ -1011,7 +1010,6 @@ if ($outpid ne "")
 
 if (is_verbose_enabled())
 {
-    vprint "version: $version\n";
     vprint "subtests: @subtests\n";
     vprint "xmlvars{machine}: $xmlvars{machine}\n";
     vprint "test_env: $test_env\n";

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -85,6 +85,7 @@ restrict_env => '$'
 1;
 
 use OpTestInfra;
+use OPBVTXML;
 
                                                                             ###
 my $filename = "";
@@ -942,9 +943,8 @@ if (is_verbose_enabled())
 exportXmlVars();
 
 # Validate the syntax of the specified XML file
-$cmd = "op-it-list $verbose_str --q $filename";
-if (is_verbose_enabled() || ($debug eq "cmd")) { vprint "Running: $cmd\n"; }
-system($cmd) && die "ERROR: XML file failed validity checking\n";
+OPBVTXML::bvt_xml_is_valid("op-it.xsd", $filename)
+    or die "ERROR: XML file $filename failed validity checking";
 
 #------------------------------------------------------------------------------
 # Run the integration test bucket as defined by the input file

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -48,8 +48,6 @@ OPTIONS is one or more of:
    --debug xml | cmd : instead of running the test, do the specified debug:
           xml : just display the resulting XML after include processing and variable substitution
           cmd : just display all commands instead of running them
-   --outpid xxxx : the name of a file in which to store the PID of this process.
-          This can be useful in managing multiple run-op-it programs running concurrently.
    --outrc yyyy : the name of a file in which to store the exit code of this process.
           This can be useful in managing multiple run-op-it programs running concurrently.
    --logpfx xxxx : the string with which to prefix all log messages (this can be useful
@@ -114,7 +112,6 @@ my %keyattrs;
 my $debug = "";
 my $title_text = "Integration Test";
 my $testcaseid = "";
-my $outpid = "";
 my $outrc = "";
 my @tcs;
 
@@ -916,7 +913,6 @@ while(@argv)
         $xmlvars{fverbose} = "--fverbose $fvfile";
         next;
     }
-    if ($arg eq "--outpid") { $outpid = shift(@argv); next; }
     if ($arg eq "--outrc") { $outrc = shift(@argv); next; }
     if ($arg eq "--cleanup")
     {
@@ -996,11 +992,6 @@ if ($xmlvars{machine} ne "")
 # set vars representing execution environment
 #-------------------------------------------------------------------------------
 
-# Store the PID, if requested
-if ($outpid ne "")
-{
-    system("echo $$ >$outpid");
-}
 #if ($logpfxstr eq "")
 #{
     #$logpfxstr = `whoami`;

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -31,6 +31,7 @@
 use strict;
 
 use FindBin;
+use XML::LibXML;
 use lib "$FindBin::Bin";
 
 my $test_env = "";
@@ -275,10 +276,10 @@ sub readXml
 {
     my ($xml_path) = @_;
 
-    open(my $xml_in, "read-op-xml-it $xml_path |")
-	or die "couldn't run reda-op-xml-it for $xml_path";
-
-    return join '', <$xml_in>;
+    my $parser = XML::LibXML->new();
+    my $dom = XML::LibXML->load_xml(location => $xml_path);
+    $parser->process_xincludes($dom);
+    return $dom->serialize;
 }
 
                                                                             ###

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -555,12 +555,6 @@ sub cleanUp
     vprint "<cleanUp\n";
 }
 
-sub doExit
-{
-    my ($exitcode) = @_;
-    exit($exitcode);
-}
-
 sub runAllTests
 {
     my $savexmldata;
@@ -576,7 +570,7 @@ sub runAllTests
     if ($tmp eq "")
     {
         printErrorMsg("ERROR: unable to read XML file $filename\n");
-        doExit(1);
+        exit(1);
     }
     #$tmp =~ s/\n/ /g; <- messes up <fspscript> values
 
@@ -604,7 +598,7 @@ sub runAllTests
             my $tmpmsg = sprintf("ERROR: XML syntax error: unterminated comment found starting with \"<--%s\"\n", substr($tmp, 0, 10));
             cleanUp(1);;
             printErrorMsg($tmpmsg);
-            doExit(1);
+            exit(1);
         }
         $tmp = substr($tmp, ($x + 3));
         $x = index($tmp, "<!--");
@@ -636,7 +630,7 @@ sub runAllTests
             {
                 cleanUp(1);;
                 printErrorMsg("ERROR: XML syntax error: no name found in <subtest>\n");
-                doExit(1);
+                exit(1);
             }
             $tmp = substr($tmp, ($x + 6));
             $x = index($tmp, "</name>");
@@ -644,7 +638,7 @@ sub runAllTests
             {
                 cleanUp(1);;
                 printErrorMsg("ERROR: XML syntax error: no end-name element found in <subtest>\n");
-                doExit(1);
+                exit(1);
             }
             $subtest_name = substr($tmp, 0, $x);
             $tmp = substr($tmp, ($x + 7));
@@ -669,7 +663,7 @@ sub runAllTests
                 {
                     cleanUp(1);;
                     printErrorMsg("ERROR: XML syntax error: missing </subtest>\n");
-                    doExit(1);
+                    exit(1);
                 }
                 $tmp = substr($tmp, ($x + 10));
             }
@@ -686,7 +680,7 @@ sub runAllTests
     if ($debug eq "xml")
     {
         print "$xmldata\n";
-        doExit(0);
+        exit(0);
     }
     if (is_verbose_enabled()) { vprint "xmldata:\n"; vprint "$xmldata\n"; }
 
@@ -697,7 +691,7 @@ sub runAllTests
     {
         cleanUp(1);;
         printErrorMsg("ERROR: could not find <integrationtest> in XML file\n");
-        doExit(1);
+        exit(1);
     }
 
     # Get the integration test title (if any)
@@ -718,7 +712,7 @@ sub runAllTests
 
         # Find the machine name
         $machine = getNextKey("machine", "platform");
-        #if ($machine eq "") { printErrorMsg("ERROR: could not find <machine> key in platform\n"); doExit(9); }
+        #if ($machine eq "") { printErrorMsg("ERROR: could not find <machine> key in platform\n"); exit(9); }
 
         # Check if this is specific to a platform we're not running and, if so, skip it
         if (($cmd_line_machine ne "") && (lc($cmd_line_machine) ne lc($machine)))
@@ -794,7 +788,7 @@ sub runAllTests
                     {
                         cleanUp(1);;
                         printErrorMsg("ERROR: unrecognized value in <exitonerror>: $tmp\n");
-                        doExit(1);
+                        exit(1);
                     }
                 }
 
@@ -840,7 +834,7 @@ sub runAllTests
                     {
                         cleanUp(1);
                         printErrorMsg("ERROR: terminating test\n");
-                        doExit(1);
+                        exit(1);
                     }
                 }
             }
@@ -912,7 +906,7 @@ while(@argv)
         if (($cleanup_old_signal ne "SIGTERM") && ($cleanup_old_signal ne "SIGKILL"))
         {
             print STDERR "ERROR: unrecognized signal specified on --cleanup: \"$cleanup_old_signal\"\n";
-            doExit(9);
+            exit(9);
         }
         next;
     }
@@ -959,7 +953,7 @@ if ($ENV{OP_TEST_FAILSUMM_LOG} ne "")
 if (($filename eq "") && ($cleanup_old_signal eq ""))
 {
     printErrorMsg("ERROR: you must specify a XML file defining the test\n");
-    doExit(9);
+    exit(9);
 }
 
 # Validate test_env
@@ -1031,7 +1025,7 @@ if ($cleanup_old_signal ne "")
         }
     }
 
-    doExit(0);
+    exit(0);
 }
 
 # export %%variables%% for read-op-xml-it (which is run under fips-it-list)
@@ -1066,4 +1060,4 @@ if ($logfile ne "")
 {
     print "${logpfxstr}Output from this test saved in $logfile (simics server logs stored in same directory)\n";
 }
-doExit($totalrc);
+exit($totalrc);

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -39,7 +39,6 @@ my $usage = "Run OpenPower Automated Integration Test
 
 Syntax:
    1) Run test:                         run-op-it [OPTIONS] file.xml
-   2) Cleanup old run-op-it processes:  run-op-it --cleanup SIGTERM | SIGKILL [--all]
 
    file.xml : the test definition file
 
@@ -111,11 +110,6 @@ my $debug = "";
 my $title_text = "Integration Test";
 my $testcaseid = "";
 my @tcs;
-
-my $cleanup_old_signal = "";
-my @cleanup_targets = (
-"run-op-it",
-);
 
 my $cmdtmpfile = "/tmp/run-op-it-cmd-$$.tmp";
 my $logfiledir = "";
@@ -900,16 +894,6 @@ while(@argv)
         $xmlvars{fverbose} = "--fverbose $fvfile";
         next;
     }
-    if ($arg eq "--cleanup")
-    {
-        $cleanup_old_signal = shift(@argv);
-        if (($cleanup_old_signal ne "SIGTERM") && ($cleanup_old_signal ne "SIGKILL"))
-        {
-            print STDERR "ERROR: unrecognized signal specified on --cleanup: \"$cleanup_old_signal\"\n";
-            exit(9);
-        }
-        next;
-    }
     if ($arg eq "--subtest")
     {
         $arg = shift(@argv);
@@ -950,7 +934,7 @@ if ($ENV{OP_TEST_FAILSUMM_LOG} ne "")
     set_failsumm_log($ENV{OP_TEST_FAILSUMM_LOG});
 }
 
-if (($filename eq "") && ($cleanup_old_signal eq ""))
+if ($filename eq "")
 {
     printErrorMsg("ERROR: you must specify a XML file defining the test\n");
     exit(9);
@@ -999,33 +983,6 @@ if (is_verbose_enabled())
     {
         system("env | grep OP_TEST_");
     }
-}
-
-#------------------------------------------------------------------------------
-# Handle cleanup request
-#------------------------------------------------------------------------------
-if ($cleanup_old_signal ne "")
-{
-    printMsg("Killing old run-op-it processes...\n");
-
-    # Process all running run-op-it processes belonging to this user
-    my $userid = `whoami`;
-    chomp($userid);
-    my $tmp;
-    my @old_procs;
-    foreach my $target (@cleanup_targets)
-    {
-        $tmp = `ps -ef | grep $target | grep $userid | grep -v $$ | grep -v grep | awk '{ print \$2 }'`;
-        @old_procs = split(/\n/, $tmp);
-
-        # Kill them
-        foreach my $old_pid (@old_procs)
-        {
-            killtree($old_pid, $cleanup_old_signal);
-        }
-    }
-
-    exit(0);
 }
 
 # export %%variables%% for read-op-xml-it (which is run under fips-it-list)

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -23,11 +23,11 @@
 # permissions and limitations under the License.
 #
 # IBM_PROLOG_END_TAG
-                                                                                
+
 # Run simics/FSP automated integration test
 #
 # Author: Alan Hlava
-                                                                                
+
 use strict;
 
 use FindBin;
@@ -130,9 +130,8 @@ my $logfile = "";
 my $logpfx = "";
 my $logpfxstr = "";
 
-                                                                                
 # killtree
-                                                                                
+
 sub killtree
 {
     my ($killpid, $sig) = @_;
@@ -149,9 +148,6 @@ sub killtree
     }
 }
 
-                                                                                
-# sigtermHandler
-                                                                                
 $SIG{'TERM'} = 'sigtermHandler';
 sub sigtermHandler
 {
@@ -166,18 +162,12 @@ sub sigtermHandler
     exit (1);
 }
 
-                                                                                
-# syntax
-                                                                                
 sub syntax()
 {
     print "$usage";
     exit(1);
 }
 
-                                                                                
-# printMsg
-                                                                                
 sub printMsg
 {
     my ($msg) = @_;
@@ -197,9 +187,6 @@ sub printMsg
     }
 }
 
-                                                                                
-# printErrorMsg
-                                                                                
 sub printErrorMsg
 {
     my ($msg) = @_;
@@ -217,9 +204,6 @@ sub printErrorMsg
     write_log_hist("Failure summary from run-op-it running $filename");
 }
 
-                                                                                
-# runCmd
-                                                                                
 sub runCmd
 {
     my ($cmd, $log_cmd) = @_;
@@ -281,14 +265,11 @@ sub runCmd
     return $cmdrc;
 }
 
-                                                                                
-# runCmdTest
-                                                                                
 sub runCmdTest
 {
     vprint ">runCmdTest\n";
     my $x;
-    
+
     # Trim off any arguments included in the testcase string
     $x = index($testcase, " ");
     if ($x != -1)
@@ -296,24 +277,22 @@ sub runCmdTest
         $args .= substr($testcase, $x);
         $testcase = substr($testcase, 0, $x);
     }
-    
+
     # Convert relative path (if any) to absolute path
     my $x86_script_file = findRelFile($testcase);
-    
+
     $testrc = runCmd("$x86_script_file $args", 1);
     $totalrc += $testrc;
-    
+
     vprint "<runCmdTest (testrc: $testrc   totalrc: $totalrc)\n";
 }
 
 my $tmpxmlfile = "/tmp/run-op-it-temp-$$.xml";
-                                                                                
-# readXml
-                                                                                
+
 sub readXml
 {
     my ($xml_path) = @_;
-    my $outstr = "";    
+    my $outstr = "";
     my $cmd;
 
     $cmd = "read-op-xml-it $xml_path >$tmpxmlfile";
@@ -341,7 +320,7 @@ sub getAttrs
     my $attr;
     my $val;
     my $enddelim;
-    
+
     vprint ">getAttrs($attrstr)\n";
     $attrstr = trim($attrstr);
     while($attrstr ne "")
@@ -356,7 +335,7 @@ sub getAttrs
         }
         $attr = substr($attrstr, 0, $x);
         $attrstr = substr($attrstr, ($x + 1));
-        
+
         # Determine how the value is delimited
         if ( !($attrstr =~ /^\"/))
         {
@@ -365,7 +344,7 @@ sub getAttrs
             exit(1);
         }
         $attrstr = substr($attrstr, 1);
-        
+
         # Get the value string
         $x = index($attrstr, "\"");
         if ($x == -1)
@@ -380,8 +359,8 @@ sub getAttrs
         vprint "   storing: \"$attr\" -> \"$val\"\n";
         # Store the attr->value mapping
         $outhash{$attr} = "$val";
-        
-        
+
+
         # Prepare for next loop
         $attrstr = trim($attrstr);
         vprint "   attrstr>$attrstr<\n";
@@ -389,7 +368,6 @@ sub getAttrs
     vprint "<getAttrs()\n";
     return %outhash;
 }
-    
                                                                             ###
 # getValue (do NOT change xmldata, just return the value)
                                                                             ###
@@ -433,7 +411,7 @@ sub getValue
                 return $value;
             }
         }
-        
+
         my $attrs_present = 1;
         if (substr($l_xmldata, ($x + length($key) + 1), 1) eq ">")
         {
@@ -443,9 +421,9 @@ sub getValue
         $x = index($l_xmldata, "</${key}>");
         if ($x != -1)
         {
-            $value = substr($l_xmldata, 0, $x);        
+            $value = substr($l_xmldata, 0, $x);
         }
-        
+
         # See if any key attributes
         if ($attrs_present)
         {
@@ -463,10 +441,7 @@ sub getValue
     vprint "<getValue($key,$limkeyarg) returning: \"$value\"\n";
     return $value;
 }
-    
-                                                                            ###
-# findNextKey
-                                                                            ###
+
 sub findNextKey
 {
     my ($key, $limkeyarg) = @_;
@@ -509,7 +484,7 @@ sub findNextKey
                 return $rc;
             }
         }
-        
+
         my $attrs_present = 1;
         if (substr($xmldata, ($x + length($key) + 1), 1) eq ">")
         {
@@ -517,7 +492,7 @@ sub findNextKey
         }
         $xmldata = substr($xmldata, ($x + length($key) + 2));
         $rc = 1;
-        
+
         # See if any key attributes
         if ($attrs_present)
         {
@@ -547,8 +522,8 @@ sub getNextKey
         $x = index($xmldata, "</${key}>");
         if ($x != -1)
         {
-            $outstr = substr($xmldata, 0, $x);        
-            $xmldata = substr($xmldata, ($x + length($key) + 3));    
+            $outstr = substr($xmldata, 0, $x);
+            $xmldata = substr($xmldata, ($x + length($key) + 3));
         }
     }
     if (!$nonewline)
@@ -574,25 +549,19 @@ sub matchstr
     return $outstr;
 }
 
-                                                                                
-# cleanUp
-                                                                                
 sub cleanUp
 {
     my ($errorterm) = @_;
     vprint ">cleanUp\n";
-    
+
     if ($errorterm && ($logfile ne ""))
     {
         print "${logpfxstr}Output from this test saved in $logfile\n";
     }
-    
+
     vprint "<cleanUp\n";
 }
 
-                                                                                
-# doExit
-                                                                                
 sub doExit
 {
     my ($exitcode) = @_;
@@ -603,9 +572,6 @@ sub doExit
     exit($exitcode);
 }
 
-                                                                                
-# runAllTests
-                                                                                
 sub runAllTests
 {
     my $savexmldata;
@@ -613,7 +579,7 @@ sub runAllTests
     my @ffdc_scripts;
     my $ffdc_script = "";
     my $ffdc_script_count = 0;
-    
+
     #--------------------------------------------------------------------------
     # Read in the XML file and treat as one big string
     #--------------------------------------------------------------------------
@@ -655,7 +621,7 @@ sub runAllTests
         $x = index($tmp, "<!--");
     }
     $xmldata .= $tmp;
-    
+
     #--------------------------------------------------------------------------
     # Strip out any excluded subtests
     #--------------------------------------------------------------------------
@@ -665,7 +631,7 @@ sub runAllTests
         my $subtest_requested = 0;
         my $subtest_name;
         my $req_subtest_name;
-        
+
         $tmp = $xmldata;
         $xmldata = "";
         $x = index($tmp, "<subtest>");
@@ -673,7 +639,7 @@ sub runAllTests
         {
             # Add the data up to the next subtest start
             $xmldata .= substr($tmp, 0, $x);
-            
+
             # Parse out the subtest name
             $tmp = substr($tmp, ($x + 9));
             $x = index($tmp, "<name>");
@@ -693,7 +659,7 @@ sub runAllTests
             }
             $subtest_name = substr($tmp, 0, $x);
             $tmp = substr($tmp, ($x + 7));
-            
+
             # See if this is one we want
             $subtest_requested = 0;
             foreach $req_subtest_name (@subtests)
@@ -704,7 +670,7 @@ sub runAllTests
                     last;
                 }
             }
-            
+
             # Include it or skip it
             if (!$subtest_requested)
             {
@@ -718,15 +684,15 @@ sub runAllTests
                 }
                 $tmp = substr($tmp, ($x + 10));
             }
-            
+
             $x = index($tmp, "<subtest>");
         }
         $xmldata .= $tmp;
-        
+
         $xmldata =~ s/\<\/subtest\>//; # Might be some leftovers
-        vprint "XML after processing requested subtests:\n$xmldata\n";    
+        vprint "XML after processing requested subtests:\n$xmldata\n";
     }
-    
+
     # If we're just debugging XML, then display it and we're done
     if ($debug eq "xml")
     {
@@ -734,7 +700,7 @@ sub runAllTests
         doExit(0);
     }
     if (is_verbose_enabled()) { vprint "xmldata:\n"; vprint "$xmldata\n"; }
-    
+
     #------------------------------------------------------------------------------
     # Find the start
     #------------------------------------------------------------------------------
@@ -744,25 +710,23 @@ sub runAllTests
         printErrorMsg("ERROR: could not find <integrationtest> in XML file\n");
         doExit(1);
     }
-    
+
     # Get the integration test title (if any)
     my $chk_title = getNextKey("title", "<test>"); # Don't find <test> title by mistake!
     if ($chk_title ne "")
     {
         $title_text = $chk_title;
     }
-    
+
     $tmp = `date +'%Y-%B-%d'`;
     chomp($tmp);
     printMsg("Starting $title_text on $tmp...\n");
-    
-    #------------------------------------------------------------------------------
+
     # Process each platform
-    #------------------------------------------------------------------------------
     while(findNextKey("platform", "platform"))
     {
         vprint "Processing new platform...\n";
-                
+
         # Find the machine name
         $machine = getNextKey("machine", "platform");
         #if ($machine eq "") { printErrorMsg("ERROR: could not find <machine> key in platform\n"); doExit(9); }
@@ -774,7 +738,7 @@ sub runAllTests
             findNextKey("test", "platform"); # skip ahead so we go to next platform
             next;
         }
-        
+
         # Process each test group
         while(findNextKey("test", "platform"))
         {
@@ -808,7 +772,7 @@ sub runAllTests
                 $tc->restrict_env( getValue("restrict-env", "testcase") );
                 push(@tcs, $tc);
             }
-            
+
             # Process each testcase within the group
             foreach my $tc_ref (@tcs)
             {
@@ -822,7 +786,7 @@ sub runAllTests
                     printMsg("Skipping testcase $testcase_index due to not running in $restrict_env environment\n");
                     next;
                 }
-                
+
                 # Get exit-on-error specification (if any)
                 $exitonerror = 0; # default is "no"
                 $tmp = $tc_ref->exitonerror;
@@ -844,22 +808,22 @@ sub runAllTests
                         doExit(1);
                     }
                 }
-                
+
                 # Get the command arguments (if specified separately)
                 $testcase = $tc_ref->cmd;
                 $args = $tc_ref->arg;
                 $testcase =~ s/\%\%testcaseid\%\%/${testcaseid}/g;
                 $args =~ s/\%\%testcaseid\%\%/${testcaseid}/g;
-                
+
                 # Get the FFDC script(s) (if any)
                 $tmp = $tc_ref->ffdc;
                 $tmp =~ s/\%\%testcaseid\%\%/${testcaseid}/g;
                 @ffdc_scripts = split(/\,/, $tmp);
                 $ffdc_script_count = @ffdc_scripts;
-                
+
                 # Run the command
                 runCmdTest();
-                
+
                 # Handle testcase errors
                 if ($testrc)
                 {
@@ -871,7 +835,7 @@ sub runAllTests
                         {
                             $testcase = "$ffdc_script";
                             $args = "";
-                        
+
                             runCmdTest();
 
                             # reset, so we won't pass this --timeout option on the next command
@@ -881,7 +845,7 @@ sub runAllTests
                             }
                         }
                     }
-                    
+
                     # Clean up and terminate if requested
                     if ($exitonerror)
                     {
@@ -894,18 +858,12 @@ sub runAllTests
 
             printMsg("Finished Test: $testgrp\n");
         }
-        
+
         # Stop simics and simics server
         cleanUp(0);
-        
     }
-    
 }
 
-
-                                                                                
-# exportXmlVars
-                                                                                
 # Export any %%variable%%'s as environment variables, so read-op-xml-it can access them
 sub exportXmlVars
 {
@@ -916,9 +874,6 @@ sub exportXmlVars
     }
 }
 
-                                                                                
-# setLogfileName
-                                                                                
 sub setLogfileName
 {
     my ($basedir) = @_;
@@ -935,14 +890,7 @@ sub setLogfileName
     }
 }
 
-                                                                                
-#                            main
-                                                                                
-sub main() { }
-
-#-------------------------------------------------------------------------------
 # parse the arguments
-#-------------------------------------------------------------------------------
 my @argv = @ARGV;
 my $arg;
 $xmlvars{verbose} = "";
@@ -951,9 +899,9 @@ $xmlvars{fverbose} = "";
 while(@argv)
 {
     $arg = shift(@argv);
-    
+
     if (($arg eq "-?") || ($arg eq "-h") || ($arg eq "--help")) { syntax(); }
-    
+
     if ($arg eq "--verbose")
     {
         set_verbose(1);
@@ -1003,16 +951,16 @@ while(@argv)
 
     # Arguments representing XML substitution variables...
     if ($arg =~ /^\-\-/)
-    {    
+    {
         $arg = substr($arg, 2);
         $xmlvars{$arg} = shift(@argv);
     }
     elsif ($arg =~ /^\-/)
-    {    
+    {
         $arg = substr($arg, 1);
         $xmlvars{$arg} = shift(@argv);
     }
-    
+
     $filename = $arg;
 }
 
@@ -1094,14 +1042,14 @@ if ($cleanup_old_signal ne "")
     {
         $tmp = `ps -ef | grep $target | grep $userid | grep -v $$ | grep -v grep | awk '{ print \$2 }'`;
         @old_procs = split(/\n/, $tmp);
-        
+
         # Kill them
         foreach my $old_pid (@old_procs)
         {
             killtree($old_pid, $cleanup_old_signal);
         }
     }
-    
+
     doExit(0);
 }
 

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -276,229 +276,6 @@ sub readXml
     return $dom->serialize;
 }
 
-                                                                            ###
-# getAttrs
-                                                                            ###
-sub getAttrs
-{
-    my ($attrstr) = @_;
-    my $saveattrstr = $attrstr;
-    my %outhash;
-    my $x;
-    my $attr;
-    my $val;
-    my $enddelim;
-
-    vprint ">getAttrs($attrstr)\n";
-    $attrstr = trim($attrstr);
-    while($attrstr ne "")
-    {
-        # Get the attribute name
-        $x = index($attrstr, "=");
-        if ($x == -1)
-        {
-            printErrorMsg("ERROR: XML syntax error: no equal sign found in attribute area: $saveattrstr\n");
-            exit(1);
-        }
-        $attr = substr($attrstr, 0, $x);
-        $attrstr = substr($attrstr, ($x + 1));
-
-        # Determine how the value is delimited
-        if ( !($attrstr =~ /^\"/))
-        {
-            printErrorMsg("ERROR: XML syntax error: all attribute values must start with a double-quote: $saveattrstr\n");
-            exit(1);
-        }
-        $attrstr = substr($attrstr, 1);
-
-        # Get the value string
-        my $x = index($attrstr, "\"");
-        if ($x == -1)
-        {
-            printErrorMsg("ERROR: XML syntax error: all attribute values must end with a double-quote: $saveattrstr\n");
-            exit(1);
-        }
-        $val = substr($attrstr, 0, $x);
-        $attrstr = substr($attrstr, ($x + 1));
-
-        vprint "   storing: \"$attr\" -> \"$val\"\n";
-        # Store the attr->value mapping
-        $outhash{$attr} = "$val";
-
-
-        # Prepare for next loop
-        $attrstr = trim($attrstr);
-        vprint "   attrstr>$attrstr<\n";
-    }
-    vprint "<getAttrs()\n";
-    return %outhash;
-}
-                                                                            ###
-# getValue (do NOT change xmldata, just return the value)
-                                                                            ###
-sub getValue
-{
-    my ($key, $limkeyarg) = @_;
-    vprint ">getValue($key,$limkeyarg)\n";
-    my $value = "";
-    my $l_xmldata = $xmldata;
-    my $limkey;
-
-    if ($limkeyarg =~ /^\</)
-    {
-        $limkey = $limkeyarg;
-    }
-    else
-    {
-        $limkey = "</$limkeyarg>";
-    }
-
-    # Only clear out attributes when we start reading a new <testcase> node
-    if ($key =~ /testcase/) {
-        vprint "    zeroing keyattrs\n";
-        %keyattrs = ();
-    }
-    my $x = index($l_xmldata, "<${key}>");
-    if ($x == -1)
-    {
-        $x = index($l_xmldata, "<${key} "); # Maybe it has attribute(s)?
-    }
-    if (($x != -1) &&
-        ((substr($l_xmldata, ($x + length($key) + 1), 1) eq ">") || (substr($l_xmldata, ($x + length($key) + 1), 1) eq " "))
-        )
-    {
-        if ($limkeyarg ne $key)
-        {
-            my $y = index($l_xmldata, ${limkey});
-            if (($y != -1) && ($y < $x))
-            {
-                vprint "<getValue($key,$limkeyarg) hit limkey, returning: \"$value\"\n";
-                return $value;
-            }
-        }
-
-        my $attrs_present = 1;
-        if (substr($l_xmldata, ($x + length($key) + 1), 1) eq ">")
-        {
-            $attrs_present = 0;
-        }
-        $l_xmldata = substr($l_xmldata, ($x + length($key) + 2));
-        $x = index($l_xmldata, "</${key}>");
-        if ($x != -1)
-        {
-            $value = substr($l_xmldata, 0, $x);
-        }
-
-        # See if any key attributes
-        if ($attrs_present)
-        {
-            my $pos_caret = index($l_xmldata, ">");
-            my $keyattrstr = substr($l_xmldata, 0, $pos_caret);
-            %keyattrs = getAttrs($keyattrstr);
-            vprint "    attribs present (keyattrs is ".%keyattrs.")\n";
-            #
-            $l_xmldata = substr($l_xmldata, length($keyattrstr)+1);
-        }
-    }
-    # Remove newlines which mess up commands sent to the shell
-    $value =~ s/\n/ /g;
-
-    vprint "<getValue($key,$limkeyarg) returning: \"$value\"\n";
-    return $value;
-}
-
-sub findNextKey
-{
-    my ($key, $limkeyarg) = @_;
-    vprint ">findNextKey($key,$limkeyarg)\n";
-    #vprint "start of xmldata: [";
-    #vprint substr($xmldata, 0, 40);
-    #vprint "...]\n";
-    my $rc = 0;
-    my $limkey;
-
-    if ($limkeyarg =~ /^\</)
-    {
-        $limkey = $limkeyarg;
-    }
-    else
-    {
-        $limkey = "</$limkeyarg>";
-    }
-
-    # Only clear out attributes when we start reading a new <testcase> node
-    if ($key =~ /testcase/) {
-        vprint "    zeroing keyattrs\n";
-        %keyattrs = ();
-    }
-    my $x = index($xmldata, "<${key}>");
-    if ($x == -1)
-    {
-        $x = index($xmldata, "<${key} "); # Maybe it has attribute(s)?
-    }
-    if (($x != -1) &&
-        ((substr($xmldata, ($x + length($key) + 1), 1) eq ">") || (substr($xmldata, ($x + length($key) + 1), 1) eq " "))
-        )
-    {
-        if ($limkeyarg ne $key)
-        {
-            my $y = index($xmldata, ${limkey});
-            if (($y != -1) && ($y < $x))
-            {
-                vprint "<findNextKey($key,$limkeyarg) hit limkey, returning: $rc\n";
-                return $rc;
-            }
-        }
-
-        my $attrs_present = 1;
-        if (substr($xmldata, ($x + length($key) + 1), 1) eq ">")
-        {
-            $attrs_present = 0;
-        }
-        $xmldata = substr($xmldata, ($x + length($key) + 2));
-        $rc = 1;
-
-        # See if any key attributes
-        if ($attrs_present)
-        {
-            my $pos_caret = index($xmldata, ">");
-            my $keyattrstr = substr($xmldata, 0, $pos_caret);
-            %keyattrs = getAttrs($keyattrstr);
-            vprint "    attribs present (keyattrs is ".%keyattrs.")\n";
-            #
-            $xmldata = substr($xmldata, length($keyattrstr)+1);
-        }
-    }
-    vprint "<findNextKey($key,$limkeyarg) returning: $rc\n";
-    return $rc;
-}
-
-                                                                            ###
-# getNextKey
-                                                                            ###
-sub getNextKey
-{
-    my ($key, $limkey, $nonewline) = @_;
-    vprint ">getNextKey($key,$limkey)\n";
-    my $outstr = "";
-    my $x;
-    if (findNextKey($key, $limkey))
-    {
-        $x = index($xmldata, "</${key}>");
-        if ($x != -1)
-        {
-            $outstr = substr($xmldata, 0, $x);
-            $xmldata = substr($xmldata, ($x + length($key) + 3));
-        }
-    }
-    if (!$nonewline)
-    {
-        $outstr =~ s/\n/ /g;
-    }
-    vprint "<getNextKey($key,$limkey) returning: $outstr\n";
-    return $outstr;
-}
-
 END
 {
     if ($? && ($logfile ne ""))
@@ -536,52 +313,52 @@ sub runAllTests
 
     if (is_verbose_enabled()) { vprint "xmldata:\n"; vprint "$xmldata\n"; }
 
-    #------------------------------------------------------------------------------
-    # Find the start
-    #------------------------------------------------------------------------------
-    if (! findNextKey("integrationtest", "integrationtest"))
-    {
-        printErrorMsg("ERROR: could not find <integrationtest> in XML file\n");
-        exit(1);
-    }
+    my $dom = XML::LibXML->load_xml(string => $xmldata);
 
-    # Get the integration test title (if any)
-    my $chk_title = getNextKey("title", "<test>"); # Don't find <test> title by mistake!
-    if ($chk_title ne "")
-    {
-        $title_text = $chk_title;
-    }
+    # find <integrationtest>
+    my @it = $dom->findnodes("/integrationtest");
+    die "multiple <integrationtest>" if @it > 1;
+    my $integrationtest = shift @it;
+
+    my @titles = $integrationtest->findnodes("./title");
+    die "multiple <integrationtest> <title>(s)" if @titles > 1;
+    $title_text = $filename;
+    $title_text = $titles[0]->textContent if @titles > 0;
 
     $tmp = sprintf("%d-%02d-%02d", localtime->year + 1900, localtime->mon + 1, localtime->mday);
     printMsg("Starting $title_text on $tmp...\n");
 
     # Process each platform
-    while(findNextKey("platform", "platform"))
+    foreach my $platform ($integrationtest->findnodes('./platform'))
     {
         vprint "Processing new platform...\n";
 
         # Find the machine name
-        $machine = getNextKey("machine", "platform");
-        #if ($machine eq "") { printErrorMsg("ERROR: could not find <machine> key in platform\n"); exit(9); }
+	$machine = "";
+	my @machines = $platform->findnodes('./machine');
+	die "multiple <machine>s" if @machines > 1;
+	$machine = $machines[0]->textContent if @machines > 0;
 
         # Check if this is specific to a platform we're not running and, if so, skip it
         if (($cmd_line_machine ne "") && (lc($cmd_line_machine) ne lc($machine)))
         {
             printMsg("Skipping platform test because XML <machine>$machine</machine> does not match --machine $cmd_line_machine\n");
-            findNextKey("test", "platform"); # skip ahead so we go to next platform
             next;
         }
 
         # Process each test group
-        while(findNextKey("test", "platform"))
+	my $testnr = 0;
+        foreach my $test ($platform->findnodes('./test'))
         {
-            $restrict_env = getValue("restrict-env", "<testcase>");
-            $testgrp = getNextKey("name", "test");
-            if ($testgrp eq "")
-            {
-                $testgrp = getNextKey("title", "test");
-            }
-            vprint "starting to process test: \"$testgrp\"\n";
+	    $testnr++;
+
+            $restrict_env = ${$test->findnodes('./restrict-env')}[0];
+	    $restrict_env = $restrict_env->textContent if $restrict_env;
+
+            $testgrp = ${$test->findnodes('./name')}[0];
+	    $testgrp = ${$test->findnodes('./title')}[0] if !$testgrp;
+	    $testgrp = $testgrp->textContent if $testgrp;
+	    $testgrp = $testnr if !$testgrp;
 
             # Check for env restriction at <test> level
             if (($restrict_env ne "") && ($restrict_env ne $test_env))
@@ -593,17 +370,24 @@ sub runAllTests
 
             # Create the contained testcases
             @tcs = ();
-            while(findNextKey("testcase", "test"))
+            foreach my $testcase ($test->findnodes('./testcase'))
             {
-                my $tc = new Testcase;
                 ++$testcase_index;
-                $tc->id("$$-$testcase_index");
-                $tc->cmd( getValue("cmd", "testcase") );
-                $tc->arg( getValue("arg", "testcase") );
-                $tc->ffdc( getValue("ffdc", "testcase") );
-                $tc->exitonerror( getValue("exitonerror", "testcase") );
-                $tc->restrict_env( getValue("restrict-env", "testcase") );
-                push(@tcs, $tc);
+		my $cmd = ${$testcase->findnodes('./cmd')}[0];
+		$cmd = $cmd->textContent if $cmd;
+		my $arg = ${$testcase->findnodes('./arg')}[0];
+		$arg = $arg->textContent if $arg;
+		my $ffdc = ${$testcase->findnodes('./ffdc')}[0];
+		$ffdc = $ffdc->textContent if $ffdc;
+		my $exitonerror = ${$testcase->findnodes('./exitonerror')}[0];
+		$exitonerror = $exitonerror->textContent if $exitonerror;
+		my $restrict_env = ${$testcase->findnodes('./restrict_env')}[0];
+		$restrict_env = $restrict_env->textContent if $restrict_env;
+
+                push(@tcs, new Testcase(id=>"$$-$testcase_index",
+					cmd=>$cmd, arg=>$arg, ffdc=>$ffdc,
+					exitonerror=>$exitonerror,
+					restrict_env=>$restrict_env));
             }
 
             # Process each testcase within the group


### PR DESCRIPTION
This patchset goes through and does a *lot* of clean-up in the perl code.

Each change is as self contained as possible, and tries to move us to modern, clean, less error prone perl.

Basic idea is: use Perl modules rather than re-implementing something from scratch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/30)
<!-- Reviewable:end -->
