### PR TITLE
rename LPAR to Host

### DIFF
--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -51,7 +51,7 @@
 
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.validate_lpar()"</cmd>
+                <cmd>op-ci-bmc-run "op_ci_bmc.validate_host()"</cmd>
             </testcase>
         </test>
 

--- a/bvt/op-ci-bvt
+++ b/bvt/op-ci-bvt
@@ -39,9 +39,9 @@ passwordipmi="???"
 cfgfiledir="???"
 imagedir="???"
 imagename="???"
-lparip="???"
-lparuser="???"
-lparPasswd="???"
+hostip="???"
+hostuser="???"
+hostPasswd="???"
 hpmimage="???"
 
 bvtoutfile="/tmp/op-ci-bvt-$$.out"
@@ -50,7 +50,7 @@ fvfile="/tmp/op-ci-bvt-fv-$$.out"
 # If you have special code to set env vars to get python 2.7 active, edit and uncomment:
 #source ???
 export PATH="$PATH:."
-run-op-bvt --fverbose $fvfile --bmcip $bmcip --bmcuser $bmcuser --bmcpwd $bmcpwd --usernameipmi $usernameipmi --passwordipmi $passwordipmi --cfgfiledir $cfgfiledir --imagedir $imagedir --imagename $imagename --lparip $lparip --lparuser $lparuser --lparPasswd $lparPasswd --hpmimage $hpmimage $1 2>&1 | tee $bvtoutfile
+run-op-bvt --fverbose $fvfile --bmcip $bmcip --bmcuser $bmcuser --bmcpwd $bmcpwd --usernameipmi $usernameipmi --passwordipmi $passwordipmi --cfgfiledir $cfgfiledir --imagedir $imagedir --imagename $imagename --hostip $hostip --hostuser $hostuser --hostPasswd $hostPasswd --hpmimage $hpmimage $1 2>&1 | tee $bvtoutfile
 rc=${PIPESTATUS[0]}
 set +x
 echo "run-op-bvt finished with exit code $rc"

--- a/bvt/op-ci-setup.xml
+++ b/bvt/op-ci-setup.xml
@@ -26,7 +26,7 @@
 
 <test>
     <testcase>
-        <cmd>run-bvt-setup --bmcip %%bmcip%% --bmcuser %%bmcuser%% --bmcpwd %%bmcpwd%% --usernameipmi %%usernameipmi%% --passwordipmi %%passwordipmi%% --cfgfiledir %%cfgfiledir%% --ffdcdir %%ffdcdir%% --imagedir %%imagedir%% --imagename %%imagename%% --lparip %%lparip%% --lparuser %%lparuser%% --lparPasswd %%lparPasswd%% --hpmimage %%hpmimage%%</cmd>
+        <cmd>run-bvt-setup --bmcip %%bmcip%% --bmcuser %%bmcuser%% --bmcpwd %%bmcpwd%% --usernameipmi %%usernameipmi%% --passwordipmi %%passwordipmi%% --cfgfiledir %%cfgfiledir%% --ffdcdir %%ffdcdir%% --imagedir %%imagedir%% --imagename %%imagename%% --hostip %%hostip%% --hostuser %%hostuser%% --hostPasswd %%hostPasswd%% --hpmimage %%hpmimage%%</cmd>
         <exitonerror>yes</exitonerror>
     </testcase>
 </test>

--- a/bvt/op-firmware-component-update.xml
+++ b/bvt/op-firmware-component-update.xml
@@ -31,7 +31,7 @@
 
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_firmware_component_update.validate_lpar()"</cmd>
+                <cmd>op-ci-bmc-run "op_firmware_component_update.validate_host()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>

--- a/bvt/op-opal-ci.xml
+++ b/bvt/op-opal-ci.xml
@@ -74,7 +74,7 @@
 
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.validate_lpar()"</cmd>
+                <cmd>op-ci-bmc-run "op_ci_bmc.validate_host()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>

--- a/bvt/op-outofband-firmware-update.xml
+++ b/bvt/op-outofband-firmware-update.xml
@@ -87,7 +87,7 @@
 
         <test>
             <testcase>
-                <cmd>op-ci-bmc-run "op_outofband_firmware_update.validate_lpar()"</cmd>
+                <cmd>op-ci-bmc-run "op_outofband_firmware_update.validate_host()"</cmd>
                 <exitonerror>yes</exitonerror>
             </testcase>
         </test>

--- a/bvt/run-bvt-setup
+++ b/bvt/run-bvt-setup
@@ -43,9 +43,9 @@ my $imagedir = "";
 my $ffdcdir = "ffdc/";
 my $imagename = "habanero.pnor";
 my $cfgfiledir = ".";
-my $lparip = "";
-my $lparuser = "";
-my $lparPasswd = "";
+my $hostip = "";
+my $hostuser = "";
+my $hostPasswd = "";
 my $hpmimage = "";
 
 my $usage = "Setup an OP CI BVT test config file per the passed arguments
@@ -78,10 +78,10 @@ ffdcdir = %s
 imagedir = %s
 imagename = %s
 
-[lpar]
-lparip = %s
-lparuser = %s
-lparPasswd = %s
+[host]
+hostip = %s
+hostuser = %s
+hostPasswd = %s
 prompt = \#
 hpmimage = %s
 
@@ -109,9 +109,9 @@ GetOptions("help|?|h" => \$help,
 	   "bmcpwd=s" => \$bmcpwd,
 	   "usernameipmi=s" => \$usernameipmi,
 	   "passwordipmi=s" => \$passwordipmi,
-	   "lparip=s" => \$lparip,
-	   "lparuser=s" => \$lparuser,
-	   "lparPasswd=s" => \$lparPasswd,
+	   "hostip=s" => \$hostip,
+	   "hostuser=s" => \$hostuser,
+	   "hostPasswd=s" => \$hostPasswd,
 	   "hpmimage:s" => \$hpmimage,
 	   "ffdcdir:s" => \$ffdcdir,
 	   "cfgfiledir:s" => \$cfgfiledir,
@@ -138,9 +138,9 @@ printf OUTF $cfgfile_fmt,
         $ffdcdir,
         $imagedir,
         $imagename,
-        $lparip,
-        $lparuser,
-        $lparPasswd,
+        $hostip,
+        $hostuser,
+        $hostPasswd,
         $hpmimage;
 close(OUTF);
 if ($verbose)

--- a/ci/source/op_bmc_web_update.py
+++ b/ci/source/op_bmc_web_update.py
@@ -49,20 +49,20 @@ def _config_read():
     bmcConfig = ConfigParser.RawConfigParser()
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')),dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')),dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 opTestSys = OpTestSystem(bmcCfg['ip'],bmcCfg['username'],
                          bmcCfg['password'],
                          bmcCfg['usernameipmi'],
                          bmcCfg['passwordipmi'],
                          testCfg['ffdcdir'],
-                         lparCfg['lparip'],
-                         lparCfg['lparuser'],
-                         lparCfg['lparpasswd'])
+                         hostCfg['hostip'],
+                         hostCfg['hostuser'],
+                         hostCfg['hostpasswd'])
 
 
 def test_init():
@@ -88,18 +88,18 @@ def bmc_web_pnor_update_hpm():
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_web_pnor_update_hpm(lparCfg['hpmimage'])
+    return opTestSys.sys_bmc_web_pnor_update_hpm(hostCfg['hpmimage'])
 
 def bmc_web_bmc_update_hpm():
     """This function does a update of BMC using the image provided by the user.
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_web_bmc_update_hpm(lparCfg['hpmimage'])
+    return opTestSys.sys_bmc_web_bmc_update_hpm(hostCfg['hpmimage'])
 
 def bmc_web_bmcandpnor_update_hpm():
     """This function does a complete update of BMC and PNOR using the image provided by the user.
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_web_bmcandpnor_update_hpm(lparCfg['hpmimage'])
+    return opTestSys.sys_bmc_web_bmcandpnor_update_hpm(hostCfg['hpmimage'])

--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -62,20 +62,20 @@ def _config_read():
     bmcConfig = ConfigParser.RawConfigParser()
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')),dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')),dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 opTestSys = OpTestSystem(bmcCfg['ip'],bmcCfg['username'],
                          bmcCfg['password'],
                          bmcCfg['usernameipmi'],
                          bmcCfg['passwordipmi'],
                          testCfg['ffdcdir'],
-                         lparCfg['lparip'],
-                         lparCfg['lparuser'],
-                         lparCfg['lparpasswd'])
+                         hostCfg['hostip'],
+                         hostCfg['hostuser'],
+                         hostCfg['hostpasswd'])
 
 
 def test_init():
@@ -215,12 +215,12 @@ def ipmi_sel_check():
     selDesc = 'Transition to Non-recoverable'
     return opTestSys.sys_sel_check(selDesc)
 
-def validate_lpar():
+def validate_host():
     """This function validate that the OS/partition can be pinged.
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_power_on_validate_lpar()
+    return opTestSys.sys_bmc_power_on_validate_host()
 
 
 def outofband_fwandpnor_update_hpm():
@@ -228,4 +228,4 @@ def outofband_fwandpnor_update_hpm():
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_outofband_fwandpnor_update_hpm(lparCfg['hpmimage'])
+    return opTestSys.sys_bmc_outofband_fwandpnor_update_hpm(hostCfg['hpmimage'])

--- a/ci/source/op_firmware_component_update.py
+++ b/ci/source/op_firmware_component_update.py
@@ -41,7 +41,7 @@ sys.path.append(full_path)
 
 import ConfigParser
 from common.OpTestSystem import OpTestSystem
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 
 def _config_read():
@@ -49,25 +49,25 @@ def _config_read():
     bmcConfig = ConfigParser.RawConfigParser()
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 opTestSys = OpTestSystem(bmcCfg['ip'],bmcCfg['username'],
                          bmcCfg['password'],
                          bmcCfg['usernameipmi'],
                          bmcCfg['passwordipmi'],
                          testCfg['ffdcdir'],
-                         lparCfg['lparip'],lparCfg['lparuser'],lparCfg['lparpasswd'])
+                         hostCfg['hostip'],hostCfg['hostuser'],hostCfg['hostpasswd'])
 
 
-def validate_lpar():
+def validate_host():
     """This function Validates the partition and waits for partition to connect
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.sys_bmc_validate_lpar()
+    opTestSys.sys_bmc_validate_host()
 
     return 0
 
@@ -75,7 +75,7 @@ def outofband_fw_update_hpm():
     """This function Update the BMC fw image using hpm file
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.sys_bmc_outofband_fw_update_hpm(lparCfg['hpmimage'])
+    opTestSys.sys_bmc_outofband_fw_update_hpm(hostCfg['hpmimage'])
 
     return 0
 
@@ -83,23 +83,23 @@ def outofband_pnor_update_hpm():
     """This function Update the BMC pnor image using hpm file
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.sys_bmc_outofband_pnor_update_hpm(lparCfg['hpmimage'])
+    opTestSys.sys_bmc_outofband_pnor_update_hpm(hostCfg['hpmimage'])
 
     return 0
 
 def inband_fw_update_hpm():
-    """This function Update the BMC fw using hpm file using LPAR
+    """This function Update the BMC fw using hpm file using HOST
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.sys_bmc_inband_fw_update_hpm(lparCfg['hpmimage'])
+    opTestSys.sys_bmc_inband_fw_update_hpm(hostCfg['hpmimage'])
 
     return 0
 
 def inband_pnor_update_hpm():
-    """This function Update the BMC pnor using hpm file using LPAR
+    """This function Update the BMC pnor using hpm file using HOST
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.sys_bmc_inband_pnor_update_hpm(lparCfg['hpmimage'])
+    opTestSys.sys_bmc_inband_pnor_update_hpm(hostCfg['hpmimage'])
 
     return 0
 

--- a/ci/source/op_inbound_hpm.py
+++ b/ci/source/op_inbound_hpm.py
@@ -26,7 +26,7 @@
 """
 .. module:: op_inbound_hpm
     :platform: Unix
-    :synopsis: This module contains the test functions for enabling LPAR communication in OpenPower systems.
+    :synopsis: This module contains the test functions for enabling HOST communication in OpenPower systems.
 
 .. moduleauthor:: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>
 
@@ -41,7 +41,7 @@ sys.path.append(full_path)
 
 import ConfigParser
 from common.OpTestSystem import OpTestSystem
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 
 def _config_read():
@@ -49,20 +49,20 @@ def _config_read():
     bmcConfig = ConfigParser.RawConfigParser()
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 
-opTestLp = OpTestLpar(lparCfg['lparip'],lparCfg['lparuser'],lparCfg['lparpasswd'],bmcCfg['ip'])
+opTestLp = OpTestHost(hostCfg['hostip'],hostCfg['hostuser'],hostCfg['hostpasswd'],bmcCfg['ip'])
 
 def get_OS_Level():
     """This function gets the OS level installed on the machine
     :returns: int -- 0: success, 1: error
     """
-    opTestLp.lpar_get_OS_Level()
+    opTestLp.host_get_OS_Level()
 
     return 0
 
@@ -70,13 +70,13 @@ def protect_network_setting():
     """This function Executes a command on the os of the bmc to protect network setting
     :returns: int -- 0: success, 1: error
     """
-    return opTestLp.lpar_protect_network_setting()
+    return opTestLp.host_protect_network_setting()
 
 def cold_reset():
-    """This function Performs a cold reset onto the lpar
+    """This function Performs a cold reset onto the host
     :returns: int -- 0: success, 1: error
     """
-    opTestLp.lpar_cold_reset()
+    opTestLp.host_cold_reset()
 
     return 0
 
@@ -84,7 +84,7 @@ def code_update():
     """This function Flashes component 1 Firmware image of hpm file using ipmitool
     :returns: int -- 0: success, 1: error
     """
-    opTestLp.lpar_code_update(lparCfg['hpmimage'],str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
+    opTestLp.host_code_update(hostCfg['hpmimage'],str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
 
     return 0
 

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -65,18 +65,18 @@ def _config_read():
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     print configFile
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 opTestSensors = OpTestSensors(bmcCfg['ip'], bmcCfg['username'],
                               bmcCfg['password'],
                               bmcCfg['usernameipmi'],
                               bmcCfg['passwordipmi'],
-                              testCfg['ffdcdir'], lparCfg['lparip'],
-                              lparCfg['lparuser'], lparCfg['lparpasswd'])
+                              testCfg['ffdcdir'], hostCfg['hostip'],
+                              hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestSwitchEndianSyscall = OpTestSwitchEndianSyscall(bmcCfg['ip'],
                                                       bmcCfg['username'],
@@ -84,9 +84,9 @@ opTestSwitchEndianSyscall = OpTestSwitchEndianSyscall(bmcCfg['ip'],
                                                       bmcCfg['usernameipmi'],
                                                       bmcCfg['passwordipmi'],
                                                       testCfg['ffdcdir'],
-                                                      lparCfg['lparip'],
-                                                      lparCfg['lparuser'],
-                                                      lparCfg['lparpasswd'])
+                                                      hostCfg['hostip'],
+                                                      hostCfg['hostuser'],
+                                                      hostCfg['hostpasswd'])
 
 opTestRTCdriver = OpTestRTCdriver(bmcCfg['ip'],
                                   bmcCfg['username'],
@@ -94,73 +94,73 @@ opTestRTCdriver = OpTestRTCdriver(bmcCfg['ip'],
                                   bmcCfg['usernameipmi'],
                                   bmcCfg['passwordipmi'],
                                   testCfg['ffdcdir'],
-                                  lparCfg['lparip'],
-                                  lparCfg['lparuser'],
-                                  lparCfg['lparpasswd'])
+                                  hostCfg['hostip'],
+                                  hostCfg['hostuser'],
+                                  hostCfg['hostpasswd'])
 
 opTestAt24driver = OpTestAt24driver(bmcCfg['ip'], bmcCfg['username'],
                                     bmcCfg['password'],
                                     bmcCfg['usernameipmi'],
                                     bmcCfg['passwordipmi'],
-                                    testCfg['ffdcdir'], lparCfg['lparip'],
-                                    lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                    testCfg['ffdcdir'], hostCfg['hostip'],
+                                    hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestI2Cdriver = OpTestI2Cdriver(bmcCfg['ip'], bmcCfg['username'],
                                   bmcCfg['password'],
                                   bmcCfg['usernameipmi'],
                                   bmcCfg['passwordipmi'],
-                                  testCfg['ffdcdir'], lparCfg['lparip'],
-                                  lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                  testCfg['ffdcdir'], hostCfg['hostip'],
+                                  hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestHeartbeat = OpTestHeartbeat(bmcCfg['ip'], bmcCfg['username'],
                               bmcCfg['password'],
                               bmcCfg['usernameipmi'],
                               bmcCfg['passwordipmi'],
-                              testCfg['ffdcdir'], lparCfg['lparip'],
-                              lparCfg['lparuser'], lparCfg['lparpasswd'])
+                              testCfg['ffdcdir'], hostCfg['hostip'],
+                              hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestMtdPnorDriver = OpTestMtdPnorDriver(bmcCfg['ip'], bmcCfg['username'],
                                           bmcCfg['password'],
                                           bmcCfg['usernameipmi'],
                                           bmcCfg['passwordipmi'],
-                                          testCfg['ffdcdir'], lparCfg['lparip'],
-                                          lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                          testCfg['ffdcdir'], hostCfg['hostip'],
+                                          hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestInbandIPMI = OpTestInbandIPMI(bmcCfg['ip'], bmcCfg['username'],
                               bmcCfg['password'],
                               bmcCfg['usernameipmi'],
                               bmcCfg['passwordipmi'],
-                              testCfg['ffdcdir'], lparCfg['lparip'],
-                              lparCfg['lparuser'], lparCfg['lparpasswd'])
+                              testCfg['ffdcdir'], hostCfg['hostip'],
+                              hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestHMIHandling = OpTestHMIHandling(bmcCfg['ip'], bmcCfg['username'],
                                           bmcCfg['password'],
                                           bmcCfg['usernameipmi'],
                                           bmcCfg['passwordipmi'],
-                                          testCfg['ffdcdir'], lparCfg['lparip'],
-                                          lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                          testCfg['ffdcdir'], hostCfg['hostip'],
+                                          hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestPrdDriver = OpTestPrdDriver(bmcCfg['ip'], bmcCfg['username'],
                                   bmcCfg['password'],
                                   bmcCfg['usernameipmi'],
                                   bmcCfg['passwordipmi'],
-                                  testCfg['ffdcdir'], lparCfg['lparip'],
-                                  lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                  testCfg['ffdcdir'], hostCfg['hostip'],
+                                  hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestIPMILockMode = OpTestIPMILockMode(bmcCfg['ip'], bmcCfg['username'],
                                         bmcCfg['password'],
                                         bmcCfg['usernameipmi'],
                                         bmcCfg['passwordipmi'],
-                                        testCfg['ffdcdir'], lparCfg['lparip'],
-                                        lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                        testCfg['ffdcdir'], hostCfg['hostip'],
+                                        hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 
 opTestIPMIPowerControl = OpTestIPMIPowerControl(bmcCfg['ip'], bmcCfg['username'],
                                         bmcCfg['password'],
                                         bmcCfg['usernameipmi'],
                                         bmcCfg['passwordipmi'],
-                                        testCfg['ffdcdir'], lparCfg['lparip'],
-                                        lparCfg['lparuser'], lparCfg['lparpasswd'])
+                                        testCfg['ffdcdir'], hostCfg['hostip'],
+                                        hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 
 def test_init():

--- a/ci/source/op_outofband_firmware_update.py
+++ b/ci/source/op_outofband_firmware_update.py
@@ -57,7 +57,7 @@ sys.path.append(full_path)
 
 import ConfigParser
 from common.OpTestSystem import OpTestSystem
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 
@@ -66,20 +66,20 @@ def _config_read():
     bmcConfig = ConfigParser.RawConfigParser()
     configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
     bmcConfig.read(configFile)
-    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('lpar'))
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
 
 ''' Read the configuration settings into global space so they can be used by
     other functions '''
 
-bmcCfg, testCfg, lparCfg = _config_read()
+bmcCfg, testCfg, hostCfg = _config_read()
 opTestSys = OpTestSystem(bmcCfg['ip'],bmcCfg['username'],
                          bmcCfg['password'],
                          bmcCfg['usernameipmi'],
                          bmcCfg['passwordipmi'],
                          testCfg['ffdcdir'],
-                         lparCfg['lparip'],
-                         lparCfg['lparuser'],
-                         lparCfg['lparpasswd'])
+                         hostCfg['hostip'],
+                         hostCfg['hostuser'],
+                         hostCfg['hostpasswd'])
 
 def test_init():
     """This function validates the test config before running other functions
@@ -91,7 +91,7 @@ def test_init():
         os.makedirs(os.path.dirname(ffdcDir))
 
     ''' make sure hpm image exists '''
-    hpmimage = lparCfg['hpmimage']
+    hpmimage = hostCfg['hpmimage']
     if not os.path.exists(hpmimage):
         print "FW HPM image %s does not exist!. Check config file." % hpmimage
         return 1
@@ -133,7 +133,7 @@ def ipmi_power_off():
     return opTestSys.sys_power_off()
 
 def cold_reset():
-    """This function Performs a cold reset onto the lpar
+    """This function Performs a cold reset onto the host
     :returns: int -- 0: success, 1: error
     """
     return opTestSys.cv_IPMI.ipmi_cold_reset()
@@ -150,16 +150,16 @@ def code_update():
     """This function Flashes component 1 Firmware image of hpm file using ipmitool
     :returns: int -- 0: success, 1: error
     """
-    opTestSys.cv_IPMI.ipmi_code_update(lparCfg['hpmimage'],str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
+    opTestSys.cv_IPMI.ipmi_code_update(hostCfg['hpmimage'],str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
 
     return 0
 
-def validate_lpar():
+def validate_host():
     """This function validate that the OS/partition can be pinged.
 
     :returns: int -- 0: success, 1: error
     """
-    return opTestSys.sys_bmc_power_on_validate_lpar()
+    return opTestSys.sys_bmc_power_on_validate_host()
 
 def ipl_wait_for_working_state(timeout=10):
     """This function starts the sol capture and waits for the IPL to end. The

--- a/ci/source/test_op_ci.py
+++ b/ci/source/test_op_ci.py
@@ -66,8 +66,8 @@ def test_wait_for_working_state():
 def test_ipmi_sel_check():
     assert op_ci_bmc.ipmi_sel_check() == 0
 
-def test_validate_lpar():
-    assert op_ci_bmc.validate_lpar() == 0
+def test_validate_host():
+    assert op_ci_bmc.validate_host() == 0
 
 def test_outofband_fwandpnor_update_hpm():
     assert op_ci_bmc.outofband_fwandpnor_update_hpm() == 0

--- a/ci/source/test_op_firmware_component_update.py
+++ b/ci/source/test_op_firmware_component_update.py
@@ -28,8 +28,8 @@ import os
 import sys
 import op_firmware_component_update
 
-def test_validate_lpar():
-    assert op_firmware_component_update.validate_lpar() == 0
+def test_validate_host():
+    assert op_firmware_component_update.validate_host() == 0
 
 def test_outofband_fw_update_hpm():
     assert op_firmware_component_update.outofband_fw_update_hpm() == 0

--- a/ci/source/test_op_outofband_firmware_update.py
+++ b/ci/source/test_op_outofband_firmware_update.py
@@ -52,8 +52,8 @@ def test_preserve_network_setting():
 def test_code_update():
     assert op_outofband_firmware_update.code_update() == 0
 
-def test_validate_lpar():
-    assert op_outofband_firmware_update.validate_lpar() == 0
+def test_validate_host():
+    assert op_outofband_firmware_update.validate_host() == 0
 
 def test_ipl_wait_for_working_state():
     assert op_outofband_firmware_update.ipl_wait_for_working_state() == 0

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestLpar.py $
+# $Source: op-auto-test/common/OpTestHost.py $
 #
 # OpenPOWER Automated Test Project
 #
@@ -24,10 +24,10 @@
 #
 # IBM_PROLOG_END_TAG
 
-## @package OpTestLpar
-#  Lpar package which contains all functions related to LPAR communication
+## @package OpTestHost
+#  Host package which contains all functions related to HOST communication
 #
-#  This class encapsulates all function which deals with the Lpar
+#  This class encapsulates all function which deals with the Host
 #  in OpenPower systems
 
 import sys
@@ -52,20 +52,20 @@ from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
 from OpTestUtil import OpTestUtil
 
-class OpTestLpar():
+class OpTestHost():
 
     ##
     # @brief Initialize this object
     #
-    # @param i_lparip @type string: IP Address of the lpar
-    # @param i_lparuser @type string: Userid to log into the lpar
-    # @param i_lparpasswd @type string: Password of the userid to log into the lpar
+    # @param i_hostip @type string: IP Address of the host
+    # @param i_hostuser @type string: Userid to log into the host
+    # @param i_hostpasswd @type string: Password of the userid to log into the host
     # @param i_bmcip @type string: IP Address of the bmc
     #
-    def __init__(self, i_lparip, i_lparuser, i_lparpasswd, i_bmcip):
-        self.ip = i_lparip
-        self.user = i_lparuser
-        self.passwd = i_lparpasswd
+    def __init__(self, i_hostip, i_hostuser, i_hostpasswd, i_bmcip):
+        self.ip = i_hostip
+        self.user = i_hostuser
+        self.passwd = i_hostpasswd
         self.util = OpTestUtil()
         self.bmcip = i_bmcip
 
@@ -211,7 +211,7 @@ class OpTestLpar():
     # @return l_oslevel @type string: OS level of the partition provided
     #         or raise OpTestError
     #
-    def lpar_get_OS_Level(self):
+    def host_get_OS_Level(self):
 
         l_oslevel = self._ssh_execute(BMC_CONST.BMC_GET_OS_RELEASE)
         print l_oslevel
@@ -223,7 +223,7 @@ class OpTestLpar():
     #
     # @return OpTestError if failed
     #
-    def lpar_protect_network_setting(self):
+    def host_protect_network_setting(self):
         try:
             l_rc = self._ssh_execute(BMC_CONST.OS_PRESERVE_NETWORK)
         except:
@@ -232,14 +232,14 @@ class OpTestLpar():
             raise OpTestError(l_errmsg)
 
     ##
-    # @brief Performs a cold reset onto the lpar
+    # @brief Performs a cold reset onto the host
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_cold_reset(self):
+    def host_cold_reset(self):
 
         print ("Applying Cold reset on partition.")
-        l_rc = self._ssh_execute(BMC_CONST.LPAR_COLD_RESET)
+        l_rc = self._ssh_execute(BMC_CONST.HOST_COLD_RESET)
 
         # TODO: enable once defect SW331585 is fixed
         '''if BMC_CONST.BMC_PASS_COLD_RESET in l_rc:
@@ -264,18 +264,18 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_code_update(self, i_image, imagecomponent):
+    def host_code_update(self, i_image, imagecomponent):
 
         # Copy the hpm file to the tmp folder in the partition
         try:
             self.util.copyFilesToDest(i_image, self.user,
                                              self.ip, "/tmp/", self.passwd)
         except:
-            l_msg = "Copying hpm file to lpar failed"
+            l_msg = "Copying hpm file to host failed"
             print l_msg
             raise OpTestError(l_msg)
 
-        #self.lpar_protect_network_setting() #writing to partition is not stable
+        #self.host_protect_network_setting() #writing to partition is not stable
         l_cmd = "\necho y | ipmitool -I usb " + BMC_CONST.BMC_HPM_UPDATE + "/tmp/" \
                 + i_image.rsplit("/", 1)[-1] + " " + imagecomponent
         print l_cmd
@@ -296,18 +296,18 @@ class OpTestLpar():
             raise OpTestError(l_msg)
 
     ##
-    # @brief It will run linux command(i_cmd) on lpar using private interface _ssh_execute()
+    # @brief It will run linux command(i_cmd) on host using private interface _ssh_execute()
     #        making this interface is public
     #
     # @param i_cmd @type string: linux command
     #
     # @return command output if command execution is successful else raises OpTestError
     #
-    def lpar_run_command(self, i_cmd):
+    def host_run_command(self, i_cmd):
         try:
             l_res = self._ssh_execute(i_cmd)
         except:
-            l_msg = "Command execution on lpar failed"
+            l_msg = "Command execution on host failed"
             print l_msg
             print sys.exc_info()
             raise OpTestError(l_msg)
@@ -315,39 +315,39 @@ class OpTestLpar():
         return l_res
 
     ##
-    # @brief It will check existence of given linux command(i_cmd) on lpar
+    # @brief It will check existence of given linux command(i_cmd) on host
     #
     # @param i_cmd @type string: linux command
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_check_command(self, i_cmd):
+    def host_check_command(self, i_cmd):
         l_cmd = 'which ' + i_cmd + '; echo $?'
         print l_cmd
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_res = l_res.splitlines()
 
         if (int(l_res[-1]) == 0):
             return BMC_CONST.FW_SUCCESS
         else:
-            l_msg = "%s command is not present on lpar" % i_cmd
+            l_msg = "%s command is not present on host" % i_cmd
             print l_msg
             raise OpTestError(l_msg)
 
     ##
-    # @brief It will get the linux kernel version on lpar
+    # @brief It will get the linux kernel version on host
     #
     # @return l_kernel @type string: kernel version of the partition provided
     #         or raise OpTestError
     #
-    def lpar_get_kernel_version(self):
+    def host_get_kernel_version(self):
         l_kernel = self._ssh_execute("uname -a | awk {'print $3'}")
         l_kernel = l_kernel.replace("\r\n", "")
         print l_kernel
         return l_kernel
 
     ##
-    # @brief This function will checks first for config file for a given kernel version on lpar,
+    # @brief This function will checks first for config file for a given kernel version on host,
     #        if available then check for config option value and return that value
     #            whether it is y or m...etc.
     #        sample config option values:
@@ -361,17 +361,17 @@ class OpTestLpar():
     #                               Ex:CONFIG_SENSORS_IBMPOWERNV
     #
     # @return l_val @type string: It will return config option value y or m,
-    #                             or raise OpTestError if config file is not available on lpar
+    #                             or raise OpTestError if config file is not available on host
     #                             or raise OpTestError if config option is not set in file.
     #
-    def lpar_check_config(self, i_kernel, i_config):
+    def host_check_config(self, i_kernel, i_config):
         l_file = "/boot/config-%s" % i_kernel
         l_res = self._ssh_execute("test -e %s; echo $?" % l_file)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Config file is available"
         else:
-            l_msg = "Config file %s is not available on lpar" % l_file
+            l_msg = "Config file %s is not available on host" % l_file
             print l_msg
             raise OpTestError(l_msg)
         l_cmd = "cat %s | grep -i --color=never %s" % (l_file, i_config)
@@ -388,14 +388,14 @@ class OpTestLpar():
         return l_val
 
     ##
-    # @brief It will return installed package name for given linux command(i_cmd) on lpar
+    # @brief It will return installed package name for given linux command(i_cmd) on host
     #
     # @param i_cmd @type string: linux command
     # @param i_oslevel @type string: OS level
     #
-    # @return l_pkg @type string: installed package on lpar
+    # @return l_pkg @type string: installed package on host
     #
-    def lpar_check_pkg_for_utility(self, i_oslevel, i_cmd):
+    def host_check_pkg_for_utility(self, i_oslevel, i_cmd):
         if 'Ubuntu' in i_oslevel:
             l_res = self._ssh_execute("dpkg -S `which %s`" % i_cmd)
             return l_res
@@ -414,7 +414,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_load_ibmpowernv(self, i_oslevel):
+    def host_load_ibmpowernv(self, i_oslevel):
         if "PowerKVM" not in i_oslevel:
             l_rc = self._ssh_execute("modprobe ibmpowernv; echo $?")
             l_rc = l_rc.replace("\r\n", "")
@@ -437,7 +437,7 @@ class OpTestLpar():
             return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief This function restarts the lm_sensors service on lpar using systemctl utility
+    # @brief This function restarts the lm_sensors service on host using systemctl utility
     #        systemctl utility is not present in ubuntu, This function will work in remaining all
     #        other OS'es i.e redhat, sles and PowerKVM
     #
@@ -445,18 +445,18 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_start_lm_sensor_svc(self, i_oslevel):
+    def host_start_lm_sensor_svc(self, i_oslevel):
         if 'Ubuntu' in i_oslevel:
             pass
         else:
             try:
                 # Start the lm_sensors service
                 cmd = "/bin/systemctl stop  lm_sensors.service"
-                self.lpar_run_command(cmd)
+                self.host_run_command(cmd)
                 cmd = "/bin/systemctl start  lm_sensors.service"
-                self.lpar_run_command(cmd)
+                self.host_run_command(cmd)
                 cmd = "/bin/systemctl status  lm_sensors.service"
-                res = self.lpar_run_command(cmd)
+                res = self.host_run_command(cmd)
                 return BMC_CONST.FW_SUCCESS
             except:
                 l_msg = "loading lm_sensors service failed"
@@ -470,7 +470,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_clone_linux_source(self, i_dir):
+    def host_clone_linux_source(self, i_dir):
         l_msg = 'git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
         l_cmd = "git clone %s %s" % (l_msg, i_dir)
         self._ssh_execute("rm -rf %s" % i_dir)
@@ -490,7 +490,7 @@ class OpTestLpar():
     #
     # @return @type string: Chip and Core information
     #        else raise OpTestError
-    def lpar_read_msglog_core(self):
+    def host_read_msglog_core(self):
         try:
             return self._ssh_execute(BMC_CONST.OS_READ_MSGLOG_CORE)
         except:
@@ -511,7 +511,7 @@ class OpTestLpar():
     #
     # @return @type string: getscom data
     #        else raise OpTestError
-    def lpar_read_getscom_data(self, i_xscom_dir):
+    def host_read_getscom_data(self, i_xscom_dir):
         try:
             l_rc = self._ssh_execute(BMC_CONST.SUDO_COMMAND + i_xscom_dir + BMC_CONST.OS_GETSCOM_LIST)
         except OpTestError as e:
@@ -535,7 +535,7 @@ class OpTestLpar():
     #
     # @return output generated after executing putscom command or else raise OpTestError
     #
-    def lpar_putscom(self, i_xscom_dir, i_error):
+    def host_putscom(self, i_xscom_dir, i_error):
 
         print('Injecting Error.')
         l_rc = self._execute_no_return(BMC_CONST.SUDO_COMMAND + i_xscom_dir + BMC_CONST.OS_PUTSCOM_ERROR + i_error)
@@ -547,7 +547,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or else raise OpTestError
     #
-    def lpar_clear_gard_records(self, i_gard_dir):
+    def host_clear_gard_records(self, i_gard_dir):
 
         l_rc = self._ssh_execute(BMC_CONST.SUDO_COMMAND + i_gard_dir + BMC_CONST.CLEAR_GARD_CMD)
 
@@ -557,7 +557,7 @@ class OpTestLpar():
             raise OpTestError(l_msg)
 
         # Check to make sure no gard records were left
-        l_result = self.lpar_list_gard_records(i_gard_dir)
+        l_result = self.host_list_gard_records(i_gard_dir)
         if(BMC_CONST.NO_GARD_RECORDS not in l_result):
             l_msg = l_rc + '. Gard records still found after clearing them'
             print l_msg
@@ -573,7 +573,7 @@ class OpTestLpar():
     #
     # @return gard records or else raise OpTestError
     #
-    def lpar_list_gard_records(self, i_gard_dir):
+    def host_list_gard_records(self, i_gard_dir):
         try:
             return self._ssh_execute(BMC_CONST.SUDO_COMMAND + i_gard_dir + BMC_CONST.LIST_GARD_CMD)
         except:
@@ -583,7 +583,7 @@ class OpTestLpar():
 
 
     ##
-    # @brief  Execute a command on the targeted lpar but don't expect
+    # @brief  Execute a command on the targeted host but don't expect
     #             any return data.
     #
     # @param     i_cmd: @type str: command to be executed
@@ -615,7 +615,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or OpTestError
     #
-    def lpar_disable_enable_cpu_states(self, i_cpu_state):
+    def host_disable_enable_cpu_states(self, i_cpu_state):
         try:
             self._ssh_execute(BMC_CONST.SUDO_COMMAND + "sh -c 'for i in " + \
                               BMC_CONST.CPU_IDLEMODE_STATE1 + "; do echo " + \
@@ -631,39 +631,39 @@ class OpTestLpar():
 
 
     ##
-    # @brief It will check existence of given linux command(i_cmd) on lpar
+    # @brief It will check existence of given linux command(i_cmd) on host
     #
     # @param i_cmd @type string: linux command
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_check_command(self, i_cmd):
+    def host_check_command(self, i_cmd):
         l_cmd = 'which ' + i_cmd + '; echo $?'
         print l_cmd
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_res = l_res.splitlines()
 
         if (int(l_res[-1]) == 0):
             return BMC_CONST.FW_SUCCESS
         else:
-            l_msg = "%s command is not present on lpar" % i_cmd
+            l_msg = "%s command is not present on host" % i_cmd
             print l_msg
             raise OpTestError(l_msg)
 
     ##
-    # @brief It will get the linux kernel version on lpar
+    # @brief It will get the linux kernel version on host
     #
     # @return l_kernel @type string: kernel version of the partition provided
     #         or raise OpTestError
     #
-    def lpar_get_kernel_version(self):
+    def host_get_kernel_version(self):
         l_kernel = self._ssh_execute("uname -a | awk {'print $3'}")
         l_kernel = l_kernel.replace("\r\n", "")
         print l_kernel
         return l_kernel
 
     ##
-    # @brief This function will checks first for config file for a given kernel version on lpar,
+    # @brief This function will checks first for config file for a given kernel version on host,
     #        if available then check for config option value and return that value
     #            whether it is y or m...etc.
     #        sample config option values:
@@ -677,17 +677,17 @@ class OpTestLpar():
     #                               Ex:CONFIG_SENSORS_IBMPOWERNV
     #
     # @return l_val @type string: It will return config option value y or m,
-    #                             or raise OpTestError if config file is not available on lpar
+    #                             or raise OpTestError if config file is not available on host
     #                             or raise OpTestError if config option is not set in file.
     #
-    def lpar_check_config(self, i_kernel, i_config):
+    def host_check_config(self, i_kernel, i_config):
         l_file = "/boot/config-%s" % i_kernel
         l_res = self._ssh_execute("test -e %s; echo $?" % l_file)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Config file is available"
         else:
-            l_msg = "Config file %s is not available on lpar" % l_file
+            l_msg = "Config file %s is not available on host" % l_file
             print l_msg
             raise OpTestError(l_msg)
         l_cmd = "cat %s | grep -i --color=never %s" % (l_file, i_config)
@@ -704,14 +704,14 @@ class OpTestLpar():
         return l_val
 
     ##
-    # @brief It will return installed package name for given linux command(i_cmd) on lpar
+    # @brief It will return installed package name for given linux command(i_cmd) on host
     #
     # @param i_cmd @type string: linux command
     # @param i_oslevel @type string: OS level
     #
-    # @return l_pkg @type string: installed package on lpar
+    # @return l_pkg @type string: installed package on host
     #
-    def lpar_check_pkg_for_utility(self, i_oslevel, i_cmd):
+    def host_check_pkg_for_utility(self, i_oslevel, i_cmd):
         if 'Ubuntu' in i_oslevel:
             l_res = self._ssh_execute("dpkg -S `which %s`" % i_cmd)
             return l_res
@@ -730,7 +730,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_load_ibmpowernv(self, i_oslevel):
+    def host_load_ibmpowernv(self, i_oslevel):
         if "PowerKVM" not in i_oslevel:
             l_rc = self._ssh_execute("modprobe ibmpowernv; echo $?")
             l_rc = l_rc.replace("\r\n", "")
@@ -753,7 +753,7 @@ class OpTestLpar():
             return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief This function restarts the lm_sensors service on lpar using systemctl utility
+    # @brief This function restarts the lm_sensors service on host using systemctl utility
     #        systemctl utility is not present in ubuntu, This function will work in remaining all
     #        other OS'es i.e redhat, sles and PowerKVM
     #
@@ -761,18 +761,18 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_start_lm_sensor_svc(self, i_oslevel):
+    def host_start_lm_sensor_svc(self, i_oslevel):
         if 'Ubuntu' in i_oslevel:
             pass
         else:
             try:
                 # Start the lm_sensors service
                 cmd = "/bin/systemctl stop  lm_sensors.service"
-                self.lpar_run_command(cmd)
+                self.host_run_command(cmd)
                 cmd = "/bin/systemctl start  lm_sensors.service"
-                self.lpar_run_command(cmd)
+                self.host_run_command(cmd)
                 cmd = "/bin/systemctl status  lm_sensors.service"
-                res = self.lpar_run_command(cmd)
+                res = self.host_run_command(cmd)
                 return BMC_CONST.FW_SUCCESS
             except:
                 l_msg = "loading lm_sensors service failed"
@@ -786,7 +786,7 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_clone_linux_source(self, i_dir):
+    def host_clone_linux_source(self, i_dir):
         l_msg = 'git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
         l_cmd = "git clone %s %s" % (l_msg, i_dir)
         self._ssh_execute("rm -rf %s" % i_dir)
@@ -804,12 +804,12 @@ class OpTestLpar():
     ##
     # @brief It will load the module using modprobe and verify whether it is loaded or not
     #
-    # @param i_module @type string: module name, which we want to load on lpar
+    # @param i_module @type string: module name, which we want to load on host
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_load_module(self, i_module):
-        l_res = self.lpar_run_command("modprobe %s; echo $?" % i_module)
+    def host_load_module(self, i_module):
+        l_res = self.host_run_command("modprobe %s; echo $?" % i_module)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             pass
@@ -817,7 +817,7 @@ class OpTestLpar():
             l_msg = "Error in loading the module %s, modprobe failed" % i_module
             print l_msg
             raise OpTestError(l_msg)
-        l_res = self.lpar_run_command("lsmod | grep -i --color=never %s" % i_module)
+        l_res = self.host_run_command("lsmod | grep -i --color=never %s" % i_module)
         if l_res.__contains__(i_module):
             print "%s module is loaded" % i_module
             return BMC_CONST.FW_SUCCESS
@@ -832,9 +832,9 @@ class OpTestLpar():
     # @return l_res @type string: return hwclock value if command execution successfull
     #           else raise OpTestError
     #
-    def lpar_read_hwclock(self):
+    def host_read_hwclock(self):
         print "Reading the hwclock"
-        l_res = self.lpar_run_command("hwclock -r;echo $?")
+        l_res = self.host_run_command("hwclock -r;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return l_res
@@ -849,9 +849,9 @@ class OpTestLpar():
     # @return l_res @type string: return system time value if command execution successfull
     #           else raise OpTestError
     #
-    def lpar_read_systime(self):
+    def host_read_systime(self):
         print "Reading system time using date utility"
-        l_res = self.lpar_run_command("date;echo $?")
+        l_res = self.host_run_command("date;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return l_res
@@ -868,9 +868,9 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_set_hwclock_time(self, i_time):
+    def host_set_hwclock_time(self, i_time):
         print "Setting the hwclock time to %s" % i_time
-        l_res = self.lpar_run_command("hwclock --set --date \'%s\';echo $?" % i_time)
+        l_res = self.host_run_command("hwclock --set --date \'%s\';echo $?" % i_time)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -880,21 +880,21 @@ class OpTestLpar():
             raise OpTestError(l_msg)
 
     ##
-    # @brief This function will load driver module on lpar based on the config option
+    # @brief This function will load driver module on host based on the config option
     #        if config value m: built as a module
     #                        y: driver built into kernel itself
     #        else   raises OpTestError
     #
     # @param i_kernel @type string: kernel version to get config file
     #        i_config @type string: config option to check in config file
-    #        i_module @type string: driver module to load on lpar based on config value
+    #        i_module @type string: driver module to load on host based on config value
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_load_module_based_on_config(self, i_kernel, i_config, i_module):
-        l_val = self.lpar_check_config(i_kernel, i_config)
+    def host_load_module_based_on_config(self, i_kernel, i_config, i_module):
+        l_val = self.host_check_config(i_kernel, i_config)
         if l_val == 'm':
-            self.lpar_load_module(i_module)
+            self.host_load_module(i_module)
         elif l_val == 'y':
             print "Driver built into kernel itself"
         else:
@@ -904,7 +904,7 @@ class OpTestLpar():
         return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief This function will return the list of installed i2c buses on lpar in two formats
+    # @brief This function will return the list of installed i2c buses on host in two formats
     #        list-by number Ex: ["0","1","2",....]
     #        list-by-name  Ex: ["i2c-0","i2c-1","i2c-2"....]
     #
@@ -912,8 +912,8 @@ class OpTestLpar():
     #         l_list1 @type list: list of i2c buses by name
     #         or raise OpTestError if not able to get list of i2c buses
     #
-    def lpar_get_list_of_i2c_buses(self):
-        l_res = self.lpar_run_command("i2cdetect -l;echo $?")
+    def host_get_list_of_i2c_buses(self):
+        l_res = self.host_run_command("i2cdetect -l;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             pass
@@ -921,7 +921,7 @@ class OpTestLpar():
             l_msg = "Not able to get list of i2c buses"
             print l_msg
             raise OpTestError(l_msg)
-        l_res = self.lpar_run_command("i2cdetect -l | awk '{print $1}'")
+        l_res = self.host_run_command("i2cdetect -l | awk '{print $1}'")
         l_res = l_res.splitlines()
         # list by number Ex: ["0","1","2",....]
         l_list = []
@@ -942,16 +942,16 @@ class OpTestLpar():
     # @return l_res @type string: return EEPROM chips information
     #           else raise OpTestError
     #
-    def lpar_get_info_of_eeprom_chips(self):
+    def host_get_info_of_eeprom_chips(self):
         print "Getting the information of EEPROM chips"
-        l_res = self.lpar_run_command("dmesg | grep -i --color=never at24")
+        l_res = self.host_run_command("dmesg | grep -i --color=never at24")
         if l_res.__contains__("at24"):
             pass
         else:
-            l_res = self.lpar_run_command("dmesg -C")
-            self.lpar_run_command("rmmod at24")
-            self.lpar_load_module("at24")
-            l_res = self.lpar_run_command("dmesg | grep -i --color=never at24")
+            l_res = self.host_run_command("dmesg -C")
+            self.host_run_command("rmmod at24")
+            self.host_load_module("at24")
+            l_res = self.host_run_command("dmesg | grep -i --color=never at24")
             if l_res.__contains__("at24"):
                 pass
             else:
@@ -967,8 +967,8 @@ class OpTestLpar():
     # @return l_chips @type list: list having pairs of i2c bus number and eeprom chip address.
     #           else raise OpTestError
     #
-    def lpar_get_list_of_eeprom_chips(self):
-        l_res = self.lpar_run_command("find /sys/ -name eeprom;echo $?")
+    def host_get_list_of_eeprom_chips(self):
+        l_res = self.host_run_command("find /sys/ -name eeprom;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             pass
@@ -1001,8 +1001,8 @@ class OpTestLpar():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     #
-    def lpar_hexdump(self, i_dev):
-        l_res = self.lpar_run_command("hexdump -C %s;echo $?" % i_dev)
+    def host_hexdump(self, i_dev):
+        l_res = self.host_run_command("hexdump -C %s;echo $?" % i_dev)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -1018,15 +1018,15 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_clone_skiboot_source(self, i_dir):
+    def host_clone_skiboot_source(self, i_dir):
         l_msg = 'https://github.com/open-power/skiboot.git/'
         l_cmd = "git clone %s %s" % (l_msg, i_dir)
-        self.lpar_run_command("git config --global http.sslverify false")
-        self.lpar_run_command("rm -rf %s" % i_dir)
-        self.lpar_run_command("mkdir %s" % i_dir)
+        self.host_run_command("git config --global http.sslverify false")
+        self.host_run_command("rm -rf %s" % i_dir)
+        self.host_run_command("mkdir %s" % i_dir)
         try:
             print l_cmd
-            l_res = self.lpar_run_command(l_cmd)
+            l_res = self.host_run_command(l_cmd)
             print l_res
             return BMC_CONST.FW_SUCCESS
         except:
@@ -1041,12 +1041,12 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_compile_xscom_utilities(self, i_dir):
+    def host_compile_xscom_utilities(self, i_dir):
         l_cmd = "cd %s/external/xscom-utils; make;" % i_dir
         print l_cmd
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_cmd = "test -f %s/external/xscom-utils/getscom; echo $?" % i_dir
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Executable binary getscom is available"
@@ -1055,7 +1055,7 @@ class OpTestLpar():
             print l_msg
             raise OpTestError(l_msg)
         l_cmd = "test -f %s/external/xscom-utils/putscom; echo $?" % i_dir
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Executable binary putscom is available"
@@ -1072,12 +1072,12 @@ class OpTestLpar():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def lpar_compile_gard_utility(self, i_dir):
+    def host_compile_gard_utility(self, i_dir):
         l_cmd = "cd %s/external/gard; make;" % i_dir
         print l_cmd
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_cmd = "test -f %s/external/gard/gard; echo $?" % i_dir
-        l_res = self.lpar_run_command(l_cmd)
+        l_res = self.host_run_command(l_cmd)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Executable binary gard is available"

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -38,7 +38,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
 
 
@@ -52,17 +52,17 @@ class OpTestHeartbeat():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd, i_bmcIP)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
         self.util = OpTestUtil()
 
     ##
@@ -76,17 +76,17 @@ class OpTestHeartbeat():
     def test_kopald_service(self):
 
         # Get OS level
-        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
 
         # Get kernel version
-        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+        l_kernel = self.cv_HOST.host_get_kernel_version()
 
         # Checking for ps command 
-        self.cv_LPAR.lpar_check_command("ps")
+        self.cv_HOST.host_check_command("ps")
 
         l_cmd = "ps -ef | grep -i kopald"
         print l_cmd
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         print l_res
         if (l_res.__contains__('[kopald]')):
             return BMC_CONST.FW_SUCCESS 

--- a/testcases/OpTestIPMIPowerControl.py
+++ b/testcases/OpTestIPMIPowerControl.py
@@ -38,7 +38,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestSystem import OpTestSystem
 from common.OpTestUtil import OpTestUtil
 
@@ -53,20 +53,20 @@ class OpTestIPMIPowerControl():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
-                                  i_ffdcDir, i_lparip, i_lparuser, i_lparPasswd)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd, i_bmcIP)
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostPasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
         self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
-                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_lparip,
-                         i_lparuser, i_lparPasswd)
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -97,7 +97,7 @@ class OpTestIPMIPowerControl():
         # Perform a IPMI Power ON Operation
         self.cv_IPMI.ipmi_power_on()
         self.check_system_status()
-        self.util.PingFunc(self.cv_LPAR.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
 
         print "Performing a IPMI Soft Power OFF Operation"
         # Perform a IPMI Soft Power OFF Operation(Graceful shutdown)
@@ -112,19 +112,19 @@ class OpTestIPMIPowerControl():
         # Perform a IPMI Power ON Operation
         self.cv_IPMI.ipmi_power_on()
         self.check_system_status()
-        self.util.PingFunc(self.cv_LPAR.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
 
         print "Performing a IPMI Power Cycle(Soft reboot) Operation "
         # Perform a IPMI Power Cycle(Soft reboot) Operation only when system is in ON state
         self.cv_IPMI.ipmi_power_cycle()
         self.check_system_status()
-        self.util.PingFunc(self.cv_LPAR.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
 
         print "Performing a IPMI Power Hard Reset Operation"
         # Perform a IPMI Power Hard Reset Operation
         self.cv_IPMI.ipmi_power_reset()
         self.check_system_status()
-        self.util.PingFunc(self.cv_LPAR.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
 
         return BMC_CONST.FW_SUCCESS
 

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -42,7 +42,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
 
 class OpTestInbandIPMI():
@@ -55,17 +55,17 @@ class OpTestInbandIPMI():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd, i_bmcIP)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
         self.util = OpTestUtil()
 
     ##
@@ -81,35 +81,35 @@ class OpTestInbandIPMI():
     def test_ipmi_inband_functionality(self):
 
         # Get OS level
-        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
 
         # Get kernel version
-        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+        l_kernel = self.cv_HOST.host_get_kernel_version()
 
         # Checking for ipmitool command and lm_sensors package
-        self.cv_LPAR.lpar_check_command("ipmitool")
+        self.cv_HOST.host_check_command("ipmitool")
 
-        l_pkg = self.cv_LPAR.lpar_check_pkg_for_utility(l_oslevel, "ipmitool")
+        l_pkg = self.cv_HOST.host_check_pkg_for_utility(l_oslevel, "ipmitool")
         print "Installed package: %s" % l_pkg
 
 
         # Checking Inband ipmitool command functionality with different options
         l_cmd = "ipmitool sdr; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sdr not working,exiting...."
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool sdr elist full; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sdr elist full not working,exiting...."
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool sdr type temperature; echo $?"
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if l_res.__contains__("Temp"):
             print "ipmitool sdr type temperature is working"
         else:
@@ -118,7 +118,7 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool lan print 1; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool lan print command is not working,exiting...."
@@ -126,7 +126,7 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool fru print; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool fru print is not working,exiting...."
@@ -134,7 +134,7 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool chassis status | grep \"System Power\""
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if l_res.__contains__("System Power         : on"):
             print "ipmitool Chassis status is working"
         else:
@@ -142,7 +142,7 @@ class OpTestInbandIPMI():
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool chassis identify 1; echo $?"
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if l_res.__contains__("Chassis identify interval: 1 seconds"):
             print "ipmitool Chassis identify interval is working"
         else:
@@ -150,7 +150,7 @@ class OpTestInbandIPMI():
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool chassis identify force; echo $?"
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if l_res.__contains__("Chassis identify interval: indefinite"):
             print "ipmitool Chassis identify interval is working"
         else:
@@ -159,7 +159,7 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool sensor list; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sensor list is not working,exiting...."
@@ -167,14 +167,14 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool mc info; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool mc info is not working,exiting...."
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool mc selftest; echo $?"
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if l_res.__contains__("Selftest: passed"):
             print "ipmitool mc selftest is passed"
         else:
@@ -182,14 +182,14 @@ class OpTestInbandIPMI():
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool mc getenables; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool mc getenables is not working,exiting...."
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool mc watchdog get; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool mc watchdog get is not working,exiting...."
@@ -198,14 +198,14 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool sel info; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sel info is not working,exiting...."
             raise OpTestError(l_msg)
 
         l_cmd = "ipmitool sel list; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sel list is not working,exiting...."
@@ -213,10 +213,10 @@ class OpTestInbandIPMI():
 
 
         l_cmd = "ipmitool sel list last 3 | grep \"PCI resource configuration\" | awk \'{ print $1 }\'"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         l_cmd = "ipmitool sel get 0x" + response[1] + "; echo $?"
-        output = self.cv_LPAR.lpar_run_command(l_cmd)
+        output = self.cv_HOST.host_run_command(l_cmd)
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "ipmitool sel get is not working,exiting...."

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -38,7 +38,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
 
 
@@ -52,22 +52,22 @@ class OpTestRTCdriver():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd,i_bmcIP)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
         self.util = OpTestUtil()
 
     ##
     # @brief This function will cover following test steps
-    #        1. Getting lpar information(OS and Kernel info)
+    #        1. Getting host information(OS and Kernel info)
     #        2. Loading rtc_opal module based on config option
     #        3. Testing the rtc driver functions
     #                Display the current time,
@@ -85,21 +85,21 @@ class OpTestRTCdriver():
     def test_RTC_driver(self):
 
         # Get OS level
-        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
 
         # Get Kernel Version
-        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+        l_kernel = self.cv_HOST.host_get_kernel_version()
 
         # Get hwclock version
-        l_hwclock = self.cv_LPAR.lpar_run_command("hwclock -V;echo $?")
+        l_hwclock = self.cv_HOST.host_run_command("hwclock -V;echo $?")
 
         # loading rtc_opal module based on config option
         l_config = "CONFIG_RTC_DRV_OPAL"
         l_module = "rtc_opal"
-        self.cv_LPAR.lpar_load_module_based_on_config(l_kernel, l_config, l_module)
+        self.cv_HOST.host_load_module_based_on_config(l_kernel, l_config, l_module)
 
         # Get the device files for rtc driver
-        l_res = self.cv_LPAR.lpar_run_command("ls /dev/ | grep -i --color=never rtc")
+        l_res = self.cv_HOST.host_run_command("ls /dev/ | grep -i --color=never rtc")
         l_files = l_res.splitlines()
         l_list = []
         for name in l_files:
@@ -114,41 +114,41 @@ class OpTestRTCdriver():
         for l_file in l_list:
             self.read_hwclock_from_file(l_file)
 
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         time.sleep(5)
-        self.cv_LPAR.lpar_set_hwclock_time("2015-01-01 10:10:10")
+        self.cv_HOST.host_set_hwclock_time("2015-01-01 10:10:10")
         time.sleep(5)
-        self.cv_LPAR.lpar_read_hwclock()
-        self.cv_LPAR.lpar_set_hwclock_time("2016-01-01 20:20:20")
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
+        self.cv_HOST.host_set_hwclock_time("2016-01-01 20:20:20")
+        self.cv_HOST.host_read_hwclock()
         self.set_hwclock_in_utc("2017-01-01 10:10:10")
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.set_hwclock_in_localtime("2014-01-01 05:05:05")
-        self.cv_LPAR.lpar_read_hwclock()
-        self.cv_LPAR.lpar_read_systime()
+        self.cv_HOST.host_read_hwclock()
+        self.cv_HOST.host_read_systime()
         self.systime_to_hwclock()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.systime_to_hwclock_in_utc()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.systime_to_hwclock_in_localtime()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_to_systime()
-        self.cv_LPAR.lpar_read_hwclock()
-        self.cv_LPAR.lpar_read_systime()
+        self.cv_HOST.host_read_hwclock()
+        self.cv_HOST.host_read_systime()
         self.hwclock_in_utc()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_in_localtime()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_predict("2015-01-01 10:10:10")
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_debug_mode()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_test_mode("2018-01-01 10:10:10")
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_adjust()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
         self.hwclock_compare()
-        self.cv_LPAR.lpar_read_hwclock()
+        self.cv_HOST.host_read_hwclock()
 
     ##
     # @brief This function reads hwclock from special /dev/... file instead of default
@@ -159,7 +159,7 @@ class OpTestRTCdriver():
     #
     def read_hwclock_from_file(self, i_file):
         print "Reading the hwclock from special file /dev/ ...: %s" % i_file
-        l_res = self.cv_LPAR.lpar_run_command("hwclock -r -f %s;echo $?" % i_file)
+        l_res = self.cv_HOST.host_run_command("hwclock -r -f %s;echo $?" % i_file)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -178,7 +178,7 @@ class OpTestRTCdriver():
     #
     def set_hwclock_in_utc(self, i_time):
         print "Setting the hwclock in UTC: %s" % i_time
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --utc;echo $?" % i_time)
+        l_res = self.cv_HOST.host_run_command("hwclock --set --date \'%s\' --utc;echo $?" % i_time)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -196,7 +196,7 @@ class OpTestRTCdriver():
     #
     def set_hwclock_in_localtime(self, i_time):
         print "Setting the hwclock in localtime: %s" % i_time
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --localtime;echo $?" % i_time)
+        l_res = self.cv_HOST.host_run_command("hwclock --set --date \'%s\' --localtime;echo $?" % i_time)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -212,7 +212,7 @@ class OpTestRTCdriver():
     #
     def systime_to_hwclock(self):
         print "Setting the hwclock from system time"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --systohc;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -228,7 +228,7 @@ class OpTestRTCdriver():
     #
     def systime_to_hwclock_in_utc(self):
         print "Setting the hwclock from system time, in UTC format"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --utc;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --systohc --utc;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -244,7 +244,7 @@ class OpTestRTCdriver():
     #
     def systime_to_hwclock_in_localtime(self):
         print "Setting the hwclock from system time, in localtime format"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --localtime;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --systohc --localtime;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -260,7 +260,7 @@ class OpTestRTCdriver():
     #
     def hwclock_to_systime(self):
         print "Setting the system time from hwclock"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --hctosys;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --hctosys;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -276,7 +276,7 @@ class OpTestRTCdriver():
     #
     def hwclock_in_utc(self):
         print "Keeping the hwclock in UTC format"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --utc;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --utc;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -292,7 +292,7 @@ class OpTestRTCdriver():
     #
     def hwclock_in_localtime(self):
         print "Keeping the hwclock in localtime"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --localtime;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --localtime;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -310,7 +310,7 @@ class OpTestRTCdriver():
     #
     def hwclock_compare(self):
         print "Testing hwclock compare functionality for a time of 100 seconds"
-        l_res = self.cv_LPAR.lpar_run_command("timeout 100 hwclock --compare; echo $?")
+        l_res = self.cv_HOST.host_run_command("timeout 100 hwclock --compare; echo $?")
         l_res = l_res.splitlines()
         print l_res
         if int(l_res[-1]) == 124:
@@ -329,7 +329,7 @@ class OpTestRTCdriver():
     #
     def hwclock_predict(self, i_time):
         print "Testing the hwclock predict function to a time: %s" % i_time
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --predict --date \'%s\';echo $?" % i_time)
+        l_res = self.cv_HOST.host_run_command("hwclock --predict --date \'%s\';echo $?" % i_time)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -347,7 +347,7 @@ class OpTestRTCdriver():
     #
     def hwclock_debug_mode(self):
         print "Testing the hwclock debug mode"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --systohc --debug;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --systohc --debug;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             pass
@@ -355,7 +355,7 @@ class OpTestRTCdriver():
             l_msg = "Setting the hwclock from system time in debug mode failed"
             print l_msg
             raise OpTestError(l_msg)
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --hctosys --debug;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --hctosys --debug;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -374,7 +374,7 @@ class OpTestRTCdriver():
     #
     def hwclock_test_mode(self, i_time):
         print "Testing the hwclock test mode, set time to: %s" % i_time
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --set --date \'%s\' --test;echo $?" % i_time)
+        l_res = self.cv_HOST.host_run_command("hwclock --set --date \'%s\' --test;echo $?" % i_time)
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
             return BMC_CONST.FW_SUCCESS
@@ -390,10 +390,10 @@ class OpTestRTCdriver():
     #
     def hwclock_adjust(self):
         print "Testing the hwclock adjust function"
-        l_res = self.cv_LPAR.lpar_run_command("hwclock --adjust;echo $?")
+        l_res = self.cv_HOST.host_run_command("hwclock --adjust;echo $?")
         l_res = l_res.splitlines()
         if int(l_res[-1]) == 0:
-            l_res = self.cv_LPAR.lpar_run_command("cat /etc/adjtime")
+            l_res = self.cv_HOST.host_run_command("cat /etc/adjtime")
             return BMC_CONST.FW_SUCCESS
         else:
             l_msg = "hwclock adjust function failed"

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -38,7 +38,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
 
 
@@ -52,17 +52,17 @@ class OpTestSensors():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd,i_bmcIP)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
         self.util = OpTestUtil()
 
     ##
@@ -81,56 +81,56 @@ class OpTestSensors():
     def test_hwmon_driver(self):
 
         # Get OS level
-        l_oslevel = self.cv_LPAR.lpar_get_OS_Level()
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
 
         # Get kernel version
-        l_kernel = self.cv_LPAR.lpar_get_kernel_version()
+        l_kernel = self.cv_HOST.host_get_kernel_version()
 
         # Checking for sensors config option CONFIG_SENSORS_IBMPOWERNV
         l_config = "CONFIG_SENSORS_IBMPOWERNV"
 
-        l_val = self.cv_LPAR.lpar_check_config(l_kernel, l_config)
+        l_val = self.cv_HOST.host_check_config(l_kernel, l_config)
         if l_val == "y":
             print "Driver build into kernel itself"
         else:
             print "Driver will be built as module"
 
         # Loading ibmpowernv driver only on powernv platform
-        self.cv_LPAR.lpar_load_ibmpowernv(l_oslevel)
+        self.cv_HOST.host_load_ibmpowernv(l_oslevel)
 
         # Checking for sensors command and lm_sensors package
-        self.cv_LPAR.lpar_check_command("sensors")
+        self.cv_HOST.host_check_command("sensors")
 
-        l_pkg = self.cv_LPAR.lpar_check_pkg_for_utility(l_oslevel, "sensors")
+        l_pkg = self.cv_HOST.host_check_pkg_for_utility(l_oslevel, "sensors")
         print "Installed package: %s" % l_pkg
 
         # Restart the lm_sensor service
-        self.cv_LPAR.lpar_start_lm_sensor_svc(l_oslevel)
+        self.cv_HOST.host_start_lm_sensor_svc(l_oslevel)
 
         # To detect different sensor chips and modules
-        res = self.cv_LPAR.lpar_run_command("yes | sensors-detect")
+        res = self.cv_HOST.host_run_command("yes | sensors-detect")
         print res
 
         # Checking sensors command functionality with different options
-        output = self.cv_LPAR.lpar_run_command("sensors; echo $?")
+        output = self.cv_HOST.host_run_command("sensors; echo $?")
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "sensors not working,exiting...."
             raise OpTestError(l_msg)
         print output
-        output = self.cv_LPAR.lpar_run_command("sensors -f; echo $?")
+        output = self.cv_HOST.host_run_command("sensors -f; echo $?")
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "sensors -f not working,exiting...."
             raise OpTestError(l_msg)
         print output
-        output = self.cv_LPAR.lpar_run_command("sensors -A; echo $?")
+        output = self.cv_HOST.host_run_command("sensors -A; echo $?")
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "sensors -A not working,exiting...."
             raise OpTestError(l_msg)
         print output
-        output = self.cv_LPAR.lpar_run_command("sensors -u; echo $?")
+        output = self.cv_HOST.host_run_command("sensors -u; echo $?")
         response = output.splitlines()
         if int(response[-1]):
             l_msg = "sensors -u not working,exiting...."

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -44,7 +44,7 @@ from common.OpTestBMC import OpTestBMC
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
-from common.OpTestLpar import OpTestLpar
+from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
 
 
@@ -58,21 +58,21 @@ class OpTestSwitchEndianSyscall():
     #  @param i_ffdcDir Optional param to indicate where to write FFDC
     #
     # "Only required for inband tests" else Default = None
-    # @param i_lparIP The IP address of the LPAR
-    # @param i_lparuser The userid to log into the LPAR
-    # @param i_lparPasswd The password of the userid to log into the LPAR with
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
     #
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
-                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_lparip=None,
-                 i_lparuser=None, i_lparPasswd=None):
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
         self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
-        self.cv_LPAR = OpTestLpar(i_lparip, i_lparuser, i_lparPasswd,i_bmcIP)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
         self.util = OpTestUtil()
 
     ##
-    # @brief  If git and gcc commands are availble on lpar, this function will clone linux
+    # @brief  If git and gcc commands are availble on host, this function will clone linux
     #         git repository and check for switch_endian_test directory and make
     #         the required files. And finally execute bin file switch_endian_test.
     #
@@ -81,15 +81,15 @@ class OpTestSwitchEndianSyscall():
     def testSwitchEndianSysCall(self):
 
         # Get OS level
-        self.cv_LPAR.lpar_get_OS_Level()
+        self.cv_HOST.host_get_OS_Level()
 
-        # Check whether git and gcc commands are available on lpar
-        self.cv_LPAR.lpar_check_command("git")
-        self.cv_LPAR.lpar_check_command("gcc")
+        # Check whether git and gcc commands are available on host
+        self.cv_HOST.host_check_command("git")
+        self.cv_HOST.host_check_command("gcc")
 
         # Clone latest linux git repository into l_dir
         l_dir = "/tmp/linux"
-        self.cv_LPAR.lpar_clone_linux_source(l_dir)
+        self.cv_HOST.host_clone_linux_source(l_dir)
 
         # Check for switch_endian test directory.
         self.check_dir_exists(l_dir)
@@ -117,7 +117,7 @@ class OpTestSwitchEndianSyscall():
         l_dir = '%s/tools/testing/selftests/powerpc/switch_endian' % i_dir
         l_cmd = "test -d %s; echo $?" % l_dir
         print l_cmd
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         print l_res
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
@@ -141,9 +141,9 @@ class OpTestSwitchEndianSyscall():
         l_cmd = "cd %s/tools/testing/selftests/powerpc/switch_endian;\
                  make;" % i_dir
         print l_cmd
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         l_cmd = "test -f %s/tools/testing/selftests/powerpc/switch_endian/switch_endian_test; echo $?" % i_dir
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         l_res = l_res.replace("\r\n", "")
         if int(l_res) == 0:
             print "Executable binary switch_endian_test is available"
@@ -165,7 +165,7 @@ class OpTestSwitchEndianSyscall():
         l_cmd = "cd %s/tools/testing/selftests/powerpc/switch_endian/;\
                  ./switch_endian_test" % i_dir
         print l_cmd
-        l_res = self.cv_LPAR.lpar_run_command(l_cmd)
+        l_res = self.cv_HOST.host_run_command(l_cmd)
         if (l_res.__contains__('success: switch_endian_test')):
             return 1
         else:


### PR DESCRIPTION
The LPAR terminology is from PowerVM/hardware where the machine is
partitioned up into Logical Partitions.

However, this is not what we are testing here, instead, we're testing
the Host. It makes more sense to refer to the Host (as in, the host
processor, rather than the service processor/BMC).

So, this patch is a giant string replace.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/52)
<!-- Reviewable:end -->
