### PR TITLE
common/sol_logger.exp: Reconnect SOL on EOF because BMCs suck

### DIFF
--- a/common/sol_logger.exp
+++ b/common/sol_logger.exp
@@ -27,11 +27,21 @@
 set solLogFileName  [lindex $argv 0]
 
 log_file -noappend $solLogFileName
-eval spawn [lrange $argv 1 $argc] sol activate
-set timeout -1
-expect {
-    eof {
-        send_user "\n\nEOF detected\n\n"
-        exit
+
+set max_tries 10
+
+set tries 0
+
+while {$tries <= $max_tries} {
+    incr tries
+    eval spawn [lrange $argv 1 $argc] sol activate
+    set timeout -1
+    expect {
+	eof {
+	    send_user "\n\nEOF detected ($tries / $max_tries attempts)\n\n"
+	    eval spawn [lrange $argv 1 $argc] sol deactivate
+	    expect { eof {} }
+	    continue
+	}
     }
 }


### PR DESCRIPTION
Some BMCs *really* like to randomly drop you off the Serial Over LAN
console. You can get back on it by reconnecting, so this patch changes
our sol_logger to do just that, for up to 10 attempts.

Output will look something like:

EOF detected (3 / 10 attempts)

spawn ipmitool -H fstn5-bmc.ozlabs.ibm.com -I lanplus -U ADMIN -P admin sol deactivate
spawn ipmitool -H fstn5-bmc.ozlabs.ibm.com -I lanplus -U ADMIN -P admin sol activate
[SOL Session operational.  Use ~? for help]

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/78)
<!-- Reviewable:end -->
