### PR TITLE
Effective execution of all the test cases.

### DIFF
--- a/bvt/op-occ-fvt.xml
+++ b/bvt/op-occ-fvt.xml
@@ -39,7 +39,7 @@
             <name>Test cpu idle states</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_cpu_idle_states()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -47,7 +47,7 @@
             <name>Test cpu frequency states</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_cpu_freq_states()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -55,7 +55,7 @@
             <name>Test Energy scale at Standby state</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_energy_scale_at_standby_state()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -63,7 +63,7 @@
             <name>Test Energy scale at Runtime state</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_energy_scale_at_runtime_state()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -71,7 +71,7 @@
             <name>Test DCMI at Standby/Runtime States</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_dcmi_at_standby_and_runtime_states()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -79,7 +79,7 @@
             <name>Test OCC Reset Functionality</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_occ_reset_functionality()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -87,7 +87,7 @@
             <name>Test OCC Reset(n>3) Functionality</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_occ_reset_n_times()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -95,7 +95,7 @@
             <name>Test OCC Enable/Disable Functionality</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_occ_fvt.test_occ_enable_disable_functionality()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 

--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -63,7 +63,7 @@
             <name>Test Out-of-band IPMI</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_oob_ipmi()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -71,7 +71,7 @@
             <name>Test IPMI System Power Control</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_ipmi_power_control()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -79,7 +79,7 @@
             <name>Test IPMI Lock/Unlock Functionality</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_ipmi_lock_mode()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -95,7 +95,7 @@
             <name>Test Chip TOD Error Injections</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_tod_errors()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -103,7 +103,7 @@
             <name>Test PRD(Processor Runtime Diagnostics) Driver</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_prd_driver()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -111,7 +111,7 @@
             <name>Test HMI Processor Recovery Done</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_proc_recv_done()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -119,7 +119,7 @@
             <name>Test HMI Processor Recovery Error Masked</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_proc_recv_error_masked()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -127,7 +127,7 @@
             <name>Test HMI Malfunction Alert</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_malfunction_alert()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -135,7 +135,7 @@
             <name>Test Clear Gard Entries</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.clear_gard_entries()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -143,7 +143,7 @@
             <name>Test HMI Hypervisor Resource Error</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_hmi_hypervisor_resource_error()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -151,7 +151,7 @@
             <name>Test Clear Gard Entries</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.clear_gard_entries()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -223,7 +223,7 @@
             <name>Test BMC Cold Reset Boot Sequence</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_mc_cold_reset_boot_sequence()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -231,7 +231,7 @@
             <name>Test BMC Warm Reset Boot Sequence</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_mc_warm_reset_boot_sequence()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -255,7 +255,7 @@
             <name>Test System Power Restore Policy always_on</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_always_on()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -263,7 +263,7 @@
             <name>Test System Power Restore Policy always_off</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_always_off()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
@@ -271,21 +271,23 @@
             <name>Test System Power Restore Policy previous</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_system_power_restore_policy_previous()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
         <test>
+            <name>Test System NVRAM IPMI Reprovision</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_nvram_ipmi_reprovision()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 
         <test>
+            <name>Test System GARD IPMI Reprovision</name>
             <testcase>
                 <cmd>op-ci-bmc-run "op_opal_fvt.test_gard_ipmi_reprovision()"</cmd>
-                <exitonerror>yes</exitonerror>
+                <exitonerror>no</exitonerror>
             </testcase>
         </test>
 

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -271,7 +271,9 @@ class OpTestSystem():
             print("Trying to recover partition")
             try:
                 self.cv_IPMI.ipmi_power_off()
+                self.sys_cold_reset_bmc()
                 self.cv_IPMI.ipmi_power_on()
+                self.sys_check_host_status()
                 self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
             except OpTestError as e:
                 return BMC_CONST.FW_FAILED

--- a/testcases/OpTestAt24driver.py
+++ b/testcases/OpTestAt24driver.py
@@ -44,6 +44,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestAt24driver():
@@ -67,6 +68,9 @@ class OpTestAt24driver():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                 i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -81,7 +85,7 @@ class OpTestAt24driver():
     # @return BMC_CONST.FW_SUCCESS-success or raise OpTestError
     #
     def testAt24driver(self):
-
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Get OS level
         self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestDropbearSafety.py
+++ b/testcases/OpTestDropbearSafety.py
@@ -87,6 +87,7 @@ class OpTestDropbearSafety():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_dropbear_running(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Test Dropbear running in Petitboot"
         print "Performing IPMI Power Off Operation"
         try:

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -42,6 +42,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestEM():
@@ -65,6 +66,9 @@ class OpTestEM():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -78,6 +82,8 @@ class OpTestEM():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_cpu_freq_states(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 
@@ -110,6 +116,8 @@ class OpTestEM():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_cpu_idle_states(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -130,7 +130,6 @@ class OpTestEnergyScale():
             raise OpTestError(l_msg)
         self.cv_IPMI.ipmi_sdr_clear()
         print self.cv_IPMI.ipmi_get_power_limit()
-        self.cv_IPMI.ipmi_activate_power_limit()
         self.cv_IPMI.ipmi_set_power_limit(l_power_limit_high)
         self.cv_IPMI.ipmi_activate_power_limit()
         self.cv_IPMI.ipmi_deactivate_power_limit()

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -116,6 +116,7 @@ class OpTestEnergyScale():
     # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
     #
     def test_energy_scale_at_standby_state(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Energy Scale Test 1: Get, Set, activate and deactivate platform power limit at power off"
         l_power_limit_low, l_power_limit_high = self.get_platform_power_limits(self.cv_PLATFORM)
 
@@ -197,6 +198,7 @@ class OpTestEnergyScale():
     # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
     #
     def test_energy_scale_at_runtime_state(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Energy Scale Test 2: Get, Set, activate and deactivate platform power limit at runtime"
         l_power_limit_low, l_power_limit_high = self.get_platform_power_limits(self.cv_PLATFORM)
 
@@ -301,6 +303,7 @@ class OpTestEnergyScale():
     # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
     #
     def test_dcmi_at_standby_and_runtime_states(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Energy scale Test 3: Get Sensors, Temperature and Power reading's at power off and runtime"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)

--- a/testcases/OpTestFWTS.py
+++ b/testcases/OpTestFWTS.py
@@ -147,6 +147,7 @@ class OpTestFWTS():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_init(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -89,6 +89,8 @@ class OpTestHMIHandling():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_init(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+
         # Get OS level
         self.l_oslevel = self.cv_HOST.host_get_OS_Level()
 
@@ -175,6 +177,7 @@ class OpTestHMIHandling():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def clearGardEntries(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Power off and on the system.
         self.cv_IPMI.ipmi_power_off()
         self.cv_IPMI.ipmi_power_on()

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -40,6 +40,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestHeartbeat():
@@ -63,6 +64,9 @@ class OpTestHeartbeat():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -74,6 +78,7 @@ class OpTestHeartbeat():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_kopald_service(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
 
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpTestI2Cdriver.py
+++ b/testcases/OpTestI2Cdriver.py
@@ -43,6 +43,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestI2Cdriver():
@@ -66,6 +67,9 @@ class OpTestI2Cdriver():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -86,7 +90,7 @@ class OpTestI2Cdriver():
     # @return BMC_CONST.FW_SUCCESS-success or raise OpTestError-fail
     #
     def testI2Cdriver(self):
-
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Get OS level
         self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -88,6 +88,8 @@ class OpTestIPMILockMode():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_ipmi_lock_mode(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestIPMIPowerControl.py
+++ b/testcases/OpTestIPMIPowerControl.py
@@ -83,6 +83,7 @@ class OpTestIPMIPowerControl():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testIPMIPowerControl(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
 
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)

--- a/testcases/OpTestIPMIReprovision.py
+++ b/testcases/OpTestIPMIReprovision.py
@@ -90,6 +90,7 @@ class OpTestIPMIReprovision():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_nvram_ipmi_reprovision(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         self.cv_HOST.host_run_command("uname -a")
         self.cv_HOST.host_run_command(BMC_CONST.NVRAM_PRINT_CFG)
         print "IPMI_Reprovision: Updating the nvram partition with test cfg data"
@@ -136,6 +137,7 @@ class OpTestIPMIReprovision():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_gard_ipmi_reprovision(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "IPMI_Reprovision: Injecting system core checkstop to guard the phyisical cpu"
         self.opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_MALFUNCTION_ALERT)
         print "IPMI_Reprovision: Performing a IPMI Power OFF Operation"

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -44,6 +44,8 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
+
 
 class OpTestInbandIPMI():
     ##  Initialize this object
@@ -66,6 +68,9 @@ class OpTestInbandIPMI():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -79,6 +84,7 @@ class OpTestInbandIPMI():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_ipmi_inband_functionality(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
 
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -43,6 +43,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestInbandUsbInterface():
@@ -66,6 +67,9 @@ class OpTestInbandUsbInterface():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostIP, i_hostUser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostIP,
+                 i_hostUser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -79,6 +83,7 @@ class OpTestInbandUsbInterface():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_ipmi_inband_usb_interface(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
          # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -42,6 +42,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestMtdPnorDriver():
@@ -65,6 +66,9 @@ class OpTestMtdPnorDriver():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
         self.host_user = i_hostuser
         self.host_ip = i_hostip
@@ -86,7 +90,7 @@ class OpTestMtdPnorDriver():
     # @return BMC_CONST.FW_SUCCESS-success or raise OpTestError-fail
     #
     def testMtdPnorDriver(self):
-
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestOCC.py
+++ b/testcases/OpTestOCC.py
@@ -80,6 +80,7 @@ class OpTestOCC():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_occ_reset_functionality(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
@@ -144,6 +145,7 @@ class OpTestOCC():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_occ_reset_n_times(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
@@ -198,6 +200,7 @@ class OpTestOCC():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_occ_enable_disable_functionality(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()

--- a/testcases/OpTestOOBIPMI.py
+++ b/testcases/OpTestOOBIPMI.py
@@ -45,6 +45,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestOOBIPMI():
@@ -68,6 +69,9 @@ class OpTestOOBIPMI():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                                      i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                                      i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -78,6 +82,7 @@ class OpTestOOBIPMI():
     # @return l_res @type list: output of command or raise OpTestError
     #
     def test_oob_ipmi(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
          # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -91,6 +91,7 @@ class OpTestPrdDriver():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testPrdDriver(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         self.test_init()
         l_con = self.cv_SYSTEM.sys_get_ipmi_console()
         self.cv_IPMI.ipmi_host_login(l_con)

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -40,6 +40,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestRTCdriver():
@@ -63,6 +64,9 @@ class OpTestRTCdriver():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                 i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -83,6 +87,7 @@ class OpTestRTCdriver():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_RTC_driver(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
 
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -40,6 +40,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestSensors():
@@ -63,6 +64,9 @@ class OpTestSensors():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -79,6 +83,7 @@ class OpTestSensors():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def test_hwmon_driver(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
 
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -46,6 +46,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.OpTestHost import OpTestHost
 from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpTestSystem
 
 
 class OpTestSwitchEndianSyscall():
@@ -69,6 +70,9 @@ class OpTestSwitchEndianSyscall():
         self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
                                   i_ffdcDir)
         self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd,i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                 i_hostuser, i_hostPasswd)
         self.util = OpTestUtil()
 
     ##
@@ -79,7 +83,7 @@ class OpTestSwitchEndianSyscall():
     # @return BMC_CONST.FW_SUCCESS-success or BMC_CONST.FW_FAILED-fail
     #
     def testSwitchEndianSysCall(self):
-
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Get OS level
         self.cv_HOST.host_get_OS_Level()
 

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -97,7 +97,7 @@ class OpTestSystemBootSequence():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testMcColdResetBootSequence(self):
-
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Testing MC Cold reset boot sequence"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
@@ -136,6 +136,7 @@ class OpTestSystemBootSequence():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testMcWarmResetBootSequence(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Testing MC Warm reset boot sequence"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
@@ -175,6 +176,7 @@ class OpTestSystemBootSequence():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testSystemPowerPolicyOff(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Testing System Power Policy:always-off"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
@@ -218,6 +220,7 @@ class OpTestSystemBootSequence():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testSystemPowerPolicyOn(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Testing System Power Policy:Always-ON"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
@@ -261,6 +264,7 @@ class OpTestSystemBootSequence():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def testSystemPowerPolicyPrevious(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Testing System Power Policy:previous"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)


### PR DESCRIPTION
Some test cases will make the system to not to boot (https://github.com/open-power/op-build/issues/672)
Due to that normal power off/on doesn't bring the system, we were end up in other simpler test cases to fail.

This patch makes existing function sys_bmc_power_on_validate_host to below changes.
if system ping failed---> Do IPMI Power off--->Do BMC Cold reset----> Do IPMI Power ON---> wait for system to boot.

And this sequence will executes only when the system is down and if it is up this function will be just
bypassed.

And this function added in all the test cases begining.

So now we have a effective execution of *most* of the test cases at the cost of *time*

Any new test case addition just use this function at the beginning to execute that test case most of the times.

Still if that function doesn't bring the system up, some thing goes wrong in BMC/Hostboot/HW level  ***bug***.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/77)
<!-- Reviewable:end -->
