### PR TITLE
Problem: While encoding the following lines in common/OpTestIPMI file

### DIFF
--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# encoding=utf8
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #


### PR DESCRIPTION
got the below error.
    #                   0x00 – success
    #                   0x81 – Not a valid image in golden SPI.
SyntaxError: Non-ASCII character '\xe2' in file
op-test-framework/common/OpTestIPMI.py on line 563, but no
encoding declared; see http://python.org/dev/peps/pep-0263/ for
details

To fix the above error need to add 'utf8' encoding

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/60)
<!-- Reviewable:end -->
