### PR TITLE
Add testcases for testing system power restore policy.

### DIFF
--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -200,5 +200,26 @@
             </testcase>
         </test>
 
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_always_on()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_always_off()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_previous()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
     </platform>
 </integrationtest>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -369,3 +369,24 @@ def test_fan_control_disable_functionality():
         returns: int 0-success, raises exception-error
     """
     return opTestOOBIPMI.test_fan_control_algorithm_1()
+
+
+def test_system_power_restore_policy_always_on():
+    """This function tests System Power Policy always-on
+        returns: int 0-success, raises exception-error
+    """
+    return opTestSystemBootSequence.testSystemPowerPolicyOn()
+
+
+def test_system_power_restore_policy_always_off():
+    """This function tests System Power Policy always-off
+        returns: int 0-success, raises exception-error
+    """
+    return opTestSystemBootSequence.testSystemPowerPolicyOff()
+
+
+def test_system_power_restore_policy_previous():
+    """This function tests System Power Policy previous
+        returns: int 0-success, raises exception-error
+    """
+    return opTestSystemBootSequence.testSystemPowerPolicyPrevious()

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -127,3 +127,15 @@ def test_fan_control_enable_functionality():
 
 def test_fan_control_disable_functionality():
     assert op_opal_fvt.test_fan_control_disable_functionality() == 0
+
+
+def test_system_power_restore_policy_always_on():
+    assert op_opal_fvt.test_system_power_restore_policy_always_on() == 0
+
+
+def test_system_power_restore_policy_always_off():
+    assert op_opal_fvt.test_system_power_restore_policy_always_off() == 0
+
+
+def test_system_power_restore_policy_previous():
+    assert op_opal_fvt.test_system_power_restore_policy_previous() == 0

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -42,6 +42,7 @@ import socket
 import select
 import pty
 import pexpect
+import commands
 try:
     import pxssh
 except ImportError:

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -161,3 +161,148 @@ class OpTestSystemBootSequence():
         print "Gathering the OPAL msg logs"
         self.cv_HOST.host_gather_opal_msg_log()
         return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function will test system auto reboot policy always-off.
+    #        It has below steps
+    #        1. Do a system Power OFF(Host should go down)
+    #        2. Set auto reboot policy to off(chassis policy always-off)
+    #        3. Issue a BMC Cold reset.
+    #        4. After BMC comes up, expect the system to not boot.
+    #        5. Issue a Power ON of the system
+    #        6. Check for system status and gather OPAL msg log.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testSystemPowerPolicyOff(self):
+        print "Testing System Power Policy:always-off"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Setting the system power policy to always-off"
+        self.cv_IPMI.ipmi_set_power_policy("always-off")
+        # Perform a BMC Cold Reset Operation
+        if int(self.cv_SYSTEM.sys_cold_reset_bmc()) == BMC_CONST.FW_SUCCESS:
+            print "System auto reboot policy for always-off works as expected"
+            print "System Power status not changed"
+            print "Performing a IPMI Power ON Operation"
+            # Perform a IPMI Power ON Operation
+            self.cv_IPMI.ipmi_power_on()
+        else:
+            print "Power restore policy failed"
+            l_msg = "Fail: chassis policy always-off making the system to auto boot"
+            print l_msg
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function will test system auto reboot policy always-on.
+    #        It has below steps
+    #        1. Do a system Power OFF(Host should go down)
+    #        2. Set auto reboot policy to on(chassis policy always-on)
+    #        3. Issue a BMC Cold reset.
+    #        4. After BMC comes up, Here expect the system to boot,
+    #           If not power policy is not working as expected
+    #        5. Check for system status and gather OPAL msg log.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testSystemPowerPolicyOn(self):
+        print "Testing System Power Policy:Always-ON"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Setting the system power policy to always-on"
+        self.cv_IPMI.ipmi_set_power_policy("always-on")
+
+        # Perform a BMC Cold Reset Operation
+        if int(self.cv_SYSTEM.sys_cold_reset_bmc()) == BMC_CONST.FW_FAILED:
+            print "System auto reboot policy for always-on works as expected"
+            print "System Power status changed as expected"
+        else:
+            print "Power restore policy failed"
+            l_msg = "Fail: chassis policy always-on making the system not to auto boot"
+            print "Performing a IPMI Power ON Operation"
+            # Perform a IPMI Power ON Operation
+            self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function will test system auto reboot policy previous
+    #        It has below steps
+    #        1. Do a system Power OFF(Host should go down)
+    #        2. Set auto reboot policy to previous(chassis policy previous)
+    #        3. Issue a BMC Cold reset.
+    #        4. After BMC comes up, system power status will change based on
+    #           previous power status before issuing cold reset.
+    #        5. Check for system status and gather OPAL msg log.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def testSystemPowerPolicyPrevious(self):
+        print "Testing System Power Policy:previous"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Setting the system power policy to previous"
+        self.cv_IPMI.ipmi_set_power_policy("previous")
+
+        # Perform a BMC Cold Reset Operation
+        if int(self.cv_SYSTEM.sys_cold_reset_bmc()) == BMC_CONST.FW_SUCCESS:
+            print "System auto reboot policy for previous works as expected"
+            print "System Power status not changed"
+            print "Performing a IPMI Power ON Operation"
+            # Perform a IPMI Power ON Operation
+            self.cv_IPMI.ipmi_power_on()
+        else:
+            print "Power restore policy failed"
+            l_msg = "Fail: chassis policy previous making the system to auto boot"
+            print l_msg
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        # Perform a BMC Cold Reset Operation
+        if int(self.cv_SYSTEM.sys_cold_reset_bmc()) == BMC_CONST.FW_SUCCESS:
+            print "System auto reboot policy for previous works as expected"
+            print "System Power status not changed"
+        else:
+            print "Power restore policy previous failed"
+            l_msg = "Fail: chassis policy previous making the system to change power status"
+            print l_msg
+            # Perform a IPMI Power ON Operation
+            self.cv_IPMI.ipmi_power_on()
+            self.cv_SYSTEM.sys_check_host_status()
+            self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+            self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+            print "Gathering the OPAL msg logs"
+            self.cv_HOST.host_gather_opal_msg_log()


### PR DESCRIPTION
    This patch has testcases for testing system power policy
        always-off
        always-on
        previous

And also it has a fix for gathering opal msg logs function(host_gather_opal_msg_log)
which is using commands module, But OpTestHost is not imported commands module.(missed in one of previous patch).

Signed-off-by: pridhiviraj <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/59)
<!-- Reviewable:end -->
