### PR TITLE
Add new OCC and Energy scale tests.

### DIFF
--- a/bvt/op-occ-fvt.xml
+++ b/bvt/op-occ-fvt.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IBM_PROLOG_BEGIN_TAG                                                   -->
+<!-- This is an automatically generated prolog.                             -->
+<!--                                                                        -->
+<!-- $Source: op-test-framework/bvt/op-occ-fvt.xml $                            -->
+<!--                                                                        -->
+<!-- OpenPOWER Automated Test Project                                       -->
+<!--                                                                        -->
+<!-- Contributors Listed Below - COPYRIGHT 2015                             -->
+<!-- [+] International Business Machines Corp.                              -->
+<!--                                                                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--     http://www.apache.org/licenses/LICENSE-2.0                         -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- IBM_PROLOG_END_TAG                                                     -->
+
+<integrationtest>
+    <platform>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_init()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_energy_scale_at_standby_state()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_energy_scale_at_runtime_state()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_dcmi_at_standby_and_runtime_states()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_occ_reset_functionality()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <testcase>
+                <cmd>op-ci-bmc-run "op_occ_fvt.test_occ_enable_disable_functionality()"</cmd>
+                <exitonerror>yes</exitonerror>
+            </testcase>
+        </test>
+
+    </platform>
+</integrationtest>

--- a/ci/source/op_occ_fvt.py
+++ b/ci/source/op_occ_fvt.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/ci/source/op_occ_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+"""
+.. module:: op_occ_fvt
+    :platform: Unix
+    :synopsis: This module contains functional verification test functions
+               for OCC and HBRT firmware. Corresponding source files for these
+               features will be adding in testcases directory
+
+.. moduleauthor:: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>
+
+
+"""
+import sys
+import os
+
+# Get path to base directory and append to path to get common modules
+full_path = os.path.dirname(os.path.abspath(__file__))
+full_path = full_path.split('ci')[0]
+
+sys.path.append(full_path)
+import ConfigParser
+
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from testcases.OpTestEnergyScale import OpTestEnergyScale
+from testcases.OpTestOCC import OpTestOCC
+
+
+def _config_read():
+    """ returns bmc system and test config options """
+    bmcConfig = ConfigParser.RawConfigParser()
+    configFile = os.path.join(os.path.dirname(__file__), 'op_ci_tools.cfg')
+    print configFile
+    bmcConfig.read(configFile)
+    return dict(bmcConfig.items('bmc')), dict(bmcConfig.items('test')), dict(bmcConfig.items('host'))
+
+''' Read the configuration settings into global space so they can be used by
+    other functions '''
+
+bmcCfg, testCfg, hostCfg = _config_read()
+opTestEnergyScale = OpTestEnergyScale(bmcCfg['ip'], bmcCfg['username'],
+                                      bmcCfg['password'],
+                                      bmcCfg['usernameipmi'],
+                                      bmcCfg['passwordipmi'],
+                                      testCfg['ffdcdir'], hostCfg['hostip'],
+                                      hostCfg['hostuser'], hostCfg['hostpasswd'])
+
+opTestOCC = OpTestOCC(bmcCfg['ip'], bmcCfg['username'],
+                      bmcCfg['password'],
+                      bmcCfg['usernameipmi'],
+                      bmcCfg['passwordipmi'],
+                      testCfg['ffdcdir'], hostCfg['hostip'],
+                      hostCfg['hostuser'], hostCfg['hostpasswd'])
+
+
+def test_init():
+    """This function validates the test config before running other functions
+    """
+
+    ''' create FFDC dir if it does not exist '''
+    ffdcDir = testCfg['ffdcdir']
+    if not os.path.exists(os.path.dirname(ffdcDir)):
+        os.makedirs(os.path.dirname(ffdcDir))
+
+    return 0
+
+
+def test_energy_scale_at_standby_state():
+    """This function tests the platform energy scale tests at standby state
+    returns: int 0-success, raises exception-error
+    """
+    return opTestEnergyScale.test_energy_scale_at_standby_state()
+
+
+def test_energy_scale_at_runtime_state():
+    """This function tests the platform energy scale tests at runtime
+    returns: int 0-success, raises exception-error
+    """
+    return opTestEnergyScale.test_energy_scale_at_runtime_state()
+
+
+def test_dcmi_at_standby_and_runtime_states():
+    """This function tests the dcmi commands at both standby and runtime state
+    returns: int 0-success, raises exception-error
+    """
+    return opTestEnergyScale.test_dcmi_at_standby_and_runtime_states()
+
+
+def test_occ_reset_functionality():
+    """This function tests OCC Reset functionality using opal-prd tool.
+    returns: int 0-success, raises exception-error
+    """
+    return opTestOCC.test_occ_reset_functionality()
+
+
+def test_occ_enable_disable_functionality():
+    """This function tests the OCC Enable/Disable functionality using opal-prd tool.
+    returns: int 0-success, raises exception-error
+    """
+    return opTestOCC.test_occ_enable_disable_functionality()

--- a/ci/source/test_occ_fvt.py
+++ b/ci/source/test_occ_fvt.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/ci/source/test_occ_fvt.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+import os
+import sys
+import op_occ_fvt
+
+
+def test_config_check():
+    assert op_occ_fvt.test_init() == 0
+
+
+def test_energy_scale_at_standby_state():
+    assert op_occ_fvt.test_energy_scale_at_standby_state() == 0
+
+
+def test_energy_scale_at_runtime_state():
+    assert op_occ_fvt.test_energy_scale_at_runtime_state() == 0
+
+
+def test_dcmi_at_standby_and_runtime_states():
+    assert op_occ_fvt.test_dcmi_at_standby_and_runtime_states() == 0
+
+
+def test_occ_reset_functionality():
+    assert op_occ_fvt.test_occ_reset_functionality() == 0
+
+
+def test_occ_enable_disable_functionality():
+    assert op_occ_fvt.test_occ_enable_disable_functionality() == 0

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -1,0 +1,330 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestEnergyScale.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestEnergyScale.py
+#  
+
+import time
+import subprocess
+import commands
+import re
+import sys
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestHost import OpTestHost
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestEnergyScale():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostPasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief  This function will test Energy scale features at standby state
+    #         1. Power OFF the system.
+    #         2. Validate below Energy scale features at standby state
+    #            ipmitool dcmi power get_limit                :Get the configured power limits.
+    #            ipmitool dcmi power set_limit limit <value>  :Power Limit Requested in Watts.
+    #            ipmitool dcmi power activate                 :Activate the set power limit.
+    #            ipmitool dcmi power deactivate               :Deactivate the set power limit.
+    #         3. Once platform power limit activated execute below dcmi commands at standby state.
+    #            ipmitool dcmi discover                       :This command is used to discover  
+    #                                                           supported  capabilities in DCMI.
+    #            ipmitool dcmi power reading                  :Get power related readings from the system.
+    #            ipmitool dcmi power get_limit                :Get the configured power limits.
+    #            ipmitool dcmi power sensors                  :Prints the available DCMI sensors.
+    #            ipmitool dcmi get_temp_reading               :Get Temperature Sensor Readings.
+    #         4. Power ON the system.
+    #         5. Check after system booted to runtime, whether occ's are active or not.
+    #         6. Again in runtime execute all dcmi commands to check the functionality.
+    #
+    # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
+    #
+    def test_energy_scale_at_standby_state(self):
+        print "Energy Scale Test 1: Get, Set, activate and deactivate platform power limit at power off"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_sdr_clear()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_activate_power_limit()
+        self.cv_IPMI.ipmi_set_power_limit(BMC_CONST.PLATFORM_POWER_LIMIT_HIGH)
+        self.cv_IPMI.ipmi_activate_power_limit()
+        self.cv_IPMI.ipmi_deactivate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_deactivate_power_limit()
+        self.cv_IPMI.ipmi_set_power_limit(BMC_CONST.PLATFORM_POWER_LIMIT_LOW)
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_set_power_limit(BMC_CONST.PLATFORM_POWER_LIMIT_HIGH)
+        self.cv_IPMI.ipmi_get_power_limit()
+        print "Get All dcmi readings at power off"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        l_status = self.cv_IPMI.ipmi_get_occ_status()
+        print l_status
+        if BMC_CONST.OCC_DEVICE_ENABLED in l_status:
+            print "OCC's are up and active"
+        else:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+        print self.cv_IPMI.ipmi_get_power_limit()
+        print "Get All dcmi readings at runtime"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+
+
+    ##
+    # @brief  This function will test Energy scale features at standby state
+    #         1. Power OFF the system.
+    #         2. Power On the system to boot to host OS
+    #         2. Validate below Energy scale features at runtime state
+    #            ipmitool dcmi power get_limit                :Get the configured power limits.
+    #            ipmitool dcmi power set_limit limit <value>  :Power Limit Requested in Watts.
+    #            ipmitool dcmi power activate                 :Activate the set power limit.
+    #            ipmitool dcmi power deactivate               :Deactivate the set power limit.
+    #         3. Once platform power limit activated execute below dcmi commands at runtime state.
+    #            ipmitool dcmi discover                       :This command is used to discover  
+    #                                                           supported  capabilities in DCMI.
+    #            ipmitool dcmi power reading                  :Get power related readings from the system.
+    #            ipmitool dcmi power get_limit                :Get the configured power limits.
+    #            ipmitool dcmi power sensors                  :Prints the available DCMI sensors.
+    #            ipmitool dcmi get_temp_reading               :Get Temperature Sensor Readings.
+    #         4. Issue Power OFF/ON to check whether system boots after setting platform power limit at runtime.
+    #         5. Again in runtime execute all dcmi commands to check the functionality.
+    #
+    # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
+    #
+    def test_energy_scale_at_runtime_state(self):
+        print "Energy Scale Test 2: Get, Set, activate and deactivate platform power limit at runtime"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Get All dcmi readings at power off"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+        self.cv_IPMI.ipmi_sdr_clear()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        l_status = self.cv_IPMI.ipmi_get_occ_status()
+        print l_status
+        if BMC_CONST.OCC_DEVICE_ENABLED in l_status:
+            print "OCC's are up and active"
+        else:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_set_power_limit(BMC_CONST.PLATFORM_POWER_LIMIT_HIGH)
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_deactivate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_set_power_limit(BMC_CONST.PLATFORM_POWER_LIMIT_LOW)
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_deactivate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        self.cv_IPMI.ipmi_activate_power_limit()
+        print self.cv_IPMI.ipmi_get_power_limit()
+        print "Get All dcmi readings at runtime"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        l_status = self.cv_IPMI.ipmi_get_occ_status()
+        print l_status
+        if BMC_CONST.OCC_DEVICE_ENABLED in l_status:
+            print "OCC's are up and active"
+        else:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+        print "Get All dcmi readings at runtime"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+
+    ##
+    # @brief  This function will test below dcmi commands at both standby and runtime states
+    #            ipmitool dcmi discover                       :This command is used to discover  
+    #                                                           supported  capabilities in DCMI.
+    #            ipmitool dcmi power reading                  :Get power related readings from the system.
+    #            ipmitool dcmi power get_limit                :Get the configured power limits.
+    #            ipmitool dcmi power sensors                  :Prints the available DCMI sensors.
+    #            ipmitool dcmi get_temp_reading               :Get Temperature Sensor Readings.
+    #            ipmitool dcmi get_mc_id_string               :Get management controller identifier string.
+    #            ipmitool dcmi get_conf_param                 :Get DCMI Configuration Parameters.
+    #            ipmitool dcmi oob_discover                   :Ping/Pong Message for DCMI Discovery.
+    #
+    # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
+    #
+    def test_dcmi_at_standby_and_runtime_states(self):
+        print "Energy scale Test 3: Get Sensors, Temperature and Power reading's at power off and runtime"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        print "Get All dcmi readings at power off"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+        print "Performing a IPMI Power ON Operation"
+        # Perform a IPMI Power ON Operation
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        l_status = self.cv_IPMI.ipmi_get_occ_status()
+        print l_status
+        if BMC_CONST.OCC_DEVICE_ENABLED in l_status:
+            print "OCC's are up and active"
+        else:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+        print "Get All dcmi readings at runtime"
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_DISCOVER)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_SENSORS)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_TEMP_READING)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_GET_CONF_PARAM)
+        self.run_ipmi_cmd(BMC_CONST.IPMI_DCMI_OOB_DISCOVER)
+
+
+    ##
+    # @brief  It will execute and test the return code of ipmi command.
+    #
+    # @param i_cmd @type string:The ipmitool command, for example: chassis power on; echo $?
+    #
+    # @return l_res @type list: output of command or raise OpTestError
+    #
+    def run_ipmi_cmd(self, i_cmd):
+        l_cmd = i_cmd
+        l_res = self.cv_IPMI.ipmitool_execute_command(l_cmd)
+        print l_res
+        l_res = l_res.splitlines()
+        if int(l_res[-1]):
+            l_msg = "IPMI: command failed %c" % l_cmd
+            raise OpTestError(l_msg)
+        return l_res

--- a/testcases/OpTestOCC.py
+++ b/testcases/OpTestOCC.py
@@ -1,0 +1,197 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestOCC.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+# @package OpTestOCC
+#  OCC Control package for OpenPower testing.
+#
+#  This class will test the functionality of following.
+#  1. OCC Reset\Enable\Disable
+
+import time
+import subprocess
+import re
+import sys
+import os
+import random
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestHost import OpTestHost
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestOCC():
+    ## Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostPasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                 i_hostuser, i_hostPasswd)
+        self.util = OpTestUtil()
+
+
+    ##
+    # @brief This function is used to test OCC Reset funtionality in BMC based systems.
+    #        OCC Reset reload is limited to 3 times per full power cycle.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_occ_reset_functionality(self):
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            #raise OpTestError(l_msg)
+        print "OPAL-PRD: OCC Enable"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_ENABLE)
+        print "OPAL-PRD: OCC DISABLE"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_DISABLE)
+        print "OPAL-PRD: OCC RESET"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_RESET)
+        time.sleep(60)
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            #raise OpTestError(l_msg)
+        print "OPAL-PRD: OCC Enable"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_ENABLE)
+        print "OPAL-PRD: OCC DISABLE"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_DISABLE)
+        print "OPAL-PRD: OCC RESET"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_RESET)
+        time.sleep(60)
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            #raise OpTestError(l_msg)
+        print "OPAL-PRD: OCC Enable"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_ENABLE)
+        print "OPAL-PRD: OCC DISABLE"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_DISABLE)
+        print "OPAL-PRD: OCC RESET"
+        self.cv_HOST.host_run_command(BMC_CONST.OCC_RESET)
+        time.sleep(60)
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state, rebooting the system"
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+
+
+    ##
+    # @brief This function is used to test OCC Enable and Disable funtionality in BMC based systems.
+    #        There is no limit for occ enable and disable, as of now doing 10 times in a loop.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_occ_enable_disable_functionality(self):
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+        for count in range(1,10):
+            print "OPAL-PRD: OCC Enable"
+            self.cv_HOST.host_run_command(BMC_CONST.OCC_ENABLE)
+            print "OPAL-PRD: OCC Disable"
+            self.cv_HOST.host_run_command(BMC_CONST.OCC_DISABLE)
+            time.sleep(60)
+            if self.check_occ_status() == BMC_CONST.FW_FAILED:
+                l_msg = "OCC's are not in active state"
+                #raise OpTestError(l_msg)
+        print "Performing a IPMI Power OFF Operation"
+        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
+        self.cv_IPMI.ipmi_power_off()
+        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+            print "System is in standby/Soft-off state"
+        else:
+            l_msg = "System failed to reach standby/Soft-off state"
+            raise OpTestError(l_msg)
+        self.cv_IPMI.ipmi_power_on()
+        self.cv_SYSTEM.sys_check_host_status()
+        if self.check_occ_status() == BMC_CONST.FW_FAILED:
+            l_msg = "OCC's are not in active state"
+            raise OpTestError(l_msg)
+
+    ##
+    # @brief This function is used to get OCC status enable/disable.
+    #
+    # @return BMC_CONST.FW_SUCCESS - OCC's are active or 
+    #         BMC_CONST.FW_FAILED  - OCC's are not in active state
+    #
+    def check_occ_status(self):
+        l_status = self.cv_IPMI.ipmi_get_occ_status()
+        print l_status
+        if BMC_CONST.OCC_DEVICE_ENABLED in l_status:
+            print "OCC's are up and active"
+            return BMC_CONST.FW_SUCCESS
+        else:
+            print "OCC's are not in active state"
+            return BMC_CONST.FW_FAILED


### PR DESCRIPTION
This patch adds below tests
        OCC Reset/Enable/Disable functionality
        Energy scale tests(BMC to OCC Interface tests)- dcmi get,set,activate,deactivate power limit.

Note: In order to work Energy scale tests user needs to add corresponding platform power limits
      PLATFORM_POWER_LIMIT_HIGH and PLATFORM_POWER_LIMIT_LOW in OpTestConstants.py, because different
      platforms has different platform power limits.

Signed-off-by: Pridhiviraj <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/64)
<!-- Reviewable:end -->
