### PR TITLE
Changed the FW Update script for out-of-band procedure.

### DIFF
--- a/bvt/op-outofband-firmware-update.xml
+++ b/bvt/op-outofband-firmware-update.xml
@@ -31,7 +31,21 @@
 
         <test>
             <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
                 <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_PNOR_level()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.ipmi_sdr_clear()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>
@@ -45,14 +59,7 @@
 
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.cold_reset()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.preserve_network_setting()"</cmd>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.ipmi_power_off()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>
@@ -60,6 +67,34 @@
         <test>
             <testcase>
                 <cmd>op-ci-bmc-run "op_outofband_firmware_update.code_update()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.validate_lpar()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.ipl_wait_for_working_state()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.ipmi_sel_check()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.get_PNOR_level()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>

--- a/ci/source/test_op_outofband_firmware_update.py
+++ b/ci/source/test_op_outofband_firmware_update.py
@@ -28,18 +28,29 @@ import os
 import sys
 import op_outofband_firmware_update
 
+def test_init():
+    assert op_outofband_firmware_update.test_init() == 0
+
 def test_get_PNOR_level():
     assert op_outofband_firmware_update.get_PNOR_level() == 0
+
+def test_ipmi_sdr_clear():
+    assert op_outofband_firmware_update.ipmi_sdr_clear() == 0
 
 def test_get_side_activated():
     assert op_outofband_firmware_update.get_side_activated() == 0
 
-def test_cold_reset():
-    assert op_outofband_firmware_update.cold_reset() == 0
-
-def test_preserve_network_setting():
-    assert op_outofband_firmware_update.preserve_network_setting() == 0
+def test_ipmi_power_off():
+    assert op_outofband_firmware_update.ipmi_power_off() == 0
 
 def test_code_update():
     assert op_outofband_firmware_update.code_update() == 0
 
+def test_validate_lpar():
+    assert op_outofband_firmware_update.validate_lpar() == 0
+
+def test_ipl_wait_for_working_state():
+    assert op_outofband_firmware_update.ipl_wait_for_working_state() == 0
+
+def test_ipmi_sel_check():
+    assert op_outofband_firmware_update.ipmi_sel_check() == 0

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -32,8 +32,11 @@
 
 import sys
 import time
-import pxssh
 import pexpect
+try:
+    import pxssh
+except ImportError:
+    from pexpect import pxssh
 import subprocess
 from OpTestIPMI import OpTestIPMI
 from OpTestConstants import OpTestConstants as BMC_CONST


### PR DESCRIPTION
Fixed the pxssh module import error.

Below is the procedure for FW upgrade through Out-of-band method.
1. Get the current PNOR level before upgrade
2. Clear SEL logs
3. Get current working side-->make sure do fw update on primary side
4. Do ipmi power off.
5. Issue BMC cold reset to bring BMC to stable point
6. Preserve Network settings of BMC
7. Do a code update for both BMC and PNOR firmwares using hpm image method
8. Bring the system up(Power ON)
9. Wait for working state of system
10. Check for any Non-recoverable errors in SEL logs
11. Get PNOR level again after FW Upgrade.

TODO: Gather BMC FW Version info before and after FW upgrade, currently we are getting PNOR version only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/31)
<!-- Reviewable:end -->
