### PR TITLE
Add new FWTS tests.

### DIFF
--- a/bvt/op-ci-bmc-run
+++ b/bvt/op-ci-bmc-run
@@ -36,6 +36,7 @@ sys.path.append(full_path)
 import ci.source.op_ci_bmc as op_ci_bmc
 import ci.source.op_inbound_hpm as op_inbound_hpm
 import ci.source.op_opal_fvt as op_opal_fvt
+import ci.source.op_fwts_fvt as op_fwts_fvt
 import ci.source.op_outofband_firmware_update as op_outofband_firmware_update
 import ci.source.op_firmware_component_update as op_firmware_component_update
 import ci.source.op_bmc_web_update as op_bmc_web_update

--- a/bvt/op-fwts-fvt-bvt.xml
+++ b/bvt/op-fwts-fvt-bvt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-test-framework/bvt/op-fwts-fvt-bvt.xml $                   -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+<bvts>
+
+<bvt>
+    <id>op-fwts-fvt</id>
+    <title>OP FWTS FVT BVT</title>
+    <bvt-xml>op-fwts-fvt.xml</bvt-xml>
+    <coverage/>
+</bvt>
+
+</bvts>

--- a/bvt/op-fwts-fvt.xml
+++ b/bvt/op-fwts-fvt.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-test-framework/bvt/op-fwts-fvt.xml $                       -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+
+
+<integrationtest>
+    <platform>
+
+        <test>
+            <name>Test Setup Init</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+       <test>
+            <name>FWTS: Boot System to OS</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_system_reboot()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <name>FWTS: Test Pre init</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_pre_init()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <name>FWTS: bmc_info test</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_bmc_info()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+
+        <test>
+            <name>FWTS: oops test</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_oops()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <name>FWTS: prd_info test</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_prd_info()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <name>FWTS: olog test</name>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_fwts_fvt.test_olog()"</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/ci/source/op_fwts_fvt.py
+++ b/ci/source/op_fwts_fvt.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/ci/source/op_fwts_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+"""
+.. module:: op_fwts_fvt
+    :platform: Unix
+    :synopsis: This module contains functional verification test functions
+               for Firmware Test Suite(FWTS). Corresponding source files for new FWTS
+               features will be adding in testcases directory
+
+.. moduleauthor:: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>
+
+
+"""
+import sys
+import os
+
+# Get path to base directory and append to path to get common modules
+full_path = os.path.dirname(os.path.abspath(__file__))
+full_path = full_path.split('ci')[0]
+
+sys.path.append(full_path)
+import ConfigParser
+
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from testcases.OpTestFWTS import OpTestFWTS
+
+
+def _config_read():
+    """ returns bmc system and test config options """
+    bmcConfig = ConfigParser.RawConfigParser()
+    configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
+    print configFile
+    bmcConfig.read(configFile)
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
+
+''' Read the configuration settings into global space so they can be used by
+    other functions '''
+
+bmcCfg, testCfg, hostCfg = _config_read()
+
+opTestFWTS = OpTestFWTS(bmcCfg['ip'], bmcCfg['username'],
+                        bmcCfg['password'],
+                        bmcCfg.get('usernameipmi'),
+                        bmcCfg.get('passwordipmi'),
+                        testCfg['ffdcdir'], hostCfg['hostip'],
+                        hostCfg['hostuser'], hostCfg['hostpasswd'])
+
+
+def test_init():
+    """This function validates the test config before running other functions
+    """
+
+    ''' create FFDC dir if it does not exist '''
+    ffdcDir = testCfg['ffdcdir']
+    if not os.path.exists(os.path.dirname(ffdcDir)):
+        os.makedirs(os.path.dirname(ffdcDir))
+
+    return 0
+
+
+def test_system_reboot():
+    """This function reboots the system to OS, to start FWTS tests from stable point
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_system_reboot()
+
+
+def test_pre_init():
+    """This function tests initial setup for FWTS to work i.e checking ipmitool,
+    packages, Loading necessary modules.
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_init()
+
+
+def test_bmc_info():
+    """This function tests FWTS bmc_info test
+    BMC Info
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_bmc_info()
+
+
+def test_prd_info():
+    """This function tests FWTS prd_info test
+    OPAL Processor Recovery Diagnostics Info
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_prd_info()
+
+
+def test_oops():
+    """This function tests FWTS oops test
+    Scan kernel log for Oopses.
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_oops()
+
+
+def test_olog():
+    """This function tests FWTS olog test
+    Run OLOG scan and analysis checks(opal msg log).
+        returns: int 0-success, raises exception-error
+    """
+    return opTestFWTS.test_olog()

--- a/ci/source/test_fwts_fvt.py
+++ b/ci/source/test_fwts_fvt.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/ci/source/test_fwts_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+import os
+import sys
+import op_fwts_fvt
+
+
+def test_config_check():
+    assert op_fwts_fvt.test_init() == 0
+
+
+def test_system_reboot():
+    assert op_fwts_fvt.test_system_reboot() == 0
+
+
+def test_pre_init():
+    assert op_fwts_fvt.test_pre_init() == 0
+
+
+def test_bmc_info():
+    assert op_fwts_fvt.test_bmc_info() == 0
+
+
+def test_prd_info():
+    assert op_fwts_fvt.test_prd_info() == 0
+
+
+def test_oops():
+    assert op_fwts_fvt.test_oops() == 0
+
+
+def test_olog():
+    assert op_fwts_fvt.test_olog() == 0

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -259,6 +259,7 @@ class OpTestConstants():
     # Tools, repository and utility paths
     CLONE_SKIBOOT_DIR = "/tmp/skiboot"
     PFLASH_TOOL_DIR = "/tmp/"
+    OLOG_JSON_DIR = "/root/skiboot/external/fwts/"
 
     # IPMI commands
     IPMITOOL_USB = "ipmitool -I usb "
@@ -416,3 +417,10 @@ class OpTestConstants():
     PNOR_NVRAM_PART = "NVRAM"
     PNOR_GUARD_PART = "GUARD"
     PNOR_BOOTKERNEL_PART = "BOOTKERNEL"
+
+    HOST_FWTS_BMC_INFO = "fwts bmc_info;echo $?"
+    HOST_FWTS_OLOG = "fwts olog -j"
+    HOST_FWTS_OOPS = "fwts oops;echo $?"
+    HOST_FWTS_PRD_INFO = "fwts prd_info;echo $?"
+    HOST_FWTS_REMOVE_EXISTING_RESULTS_LOG = "rm -f results.log"
+    HOST_FWTS_RESULTS_LOG = "cat results.log; echo $?"

--- a/testcases/OpTestFWTS.py
+++ b/testcases/OpTestFWTS.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestFWTS.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestFWTS.py
+#  This package will execute and test Firmware Test Suite tests.
+#
+#   bmc_info    BMC Info
+#   prd_info    Run OLOG(OPAL Log) scan and analysis checks.
+#   oops        Scan kernel log for Oopses.
+#   olog        OPAL Processor Recovery Diagnostics Info
+#
+#   FWTS Configuration/Installation process steps:
+#   Currently fwts tool installed from distro released one, doesn't contain all the
+#   tests implemented for power systems. In order to execute and work above fwts tests user need to
+#   follow below steps to build from the source.
+#   1. Clone fwts source:
+#       git clone git://kernel.ubuntu.com/hwe/fwts.git
+#
+#   2. Install dependencies:
+#       sudo apt-get install autoconf automake libglib2.0-dev libtool libpcre3-dev libjson0-dev flex bison dkms libfdt-dev
+#
+#   3. Build and install:
+#       autoreconf -ivf
+#       ./configure
+#       make
+#
+#   4. Export the tool(fwts binary) into current path
+#       export PATH=(path_to_fwts_binary):$PATH
+#
+#   5. In order to work olog test, user need to generate olog.json file from skiboot code into below directory
+#       git clone https://github.com/open-power/skiboot
+#       cd ~/skiboot/external/fwts
+#       ./generate-fwts-olog
+#       sudo fwts olog -j /root/skiboot/external/fwts/
+#
+#   Checking of fwts tool installed or not, is not added in this version, will add that check later once
+#   that fwts tool contains all the above tests in the distro(ubuntu) released tool.
+#
+
+
+import time
+import subprocess
+import re
+import sys
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestHost import OpTestHost
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestFWTS():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostPasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                 i_hostuser, i_hostPasswd)
+        self.util = OpTestUtil()
+
+
+    ##
+    # @brief This function just brings the system to host OS.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_system_reboot(self):
+        print "Testing FWTS: Booting system to OS"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
+
+        print "Gathering the OPAL msg logs"
+        self.cv_HOST.host_gather_opal_msg_log()
+        return BMC_CONST.FW_SUCCESS
+
+
+    ##
+    # @brief This function will cover following test steps
+    #        1. It will get the OS level installed on power platform
+    #        2. It will check for kernel version installed on the Open Power Machine
+    #        3. It will check for ipmitool command existence and ipmitool package
+    #        4. Load the necessary ipmi modules based on config values
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_init(self):
+        # Get OS level
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
+
+        # Get kernel version
+        l_kernel = self.cv_HOST.host_get_kernel_version()
+
+        # Checking for ipmitool command and package
+        self.cv_HOST.host_check_command("ipmitool")
+
+        l_pkg = self.cv_HOST.host_check_pkg_for_utility(l_oslevel, "ipmitool")
+        print "Installed package: %s" % l_pkg
+
+        # loading below ipmi modules based on config option
+        # ipmi_devintf, ipmi_powernv and ipmi_masghandler
+        self.cv_HOST.host_load_module_based_on_config(l_kernel, BMC_CONST.CONFIG_IPMI_DEVICE_INTERFACE,
+                                                      BMC_CONST.IPMI_DEV_INTF)
+        self.cv_HOST.host_load_module_based_on_config(l_kernel, BMC_CONST.CONFIG_IPMI_POWERNV,
+                                                      BMC_CONST.IPMI_POWERNV)
+        self.cv_HOST.host_load_module_based_on_config(l_kernel, BMC_CONST.CONFIG_IPMI_HANDLER,
+                                                      BMC_CONST.IPMI_MSG_HANDLER)
+
+
+    ##
+    # @brief This function will execute FWTS:bmc_info test
+    #        BMC Info
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_bmc_info(self):
+        print "FWTS: executing bmc_info test"
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_host_login(l_con)
+        self.cv_IPMI.ipmi_host_set_unique_prompt(l_con)
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_REMOVE_EXISTING_RESULTS_LOG)
+        l_res = self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_BMC_INFO)
+        self.read_results_log()
+        if int(l_res[-1]):
+            l_msg = "FWTS: bmc_info test failed"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_close_console(l_con)
+        return BMC_CONST.FW_SUCCESS
+
+
+    ##
+    # @brief This function will execute FWTS:prd_info test
+    #        OPAL Processor Recovery Diagnostics Info
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_prd_info(self):
+        print "FWTS: Running prd_info test"
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_host_login(l_con)
+        self.cv_IPMI.ipmi_host_set_unique_prompt(l_con)
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_REMOVE_EXISTING_RESULTS_LOG)
+        l_res = self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_PRD_INFO)
+        self.read_results_log()
+        if int(l_res[-1]):
+            l_msg = "FWTS prd_info test failed"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_close_console(l_con)
+        return BMC_CONST.FW_SUCCESS
+
+
+    ##
+    # @brief This function will execute FWTS:olog test
+    #        Run OLOG scan and analysis checks.
+    #        In-order to work this test user needs to generate olog.json file in below directory.
+    #        git clone https://github.com/open-power/skiboot
+    #        cd ~/skiboot/external/fwts
+    #        ./generate-fwts-olog
+    #        sudo ./fwts olog -j /root/skiboot/external/fwts/
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_olog(self):
+        print "FWTS: Running olog test"
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_host_login(l_con)
+        self.cv_IPMI.ipmi_host_set_unique_prompt(l_con)
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_REMOVE_EXISTING_RESULTS_LOG)
+        l_res = self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_OLOG + BMC_CONST.OLOG_JSON_DIR + ";echo $?")
+        self.read_results_log()
+        if int(l_res[-1]):
+            l_msg = "FWTS olog test failed"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_close_console(l_con)
+        return BMC_CONST.FW_SUCCESS
+
+
+    ##
+    # @brief This function will execute FWTS:oops test
+    #        Scan kernel log for Oopses.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_oops(self):
+        print "FWTS: Running oops test"
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_host_login(l_con)
+        self.cv_IPMI.ipmi_host_set_unique_prompt(l_con)
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_REMOVE_EXISTING_RESULTS_LOG)
+        l_res = self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_OOPS)
+        self.read_results_log()
+        if int(l_res[-1]):
+            l_msg = "FWTS oops test failed"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_close_console(l_con)
+        return BMC_CONST.FW_SUCCESS
+
+
+    ##
+    # @brief This function will just print results.log file for further analysis.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def read_results_log(self):
+        print "\nFWTS: Printing test results"
+        l_res = self.cv_IPMI.run_host_cmd_on_ipmi_console(BMC_CONST.HOST_FWTS_RESULTS_LOG)
+        if int(l_res[-1]):
+            l_msg = "\nFWTS: unable to get results log file"
+            raise OpTestError(l_msg)
+        return BMC_CONST.FW_SUCCESS


### PR DESCRIPTION
This patch adds new Firmware Test Suite tests into the framework, FWTS is test suite which tests firmare basic sanity checks.

Below are the tests added.
        bmc_info        BMC Info
        olog            Run OLOG(OPAL Log) scan and analysis checks.
        oops            Scan kernel log for Oopses.
        prd_info        OPAL Processor Recovery Diagnostics Info

This test case works when the corresponding FWTS tool is installed in the ubuntu host OS.
and also olog test assumes that corresponding olog.json file is generated from the skiboot code
into the directory OLOG_JSON_DIR = "/root/skiboot/external/fwts"

And all further fwts tests will be added into this op_fwts_fvt.xml

Signed-off-by: Pridhiviraj <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/62)
<!-- Reviewable:end -->
