### PR TITLE
CI for OPAL

### DIFF
--- a/bvt/op-opal-ci-bvt.xml
+++ b/bvt/op-opal-ci-bvt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-opal-ci-bvt.xml $                        -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+<bvts>
+
+<bvt>
+    <id>op-opal-ci</id>
+    <title>OP OPAL CI BVT</title>
+    <bvt-xml>op-opal-ci.xml</bvt-xml>
+    <coverage/>
+</bvt>
+
+</bvts>

--- a/bvt/op-opal-ci.xml
+++ b/bvt/op-opal-ci.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-auto-test/bvt/op-opal-ci.xml $                            -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+
+
+<integrationtest>
+    <platform>
+
+      <xi:include href="op-ci-setup.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.validate_pflash_tool()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_sdr_clear()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.pnor_img_transfer()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.pnor_img_flash()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.validate_lpar()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.ipl_wait_for_working_state()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_sel_check()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -31,6 +31,17 @@
 
 .. moduleauthor:: Jay Azurin <jmazurin@us.ibm.com>
 
+PNOR image flash steps.
+1. check for pflash tool availablity in /tmp directory
+2. Do a system ipmi power off
+3. Clear SEL logs
+4. Transfer PNOR image to BMC busy box(/tmp dir).
+5. Flash the pnor image using pflash tool.
+6. Bring the system up.
+7. Check for any error logs in SEL.
+Run some tests after flash.
+
+Note: Assumption is pflash tool available in /tmp directory.
 
 """
 import sys
@@ -43,6 +54,7 @@ sys.path.append(full_path)
 
 import ConfigParser
 from common.OpTestSystem import OpTestSystem
+from common.OpTestConstants import OpTestConstants as BMC_CONST
 
 
 def _config_read():
@@ -98,6 +110,15 @@ def bmc_reboot():
     return 0
 
 
+def validate_pflash_tool():
+    """This function validates presence of pflash tool, which will be
+    used for pnor image flash.
+
+    :return int -- 0: success, OpTestError: error
+    """
+    return opTestSys.cv_BMC.validate_pflash_tool(BMC_CONST.PFLASH_TOOL_DIR)
+
+
 def pnor_img_transfer():
     """This function copies the PNOR image to the BMC /tmp dir.
 
@@ -108,11 +129,14 @@ def pnor_img_transfer():
 
 
 def pnor_img_flash():
-    """This function flashes the PNOR image.
+    """This function flashes the PNOR image using pflash tool,
+    And this function will work based on the assumption that pflash
+    tool available in '/tmp/'.(user need to mount pflash tool in /tmp dir,
+    as pflash tool removed from BMC)
 
     :returns: int -- the pflash command return code
     """
-    return opTestSys.cv_BMC.pnor_img_flash(testCfg['imagename'])
+    return opTestSys.cv_BMC.pnor_img_flash(BMC_CONST.PFLASH_TOOL_DIR, testCfg['imagename'])
 
 
 def ipmi_sdr_clear():

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -250,7 +250,9 @@ class OpTestConstants():
     PBA_FAULT_ISOLATION_REGISTER = "0x02010840"
     PBA_FAULT_ISOLATION_MASK_REGISTER = "0x02010843"
 
+    # Tools, repository and utility paths
     CLONE_SKIBOOT_DIR = "/tmp/skiboot"
+    PFLASH_TOOL_DIR = "/tmp/"
 
     # IPMI commands
     IPMI_LOCK_CMD = "raw 0x32 0xf3 0x4c 0x4f 0x43 0x4b 0x00; echo $?"


### PR DESCRIPTION
This patch is for flashing pnor images on openpower hardware.
And also this is uesful for flashing both types of images (*.pnor and *_update.pnor).
Note: Assumption is pflash tool available in /tmp directory.

Steps for Host FW(pnor) image flash.
1. check for pflash tool availablity in /tmp directory
2. Do a system ipmi power off
3. Clear SEL logs
4. Transfer PNOR image to BMC busy box(/tmp dir).
5. Flash the pnor image using pflash tool.
6. Bring the system up.
7. Check for any error logs in SEL.

Verified this by testing it on firestone hardware with firestone.pnor and firestone_update.pnor.

Firestone.pnor--------->It will update both side of PNOR Flash storage(Both primary and golden side).
Firestone_update.pnor-->It will update only primary side of PNOR Flash storage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/40)
<!-- Reviewable:end -->
