### PR TITLE
Add New Tests for testing system boot sequence.

### DIFF
--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -165,5 +165,19 @@
             </testcase>
         </test>
 
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_mc_cold_reset_boot_sequence()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_mc_warm_reset_boot_sequence()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
     </platform>
 </integrationtest>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -58,6 +58,7 @@ from testcases.OpTestPrdDriver import OpTestPrdDriver
 from testcases.OpTestIPMILockMode import OpTestIPMILockMode
 from testcases.OpTestIPMIPowerControl import OpTestIPMIPowerControl
 from testcases.OpTestOOBIPMI import OpTestOOBIPMI
+from testcases.OpTestSystemBootSequence import OpTestSystemBootSequence
 
 
 def _config_read():
@@ -170,6 +171,13 @@ opTestOOBIPMI = OpTestOOBIPMI(bmcCfg['ip'], bmcCfg['username'],
                                         bmcCfg['passwordipmi'],
                                         testCfg['ffdcdir'], hostCfg['hostip'],
                                         hostCfg['hostuser'], hostCfg['hostpasswd'])
+
+opTestSystemBootSequence = OpTestSystemBootSequence(bmcCfg['ip'], bmcCfg['username'],
+                                                    bmcCfg['password'],
+                                                    bmcCfg['usernameipmi'],
+                                                    bmcCfg['passwordipmi'],
+                                                    testCfg['ffdcdir'], hostCfg['hostip'],
+                                                    hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 
 def test_init():
@@ -319,3 +327,17 @@ def test_oob_ipmi():
         returns: int 0-success, raises exception-error
     """
     return opTestOOBIPMI.test_oob_ipmi()
+
+
+def test_mc_cold_reset_boot_sequence():
+    """This function tests MC Cold reset boot sequence
+        returns: int 0-success, raises exception-error
+    """
+    return opTestSystemBootSequence.testMcColdResetBootSequence()
+
+
+def test_mc_warm_reset_boot_sequence():
+    """This function tests MC Warm reset boot sequence
+        returns: int 0-success, raises exception-error
+    """
+    return opTestSystemBootSequence.testMcWarmResetBootSequence()

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -107,3 +107,11 @@ def test_ipmi_power_control():
 
 def test_oob_ipmi():
     assert op_opal_fvt.test_oob_ipmi() == 0
+
+
+def test_mc_cold_reset_boot_sequence():
+    assert op_opal_fvt.test_mc_cold_reset_boot_sequence() == 0
+
+
+def test_mc_warm_reset_boot_sequence():
+    assert op_opal_fvt.test_mc_warm_reset_boot_sequence() == 0

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -82,6 +82,7 @@ class OpTestConstants():
     SUDO_COMMAND = 'sudo '
     CLEAR_GARD_CMD = '/gard clear all'
     LIST_GARD_CMD = '/gard list'
+    OPAL_MSG_LOG = "cat /sys/firmware/opal/msglog"
 
     # Command to boot into PRIMARY and GOLDEN SIDE
     BMC_BOOT_PRIMARY = "/etc/init.d/boot_into_primary"

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -61,13 +61,16 @@ class OpTestHost():
     # @param i_hostuser @type string: Userid to log into the host
     # @param i_hostpasswd @type string: Password of the userid to log into the host
     # @param i_bmcip @type string: IP Address of the bmc
+    # @param i_ffdcDir @type string:specifies the directory under which to save all FFDC data
     #
-    def __init__(self, i_hostip, i_hostuser, i_hostpasswd, i_bmcip):
+    def __init__(self, i_hostip, i_hostuser, i_hostpasswd, i_bmcip, i_ffdcDir=None):
         self.ip = i_hostip
         self.user = i_hostuser
         self.passwd = i_hostpasswd
         self.util = OpTestUtil()
         self.bmcip = i_bmcip
+        self.cv_ffdcDir = i_ffdcDir
+
 
     ##
     #   @brief This method executes the command(i_cmd) on the host using a ssh session
@@ -313,6 +316,25 @@ class OpTestHost():
             raise OpTestError(l_msg)
         print l_res
         return l_res
+
+    # @brief It will gather OPAL Message logs and store the copy in a logfile
+    #        which will be stored in FFDC dir.
+    #
+    # @return BMC_CONST.FW_SUCCESS  or raise OpTestError
+    #
+    def host_gather_opal_msg_log(self):
+        try:
+            l_data = self.host_run_command(BMC_CONST.OPAL_MSG_LOG)
+        except OpTestError:
+            l_msg = "Failed to gather OPAL message logs"
+            raise OpTestError(l_msg)
+
+        l_res = commands.getstatusoutput("date +%Y%m%d_%H%M")
+        l_logFile = "Opal_msglog_%s.log" % l_res[1]
+        fn = self.cv_ffdcDir + "/" + l_logFile
+        with open(fn, 'w') as f:
+            f.write(l_data)
+        return BMC_CONST.FW_SUCCESS
 
     ##
     # @brief It will check existence of given linux command(i_cmd) on host

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -739,6 +739,23 @@ class OpTestIPMI():
 
 
     ##
+    # @brief Sets auto-reboot policy with given policy(i_policy)
+    #
+    # @param i_policy @type string: type of policy to be set(chassis policy <i_policy>)
+    #                               always-off
+    #                               always-on
+    #                               previous
+    #
+    # @return BMC_CONST.FW_SUCCESS or else raise OpTestError if failed
+    #
+    def ipmi_set_power_policy(self, i_policy):
+        print "IPMI: Setting the power policy to %s" % i_policy
+        l_cmd = "chassis policy %s" % i_policy
+        l_res = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
+        print l_res
+
+
+    ##
     # @brief Clears the SSH keys from the known host file
     #
     # @param i_hostname @type string: name of the host to be removed from known host file

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -270,6 +270,27 @@ class OpTestSystem():
         return BMC_CONST.FW_SUCCESS
 
 
+    ##
+    # @brief This function will check for system status and wait for
+    #        FW and Host OS Boot progress to complete.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def sys_check_host_status(self):
+        if int(self.sys_ipl_wait_for_working_state()) == BMC_CONST.FW_SUCCESS:
+            print "System booted to working state"
+        else:
+            l_msg = "System failed to boot"
+            raise OpTestError(l_msg)
+        if int(self.sys_wait_for_os_boot_complete()) == BMC_CONST.FW_SUCCESS:
+            print "System booted to Host OS"
+        else:
+            l_msg = "System failed to boot Host OS"
+            raise OpTestError(l_msg)
+
+        return BMC_CONST.FW_SUCCESS
+
+
     ###########################################################################
     # CODE-UPDATE INTERFACES
     ###########################################################################

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-auto-test/testcases/OpTestSystemBootSequence.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestSystemBootSequence.py
+#  It will test below system boot sequence operations
+#  Mc cold reset boot sequence.
+#   @ Power off state (and auto reboot policy should be off)
+#   1) Make sure BMC is pinging
+#   2) Issue Cold reset to BMC   =>   ipmitool <...> mc reset cold
+#   3) Ensure BMC stops pinging, wait until BMC fully boots
+#   4) Open network sol console =>                  ipmitool <...> sol activate
+#   5) Power on system   =>   ipmitool <...> chassis power on
+#   Make sure boots to Host OS, SOL fine
+#
+#  Mc warm reset boot sequence
+#   @ Power off state (and auto reboot policy should be off)
+#   1) Make sure BMC is pinging
+#   2) Issue warm reset to BMC   =>   ipmitool <...> mc reset warm
+#   3) Ensure BMC stops pinging, wait until BMC fully boots
+#   4) Open network sol console =>                  ipmitool <...> sol activate
+#   5) Power on system   =>   ipmitool <...> chassis power on
+#   Make sure boots to Host OS, SOL fine
+
+import time
+import subprocess
+import commands
+import re
+import sys
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestHost import OpTestHost
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestSystemBootSequence():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_hostip The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostpasswd The password of the userid to log into the HOST with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostpasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostpasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostpasswd, i_bmcIP, i_ffdcDir)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostpasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief This function will test mc cold reset boot sequence
+    #        It has below steps
+    #        1. Do a system Power OFF(Host should go down)
+    #        2. Set auto reboot policy to off(chassis policy always-off)
+    #        3. Issue a BMC Cold reset.
+    #        4. After BMC comes up, Issue a Power ON of the system
+    #        5. Check for system status and gather OPAL msg log.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testMcColdResetBootSequence(self):
+
+        print "Testing MC Cold reset boot sequence"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Setting the system power policy to always-off"
+        self.cv_IPMI.ipmi_set_power_policy("always-off")
+
+        # Perform a BMC Cold Reset Operation
+        self.cv_IPMI.ipmi_cold_reset()
+
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function will test mc warm reset boot sequence
+    #        It has below steps
+    #        1. Do a system Power OFF(Host should go down)
+    #        2. Set auto reboot policy to off(chassis policy always-off)
+    #        3. Issue a BMC Warm reset.
+    #        4. After BMC comes up, Issue a Power ON of the system
+    #        5. Check for system status and gather OPAL msg log.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testMcWarmResetBootSequence(self):
+        print "Testing MC Warm reset boot sequence"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Setting the system power policy to always-off"
+        self.cv_IPMI.ipmi_set_power_policy("always-off")
+
+        # Perform a BMC Warm Reset Operation
+        self.cv_IPMI.ipmi_warm_reset()
+
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        return BMC_CONST.FW_SUCCESS


### PR DESCRIPTION
TestMcColdResetBootSequence.
    It has below steps
        1. Do a system Power OFF(Host should go down)
        2. Set auto reboot policy to off(chassis policy always-off)
        3. Issue a BMC Cold reset.
        4. After BMC comes up, Issue a Power ON of the system
        5. Check for system status and gather OPAL msg log.

TestMcWarmResetBootSequence.
    It has below steps
        1. Do a system Power OFF(Host should go down)
        2. Set auto reboot policy to off(chassis policy always-off)
        3. Issue a BMC Warm reset.
        4. After BMC comes up, Issue a Power ON of the system
        5. Check for system status and gather OPAL msg log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/50)
<!-- Reviewable:end -->
