### PR TITLE
Corrected the name of the base folder in IBM PROLOG

### DIFF
--- a/bvt/OPBVTXML.pm
+++ b/bvt/OPBVTXML.pm
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/run-op-bvt $
+# $Source: op-test-framework/bvt/run-op-bvt $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/OpTestInfra.pm
+++ b/bvt/OpTestInfra.pm
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/OpTestInfra.pm $
+# $Source: op-test-framework/bvt/OpTestInfra.pm $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/helloworld-bvt.xml
+++ b/bvt/helloworld-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/helloworld-bvt.xml $                         -->
+<!-- $Source: op-test-framework/bvt/helloworld-bvt.xml $                    -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/helloworld-include.xml
+++ b/bvt/helloworld-include.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/helloworld.xml $                             -->
+<!-- $Source: op-test-framework/bvt/helloworld.xml $                        -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/helloworld.xml
+++ b/bvt/helloworld.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/helloworld.xml $                             -->
+<!-- $Source: op-test-framework/bvt/helloworld.xml $                        -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/helloworld2-bvt.xml
+++ b/bvt/helloworld2-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/helloworld-bvt.xml $                         -->
+<!-- $Source: op-test-framework/bvt/helloworld-bvt.xml $                    -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/helloworld2.xml
+++ b/bvt/helloworld2.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/helloworld.xml $                             -->
+<!-- $Source: op-test-framework/bvt/helloworld.xml $                        -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-bmc-web-update-bvt.xml
+++ b/bvt/op-bmc-web-update-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-bmc-web-update-bvt.xml $                  -->
+<!-- $Source: op-test-framework/bvt/op-bmc-web-update-bvt.xml $             -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-bmc-web-update.xml
+++ b/bvt/op-bmc-web-update.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-bmc-web-update.xml $                      -->
+<!-- $Source: op-test-framework/bvt/op-bmc-web-update.xml $                 -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-ci-basic-bvt.xml
+++ b/bvt/op-ci-basic-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-ci-basic-bvt.xml $                        -->
+<!-- $Source: op-test-framework/bvt/op-ci-basic-bvt.xml $                   -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-ci-basic.xml $                            -->
+<!-- $Source: op-test-framework/bvt/op-ci-basic.xml $                       -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-ci-bmc-run
+++ b/bvt/op-ci-bmc-run
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-ci-bmc-run $
+# $Source: op-test-framework/bvt/op-ci-bmc-run $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/op-ci-bvt
+++ b/bvt/op-ci-bvt
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-ci-bmc-run $
+# $Source: op-test-framework/bvt/op-ci-bmc-run $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/op-firmware-component-update-bvt.xml
+++ b/bvt/op-firmware-component-update-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-firmware-component-update-bvt.xml $       -->
+<!-- $Source: op-test-framework/bvt/op-firmware-component-update-bvt.xml $  -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-firmware-component-update.xml
+++ b/bvt/op-firmware-component-update.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-firmware-component-update.xml $           -->
+<!-- $Source: op-test-framework/bvt/op-firmware-component-update.xml $      -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-inbound-basic-bvt.xml
+++ b/bvt/op-inbound-basic-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-inbound-basic-bvt.xml $                   -->
+<!-- $Source: op-test-framework/bvt/op-inbound-basic-bvt.xml $              -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-inbound-basic.xml
+++ b/bvt/op-inbound-basic.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-inbound-basic.xml $                       -->
+<!-- $Source: op-test-framework/bvt/op-inbound-basic.xml $                  -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-it-list
+++ b/bvt/op-it-list
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/op-it-list $
+# $Source: op-test-framework/bvt/op-it-list $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/op-it.xsd
+++ b/bvt/op-it.xsd
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-ci-setup.xml $                            -->
+<!-- $Source: op-test-framework/bvt/op-ci-setup.xml $                       -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-opal-ci-bvt.xml
+++ b/bvt/op-opal-ci-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-opal-ci-bvt.xml $                        -->
+<!-- $Source: op-test-framework/bvt/op-opal-ci-bvt.xml $                    -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-opal-ci.xml
+++ b/bvt/op-opal-ci.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-opal-ci.xml $                            -->
+<!-- $Source: op-test-framework/bvt/op-opal-ci.xml $                        -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-opal-fvt-bvt.xml
+++ b/bvt/op-opal-fvt-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-opal-fvt-bvt.xml $                        -->
+<!-- $Source: op-test-framework/bvt/op-opal-fvt-bvt.xml $                   -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-opal-fvt.xml $                            -->
+<!-- $Source: op-test-framework/bvt/op-opal-fvt.xml $                       -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-outofband-firmware-update-bvt.xml
+++ b/bvt/op-outofband-firmware-update-bvt.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-outofband-firmware-update-bvt.xml $       -->
+<!-- $Source: op-test-framework/bvt/op-outofband-firmware-update-bvt.xml $  -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/op-outofband-firmware-update.xml
+++ b/bvt/op-outofband-firmware-update.xml
@@ -2,7 +2,7 @@
 <!-- IBM_PROLOG_BEGIN_TAG                                                   -->
 <!-- This is an automatically generated prolog.                             -->
 <!--                                                                        -->
-<!-- $Source: op-auto-test/bvt/op-outofband-firmware-update.xml $           -->
+<!-- $Source: op-test-framework/bvt/op-outofband-firmware-update.xml $      -->
 <!--                                                                        -->
 <!-- OpenPOWER Automated Test Project                                       -->
 <!--                                                                        -->

--- a/bvt/read-op-xml-it
+++ b/bvt/read-op-xml-it
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/read-op-xml-it $
+# $Source: op-test-framework/bvt/read-op-xml-it $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/run-op-bvt
+++ b/bvt/run-op-bvt
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/run-op-bvt $
+# $Source: op-test-framework/bvt/run-op-bvt $
 #
 # OpenPOWER Automated Test Project
 #

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/bvt/run-op-it $
+# $Source: op-test-framework/bvt/run-op-it $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestBMC.py $
+# $Source: op-test-framework/common/OpTestBMC.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/__init__.py
+++ b/ci/source/__init__.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestBMC.py $
+# $Source: op-test-framework/common/OpTestBMC.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/build-auto/op-ci-build.sh
+++ b/ci/source/build-auto/op-ci-build.sh
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/build-auto/op-ci-build.sh $
+# $Source: op-test-framework/ci/source/build-auto/op-ci-build.sh $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/opCIConfigure.py
+++ b/ci/source/opCIConfigure.py
@@ -1,7 +1,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/opCIConfigure.py $
+# $Source: op-test-framework/ci/source/opCIConfigure.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_bmc_web_update.py
+++ b/ci/source/op_bmc_web_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_bmc_web_update.py $
+# $Source: op-test-framework/ci/source/op_bmc_web_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_ci_bmc.py $
+# $Source: op-test-framework/ci/source/op_ci_bmc.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_firmware_component_update.py
+++ b/ci/source/op_firmware_component_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_firmware_component_update.py $
+# $Source: op-test-framework/ci/source/op_firmware_component_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_inbound_hpm.py
+++ b/ci/source/op_inbound_hpm.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_inbound_hpm.py $
+# $Source: op-test-framework/ci/source/op_inbound_hpm.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_opal_fvt.py $
+# $Source: op-test-framework/ci/source/op_opal_fvt.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/op_outofband_firmware_update.py
+++ b/ci/source/op_outofband_firmware_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/op_outofband_firmware_update.py $
+# $Source: op-test-framework/ci/source/op_outofband_firmware_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/run
+++ b/ci/source/run
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/run $
+# $Source: op-test-framework/ci/source/run $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_op_bmc_web_update.py
+++ b/ci/source/test_op_bmc_web_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_op_bmc_web_update.py $
+# $Source: op-test-framework/ci/source/test_op_bmc_web_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_op_ci.py
+++ b/ci/source/test_op_ci.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_op_ci.py $
+# $Source: op-test-framework/ci/source/test_op_ci.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_op_firmware_component_update.py
+++ b/ci/source/test_op_firmware_component_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_op_firmware_component_update.py $
+# $Source: op-test-framework/ci/source/test_op_firmware_component_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_op_inbound.py
+++ b/ci/source/test_op_inbound.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_op_inbound.py $
+# $Source: op-test-framework/ci/source/test_op_inbound.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_op_outofband_firmware_update.py
+++ b/ci/source/test_op_outofband_firmware_update.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_op_outofband_firmware_update.py $
+# $Source: op-test-framework/ci/source/test_op_outofband_firmware_update.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/ci/source/test_opal_fvt.py
+++ b/ci/source/test_opal_fvt.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/ci/source/test_opal_fvt.py $
+# $Source: op-test-framework/ci/source/test_opal_fvt.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestBMC.py $
+# $Source: op-test-framework/common/OpTestBMC.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestConstants.py $
+# $Source: op-test-framework/common/OpTestConstants.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestError.py
+++ b/common/OpTestError.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestConstants.py $
+# $Source: op-test-framework/common/OpTestConstants.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestHost.py $
+# $Source: op-test-framework/common/OpTestHost.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestIPMI.py $
+# $Source: op-test-framework/common/OpTestIPMI.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestSystem.py $
+# $Source: op-test-framework/common/OpTestSystem.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestUtil.py $
+# $Source: op-test-framework/common/OpTestUtil.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestWeb.py
+++ b/common/OpTestWeb.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestWeb.py $
+# $Source: op-test-framework/common/OpTestWeb.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestBMC.py $
+# $Source: op-test-framework/common/OpTestBMC.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/sol_logger.exp
+++ b/common/sol_logger.exp
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/sol_logger.exp $
+# $Source: op-test-framework/common/sol_logger.exp $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/OpTestBMC.py $
+# $Source: op-test-framework/common/OpTestBMC.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/BmcPageConstants.py
+++ b/common/util/web/BmcPageConstants.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../BmcPageConstants.py $
+# $Source: op-test-framework/common/../BmcPageConstants.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/FWUpdatePage.py
+++ b/common/util/web/FWUpdatePage.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../FWUpdatePage.py $
+# $Source: op-test-framework/common/../FWUpdatePage.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/LoginPage.py
+++ b/common/util/web/LoginPage.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../LoginPage.py $
+# $Source: op-test-framework/common/../LoginPage.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/MaintenancePage.py
+++ b/common/util/web/MaintenancePage.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../MaintenancePage.py $
+# $Source: op-test-framework/common/../MaintenancePage.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/Page.py
+++ b/common/util/web/Page.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../Page.py $
+# $Source: op-test-framework/common/../Page.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/util/web/seleniumimports.py
+++ b/common/util/web/seleniumimports.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/common/../seleniumimports.py $
+# $Source: op-test-framework/common/../seleniumimports.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestAt24driver.py
+++ b/testcases/OpTestAt24driver.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestAt24driver.py $
+# $Source: op-test-framework/testcases/OpTestAt24driver.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestHMIHandling.py $
+# $Source: op-test-framework/testcases/OpTestHMIHandling.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestHeartbeat.py $
+# $Source: op-test-framework/testcases/OpTestHeartbeat.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestI2Cdriver.py
+++ b/testcases/OpTestI2Cdriver.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestI2Cdriver.py $
+# $Source: op-test-framework/testcases/OpTestI2Cdriver.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestIPMILockMode.py $
+# $Source: op-test-framework/testcases/OpTestIPMILockMode.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestIPMIPowerControl.py
+++ b/testcases/OpTestIPMIPowerControl.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestIPMIPowerControl.py $
+# $Source: op-test-framework/testcases/OpTestIPMIPowerControl.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestInbandIPMI.py $
+# $Source: op-test-framework/testcases/OpTestInbandIPMI.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestInbandUsbInterface.py $
+# $Source: op-test-framework/testcases/OpTestInbandUsbInterface.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestMtdPnorDriver.py $
+# $Source: op-test-framework/testcases/OpTestMtdPnorDriver.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestOOBIPMI.py
+++ b/testcases/OpTestOOBIPMI.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestOOBIPMI.py $
+# $Source: op-test-framework/testcases/OpTestOOBIPMI.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestPrdDriver.py $
+# $Source: op-test-framework/testcases/OpTestPrdDriver.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestRTCdriver.py $
+# $Source: op-test-framework/testcases/OpTestRTCdriver.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestSensors.py $
+# $Source: op-test-framework/testcases/OpTestSensors.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestSwitchEndianSyscall.py $
+# $Source: op-test-framework/testcases/OpTestSwitchEndianSyscall.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/OpTestSystemBootSequence.py $
+# $Source: op-test-framework/testcases/OpTestSystemBootSequence.py $
 #
 # OpenPOWER Automated Test Project
 #

--- a/testcases/__init__.py
+++ b/testcases/__init__.py
@@ -2,7 +2,7 @@
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
-# $Source: op-auto-test/testcases/__init__.py $
+# $Source: op-test-framework/testcases/__init__.py $
 #
 # OpenPOWER Automated Test Project
 #


### PR DESCRIPTION
Changed the name of the base folder in IBM PROLOG from
op-auto-test to the correct op-test-framework

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/61)
<!-- Reviewable:end -->
