### PR TITLE
Get test_env / restrict-env working, enable testing FSP systems

### DIFF
--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -67,9 +67,27 @@
         </test>
 
         <test>
-            <name>IPL and wait for working state</name>
+            <name>IPL via IPMI, wait for Boot Status sensor to indicate booted</name>
+	    <!-- We can't test this on FSP machines due to them not having
+		 the Boot Status sensor. Technically this should be available
+		 on other BMC systems though.
+		 Eventually, once FSP bug is fixed, this should work there too.
+	    -->
+	    <restrict-env>astbmc</restrict-env>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipl_wait_for_working_state()"</cmd>
+              <cmd>op-ci-bmc-run "op_ci_bmc.ipl_wait_for_working_state()"</cmd>
+	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
+            </testcase>
+        </test>
+
+        <test>
+            <name>IPL via IPMI, sniff for Login prompt</name>
+	    <!-- Like the previous test, but we expect a Login prompt.
+		 This should work on all systems.
+	    -->
+            <testcase>
+	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_on()"</cmd>
+              <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_ipl_wait_for_login()"</cmd>
             </testcase>
         </test>
 

--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -43,16 +43,26 @@
         </test>
 
         <test>
-            <name>Out-of-band BMC and Host firmware update with HPM</name>
+            <name>IPMI Host Power off</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.outofband_fwandpnor_update_hpm()"</cmd>
+                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
             </testcase>
         </test>
 
         <test>
-            <name>Validate host booted</name>
+          <name>Out-of-band BMC and Host firmware update with HPM</name>
+	  <restrict-env>astbmc</restrict-env>
+	  <restrict-env>flash</restrict-env>
+          <testcase>
+            <cmd>op-ci-bmc-run "op_ci_bmc.outofband_fwandpnor_update_hpm()"</cmd>
+          </testcase>
+        </test>
+
+        <test>
+            <name>Power on and validate host booted</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.validate_host()"</cmd>
+	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_on()"</cmd>
+              <cmd>op-ci-bmc-run "op_ci_bmc.validate_host()"</cmd>
             </testcase>
         </test>
 

--- a/bvt/run-op-it
+++ b/bvt/run-op-it
@@ -35,7 +35,7 @@ use FindBin;
 use XML::LibXML;
 use lib "$FindBin::Bin";
 
-my $test_env = "";
+my %test_env = {};
 
 my $usage = "Run OpenPower Automated Integration Test
 
@@ -49,7 +49,7 @@ OPTIONS is one or more of:
           xml : just display the resulting XML after include processing and variable substitution
           cmd : just display all commands instead of running them
    --quiet : be quiet and just output TAP
-   --testenv xxx : is this test to run only in specific environment with this tag
+   --testenv x,y,z : Specifies test environment properties
    --verbose : display additional debug information while executing
    --xxx yyy : any \"--\" option other than the ones listed above is assumed
           to be a .xml file substitution variable. In this case, all
@@ -73,7 +73,7 @@ cmd => '$',
 arg => '$',
 ffdc   => '$',
 exitonerror => '$',
-restrict_env => '$'
+restrict_env => '@'
 );
 
 1;
@@ -333,20 +333,22 @@ sub runAllTests
         {
 	    $testnr++;
 
-            my $restrict_env = ${$test->findnodes('./restrict-env')}[0];
-	    $restrict_env = $restrict_env->textContent if $restrict_env;
-
             $testgrp = ${$test->findnodes('./name')}[0];
 	    $testgrp = ${$test->findnodes('./title')}[0] if !$testgrp;
 	    $testgrp = $testgrp->textContent if $testgrp;
 	    $testgrp = $testnr if !$testgrp;
 
-            # Check for env restriction at <test> level
-            if (($restrict_env ne "") && ($restrict_env ne $test_env))
-            {
-                printMsg("Skipping test due to not running in $restrict_env environment: $testgrp\n");
-                next;
-            }
+	    my @skip;
+	    foreach my $r_node ($test->findnodes('./restrict-env'))
+	    {
+		my $restriction = $r_node->textContent;
+		push @skip, $restriction if ! defined $test_env{$restriction};
+	    }
+	    if (@skip) {
+		printMsg("Skipping $testgrp due to restricitons: ".join(',', @skip)."\n");
+		next;
+	    }
+
             printMsg("Starting Test: $testgrp\n");
 
             # Create the contained testcases
@@ -361,13 +363,16 @@ sub runAllTests
 		$ffdc = $ffdc->textContent if $ffdc;
 		my $exitonerror = ${$testcase->findnodes('./exitonerror')}[0];
 		$exitonerror = $exitonerror->textContent if $exitonerror;
-		my $restrict_env = ${$testcase->findnodes('./restrict_env')}[0];
-		$restrict_env = $restrict_env->textContent if $restrict_env;
+		my @restrict_env;
+		foreach my $r_node ($testcase->findnodes('./restrict_env'))
+		{
+		    push @restrict_env, $r_node->textContent;
+		}
 
                 push(@testcases_to_run, new Testcase(id=>"$testgrp.$testcase_index",
 					cmd=>$cmd, arg=>$arg, ffdc=>$ffdc,
 					exitonerror=>$exitonerror,
-					restrict_env=>$restrict_env));
+					restrict_env=>\@restrict_env));
             }
 	}
     }
@@ -380,10 +385,13 @@ sub runAllTests
 	vprint "testcaseid: $testcaseid\n";
 
 	# Check for env restriction at <testcase> level
-	my $restrict_env = $tc_ref->restrict_env;
-	if (($restrict_env ne "") && ($restrict_env ne $test_env))
+	my @skip;
+	foreach my $restriction (@{$tc_ref->restrict_env})
 	{
-	    skip("Skipping testcase $testcase_index due to not running in $restrict_env environment\n", 1, 1);
+	    push @skip, $restriction if ! defined $test_env{$restriction};
+	}
+	if (@skip) {
+	    printMsg("Skipping $testcaseid due to restricitons: ".join(',',@skip)."\n");
 	    next;
 	}
 
@@ -473,6 +481,7 @@ $xmlvars{verbose} = "";
 
 my $help;
 my $resdir;
+my $test_env;
 
 GetOptions('help|?|h' => \$help,
 	   'verbose' => sub { set_verbose(1);
@@ -485,6 +494,8 @@ GetOptions('help|?|h' => \$help,
     ) or syntax();
 
 syntax() if $help;
+
+$test_env{$_} = 1 foreach (split /,/,$test_env);
 
 my @argv = @ARGV;
 while (my $arg = shift @argv)

--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -212,6 +212,15 @@ def ipl_wait_for_working_state(timeout=10):
 
     return opTestSys.sys_ipl_wait_for_working_state()
 
+def ipmi_ipl_wait_for_login(timeout=10):
+    """On IPL, wait for either the Petitboot prompt or a linux login: prompt.
+    This is used as a work-around for systems that cannot use the 'Boot Status'
+    IPMI sensor (e.g. IBM FSP based systems).
+    Similar to ipl_wait_for_working_state.
+
+    :returns: int -- 0: success, non-zero: error
+    """
+    return opTestSys.sys_ipmi_ipl_wait_for_login()
 
 def ipmi_sel_check():
     """This function dumps the sel log and looks for specific hostboot error

--- a/ci/source/op_occ_fvt.py
+++ b/ci/source/op_occ_fvt.py
@@ -63,15 +63,15 @@ def _config_read():
 bmcCfg, testCfg, hostCfg = _config_read()
 opTestEnergyScale = OpTestEnergyScale(bmcCfg['ip'], bmcCfg['username'],
                                       bmcCfg['password'],
-                                      bmcCfg['usernameipmi'],
-                                      bmcCfg['passwordipmi'],
+                                      bmcCfg.get('usernameipmi'),
+                                      bmcCfg.get('passwordipmi'),
                                       testCfg['ffdcdir'], hostCfg['hostip'],
                                       hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestOCC = OpTestOCC(bmcCfg['ip'], bmcCfg['username'],
                       bmcCfg['password'],
-                      bmcCfg['usernameipmi'],
-                      bmcCfg['passwordipmi'],
+                      bmcCfg.get('usernameipmi'),
+                      bmcCfg.get('passwordipmi'),
                       testCfg['ffdcdir'], hostCfg['hostip'],
                       hostCfg['hostuser'], hostCfg['hostpasswd'])
 

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -167,22 +167,22 @@ opTestIPMIPowerControl = OpTestIPMIPowerControl(bmcCfg['ip'], bmcCfg['username']
 
 opTestInbandUsbInterface = OpTestInbandUsbInterface(bmcCfg['ip'], bmcCfg['username'],
                                                     bmcCfg['password'],
-                                                    bmcCfg['usernameipmi'],
-                                                    bmcCfg['passwordipmi'],
+                                                    bmcCfg.get('usernameipmi'),
+                                                    bmcCfg.get('passwordipmi'),
                                                     testCfg['ffdcdir'], hostCfg['hostip'],
                                                     hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestOOBIPMI = OpTestOOBIPMI(bmcCfg['ip'], bmcCfg['username'],
                                         bmcCfg['password'],
-                                        bmcCfg['usernameipmi'],
-                                        bmcCfg['passwordipmi'],
+                                        bmcCfg.get('usernameipmi'),
+                                        bmcCfg.get('passwordipmi'),
                                         testCfg['ffdcdir'], hostCfg['hostip'],
                                         hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 opTestSystemBootSequence = OpTestSystemBootSequence(bmcCfg['ip'], bmcCfg['username'],
                                                     bmcCfg['password'],
-                                                    bmcCfg['usernameipmi'],
-                                                    bmcCfg['passwordipmi'],
+                                                    bmcCfg.get('usernameipmi'),
+                                                    bmcCfg.get('passwordipmi'),
                                                     testCfg['ffdcdir'], hostCfg['hostip'],
                                                     hostCfg['hostuser'], hostCfg['hostpasswd'])
 

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -312,6 +312,30 @@ class OpTestIPMI():
         return BMC_CONST.FW_SUCCESS
 
 
+    def ipmi_ipl_wait_for_login(self, l_con, timeout=10):
+        l_rc = l_con.expect_exact(BMC_CONST.IPMI_SOL_CONSOLE_ACTIVATE_OUTPUT, timeout=120)
+        if l_rc == 0:
+            print "IPMI: sol console activated"
+        else:
+            l_msg = "Error: not able to get IPMI console"
+            raise OpTestError(l_msg)
+        time.sleep(BMC_CONST.SHORT_WAIT_IPL)
+        l_con.send("\r")
+        time.sleep(BMC_CONST.SHORT_WAIT_IPL)
+        l_rc = l_con.expect_exact(BMC_CONST.IPMI_CONSOLE_EXPECT_ENTER_OUTPUT, timeout=120)
+        if l_rc == BMC_CONST.IPMI_CONSOLE_EXPECT_LOGIN:
+            return BMC_CONST.FW_SUCCESS
+        elif l_rc in BMC_CONST.IPMI_CONSOLE_EXPECT_PETITBOOT:
+            return BMC_CONST.FW_SUCCESS
+        elif l_rc in BMC_CONST.IPMI_CONSOLE_EXPECT_RANDOM_STATE:
+            l_msg = "Error: system is in random state"
+            raise OpTestError(l_msg)
+        else:
+            l_con.expect(pexpect.TIMEOUT, timeout=30)
+            print l_con.before
+            raise OpTestError("Timeout waiting for IPL")
+        return BMC_CONST.FW_SUCCESS
+
     ##
     # @brief This function waits for system to reach standby state or soft off. The
     #        marker for standby state is the Host Status sensor which reflects the ACPI

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -186,6 +186,14 @@ class OpTestSystem():
             return BMC_CONST.FW_FAILED
         return rc
 
+    def sys_ipmi_ipl_wait_for_login(self,i_timeout=10):
+        l_con = self.sys_get_ipmi_console()
+        try:
+            rc = self.cv_IPMI.ipmi_ipl_wait_for_login(l_con, i_timeout)
+        except OpTestError as e:
+            return BMC_CONST.FW_FAILED
+        return rc
+
     ##
     # @brief Wait for system to reach standby or[S5/G2: soft-off]
     #

--- a/run
+++ b/run
@@ -167,9 +167,9 @@ sub create_config_file {
     print $f "\n";
     print $f "[test]\n";
     print $f "ffdcdir = ".cwd()."\n";
-    my $firmware_path = get_firmware_path($test_firmware, $platform);
-    my $firmware_image = get_firmware_image_name($platform);
     unless ($noflash) {
+	my $firmware_path = get_firmware_path($test_firmware, $platform);
+	my $firmware_image = get_firmware_image_name($platform);
 	print $f "imagedir = ".cwd()."/$firmware_path\n";
 	print $f "imagename = $firmware_image\n";
     }
@@ -214,12 +214,18 @@ foreach my $m (@machines)
     # In theory, machines can have > 1 host IP and > 1 BMC
     # This code is currently likely broken for that.
 
+    my @testenv;
+    push (@testenv, ($m->findnodes('./bmc/bmc-type'))->to_literal);
+    push (@testenv, 'noflash') if $noflash;
+    push (@testenv, 'flash') if !$noflash;
+
     print "# Running test for $platform on $name\n";
     $cmd = "(cd bvt; PATH=.:\$PATH ./run-op-bvt ";
     $cmd .= " --quiet" unless $verbose;
     $cmd .= cmd_param('bmcip',$m,'./bmc/hostname');
     $cmd .= cmd_param('bmcuser',$m,'./bmc/user');
     $cmd .= cmd_param('bmcpwd',$m,'./bmc/password');
+    $cmd .= " --testenv ".join(',', @testenv);
     $cmd .= cmd_param('usernameipmi',$m,'./bmc/ipmi-user');
     $cmd .= cmd_param('passwordipmi',$m,'./bmc/ipmi-password');
     $cmd .= cmd_param('hostip',$m,'./host/hostname');

--- a/run
+++ b/run
@@ -80,13 +80,11 @@ syntax() if $help;
 die "The directory '$test_result' already exists!
 Remove previous test results and run again." if -e $test_result;
 
-mkdir $test_result;
+die "ERROR: you must specify a machines XML file to test\n" if ($machines_xml eq "");
 
-if ($machines_xml eq "")
-{
-    print STDERR "ERROR: you must specify a machines XML file to test\n";
-    exit(1);
-}
+die "No machine specified to run test on." unless (defined $machine);
+
+mkdir $test_result;
 
 my $parser = XML::LibXML->new();
 my $dom = XML::LibXML->load_xml(location => $machines_xml);


### PR DESCRIPTION
This pull req gets enough of the test environment/restrict-env working so that when we ./run with --noflash we don't attempt to do a HPM update. Since the HPM update test did a bit of power off/on things, we work around that for --noflash test runs.

This also gets us closer to running on an FSP machine as we exclude the HPM update on non-astbmc based BMCs.

We also mess about with the fun times that is the absence of "Boot Status" on FSP systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/63)
<!-- Reviewable:end -->
