### PR TITLE
Refactor how tests are run, use python unit tests rather than perl/shell wrapper

### DIFF
--- a/bvt/op-ci-basic.xml
+++ b/bvt/op-ci-basic.xml
@@ -28,41 +28,18 @@
 <integrationtest>
     <platform>
         <test>
-            <name>Test Init</name>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.test_init()"</cmd>
-                <exitonerror>yes</exitonerror>
-            </testcase>
-        </test>
-
-        <test>
-            <name>IPMI SDR Clear</name>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_sdr_clear()"</cmd>
-            </testcase>
-        </test>
-
-        <test>
-            <name>IPMI Host Power off</name>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
-            </testcase>
-        </test>
-
-        <test>
           <name>Out-of-band BMC and Host firmware update with HPM</name>
 	  <restrict-env>astbmc</restrict-env>
 	  <restrict-env>flash</restrict-env>
           <testcase>
-            <cmd>op-ci-bmc-run "op_ci_bmc.outofband_fwandpnor_update_hpm()"</cmd>
+            <cmd>../ci/source/op_ci_bmc.py TestIPL.test_outofband_fwandpnor_update_hpm</cmd>
           </testcase>
         </test>
 
         <test>
             <name>Power on and validate host booted</name>
             <testcase>
-	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_on()"</cmd>
-              <cmd>op-ci-bmc-run "op_ci_bmc.validate_host()"</cmd>
+	      <cmd>../ci/source/op_ci_bmc.py TestIPL.test_ipl_and_validate</cmd>
             </testcase>
         </test>
 
@@ -75,8 +52,7 @@
 	    -->
 	    <restrict-env>astbmc</restrict-env>
             <testcase>
-              <cmd>op-ci-bmc-run "op_ci_bmc.ipl_wait_for_working_state()"</cmd>
-	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
+	      <cmd>../ci/source/op_ci_bmc.py TestIPL.test_ipl_wait_for_working_state</cmd>
             </testcase>
         </test>
 
@@ -86,43 +62,35 @@
 		 This should work on all systems.
 	    -->
             <testcase>
-	      <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_on()"</cmd>
-              <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_ipl_wait_for_login()"</cmd>
-            </testcase>
-        </test>
-
-        <test>
-            <name>Check SELs</name>
-            <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_sel_check()"</cmd>
+              <cmd>../ci/source/op_ci_bmc.py TestIPL.test_ipl_wait_for_login</cmd>
             </testcase>
         </test>
 
         <test>
             <name>Warm Reset</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_warm_reset()"</cmd>
+                <cmd>../ci/source/op_ci_bmc.py TestIPL.test_warm_reset</cmd>
             </testcase>
         </test>
 
         <test>
             <name>IPMI soft power off</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_soft()"</cmd>
+                <cmd>../ci/source/op_ci_bmc.py TestIPL.test_power_soft</cmd>
             </testcase>
         </test>
 
         <test>
             <name>IPMI BMC reboot</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.bmc_reboot()"</cmd>
+                <cmd>../ci/source/op_ci_bmc.py TestIPL.test_bmc_reboot</cmd>
             </testcase>
         </test>
-        
+
         <test>
             <name>IPMI Host Power off</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_ci_bmc.ipmi_power_off()"</cmd>
+                <cmd>../ci/source/op_ci_bmc.py TestIPL.test_power_off</cmd>
             </testcase>
         </test>
 

--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -38,8 +38,8 @@
         <test>
             <name>Test Gather PCI Subsystem Info</name>
             <testcase>
-                <cmd>op-ci-bmc-run "op_opal_fvt.test_list_pci_device_info()"</cmd>
-                <exitonerror>no</exitonerror>
+              <cmd>../ci/source/op_opal_fvt.py OpalPCI.test_pci_device_presence</cmd>
+              <exitonerror>no</exitonerror>
             </testcase>
         </test>
 

--- a/ci/source/op_ci_bmc.py
+++ b/ci/source/op_ci_bmc.py
@@ -266,3 +266,78 @@ def validate_side_activated():
         print l_msg
         raise OpTestError(l_msg)
     return 0
+
+
+import os
+import unittest
+
+import ConfigParser
+from common.OpTestSystem import OpTestSystem
+from common.OpTestError import OpTestError
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+import ci.source.op_inbound_hpm as op_inbound_hpm
+import ci.source.op_opal_fvt as op_opal_fvt
+import ci.source.op_occ_fvt as op_occ_fvt
+import ci.source.op_fwts_fvt as op_fwts_fvt
+import ci.source.op_outofband_firmware_update as op_outofband_firmware_update
+import ci.source.op_firmware_component_update as op_firmware_component_update
+import ci.source.op_bmc_web_update as op_bmc_web_update
+
+class TestIPL(unittest.TestCase):
+    def test_ipl_and_validate(self):
+        self.assertEqual(ipmi_power_off(), 0)
+        self.assertEqual(ipmi_sdr_clear(), 0)
+        self.assertEqual(ipmi_power_on(), 0)
+        self.assertEqual(validate_host(), 0)
+        self.assertEqual(ipmi_sel_check(), 0)
+
+    def test_outofband_fwandpnor_update_hpm(self):
+        self.assertEqual(ipmi_power_off(), 0)
+        self.assertEqual(ipmi_sdr_clear(), 0)
+        self.assertEqual(outofband_fwandpnor_update_hpm(), 0)
+        self.assertEqual(ipmi_sel_check(), 0)
+
+    def test_ipl_wait_for_working_state(self):
+        self.assertEqual(ipmi_power_off(), 0)
+        self.assertEqual(ipmi_sdr_clear(), 0)
+        self.assertEqual(ipmi_power_on(), 0)
+        self.assertEqual(ipl_wait_for_working_state(), 0)
+        self.assertEqual(ipmi_sel_check(), 0)
+
+    def test_ipl_wait_for_login(self):
+        self.assertEqual(ipmi_power_off(), 0)
+        self.assertEqual(ipmi_sdr_clear(), 0)
+        self.assertEqual(ipmi_power_on(), 0)
+        self.assertEqual(ipmi_ipl_wait_for_login(), 0)
+        self.assertEqual(ipmi_sel_check(), 0)
+
+    def test_warm_reset(self):
+        # It'd be better if we could say "ensure system was on"
+        self.assertEqual(ipmi_warm_reset(), 0)
+
+    def test_power_soft(self):
+        # It'd be better if we could say "ensure system was on"
+        self.assertEqual(ipmi_power_soft(), 0)
+
+    def test_bmc_reboot(self):
+        # It'd be better if we could say "ensure system was on"
+        self.assertEqual(bmc_reboot(), 0)
+
+    def test_power_off(self):
+        # It'd be better if we could say "ensure system was on"
+        self.assertEqual(ipmi_power_off(), 0)
+
+    def setUp(self):
+        bmcCfg, testCfg, hostCfg = _config_read()
+        opTestSys = OpTestSystem(bmcCfg['ip'],bmcCfg['username'],
+                         bmcCfg['password'],
+                         bmcCfg.get('usernameipmi'),
+                         bmcCfg.get('passwordipmi'),
+                         testCfg['ffdcdir'],
+                         hostCfg['hostip'],
+                         hostCfg['hostuser'],
+                         hostCfg['hostpasswd'])
+
+
+if __name__ == '__main__':
+        unittest.main()

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -482,5 +482,13 @@ class OpalPCI(unittest.TestCase):
     def test_pci_device_presence(self):
         test_list_pci_device_info()
 
+class PetitbootEnvironmentTests(unittest.TestCase):
+    def setUp(self):
+        bmcCfg, testCfg, hostCfg = _config_read()
+        test_init()
+
+    def test_dropbear_not_running(self):
+        opTestDropbearSafety.test_dropbear_running()
+
 if __name__ == '__main__':
     unittest.main()

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -6,7 +6,7 @@
 #
 # OpenPOWER Automated Test Project
 #
-# Contributors Listed Below - COPYRIGHT 2015
+# Contributors Listed Below - COPYRIGHT 2015,2016
 # [+] International Business Machines Corp.
 #
 #
@@ -31,7 +31,6 @@
                features will be adding in testcases directory
 
 .. moduleauthor:: Pridhiviraj Paidipeddi <ppaidipe@in.ibm.com>
-
 
 """
 import sys
@@ -459,3 +458,29 @@ def test_list_pci_device_info():
         returns: int 0-success, raises exception-error
     """
     return opTestPCI.test_host_pci_devices_info()
+
+
+import os
+import unittest
+
+import ConfigParser
+from common.OpTestSystem import OpTestSystem
+from common.OpTestError import OpTestError
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+import ci.source.op_inbound_hpm as op_inbound_hpm
+import ci.source.op_occ_fvt as op_occ_fvt
+import ci.source.op_fwts_fvt as op_fwts_fvt
+import ci.source.op_outofband_firmware_update as op_outofband_firmware_update
+import ci.source.op_firmware_component_update as op_firmware_component_update
+import ci.source.op_bmc_web_update as op_bmc_web_update
+
+class OpalPCI(unittest.TestCase):
+    def setUp(self):
+        bmcCfg, testCfg, hostCfg = _config_read()
+        test_init()
+
+    def test_pci_device_presence(self):
+        test_list_pci_device_info()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -103,7 +103,7 @@ class OpTestBMC():
         if index == 0:
             rc = 0
         elif index == 1:
-            l_msg = "pflash not on BMC"
+            l_msg = "Command not on BMC or failed"
             print l_msg
             raise OpTestError(l_msg)
         elif index == 2:

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1206,3 +1206,14 @@ class OpTestIPMI():
             l_msg = "IPMI: failed to close ipmi console"
             raise OpTestError(l_msg)
         return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief Set boot device to be boot to BIOS (i.e. petitboot)
+    # @return 0 for success or throws exception
+    #
+    def ipmi_set_boot_to_petitboot(self):
+        l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'chassis bootdev bios')
+        if('Set Boot Device to bios' in l_output):
+            return 0
+        else:
+            raise OpTestError("Failure setting bootdev to bios: " + str(l_output))

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1172,7 +1172,6 @@ class OpTestIPMI():
     #
     def run_host_cmd_on_ipmi_console(self, i_cmd):
         self.l_con.sendline(i_cmd)
-        time.sleep(BMC_CONST.SHORT_WAIT_IPL)
         try:
             rc = self.l_con.expect(BMC_CONST.IPMI_HOST_EXPECT_PEXPECT_PROMPT_LIST, timeout=500)
             if rc == 0:

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -260,7 +260,11 @@ class OpTestIPMI():
 
         logFile = self.cv_ffdcDir + '/' + 'host_sol_%s.log' % l_res[1]
         print "Time: %s, logfile: %s" % (l_res, logFile)
-        cmd = os.getcwd() + "/../common/sol_logger.exp %s %s" % (
+        cmd = os.getcwd() + "/../common/sol_logger.exp"
+        if (not os.path.isfile(cmd)):
+            cmd = os.getcwd() + "/common/sol_logger.exp"
+
+        cmd += " %s %s" % (
             logFile, self.cv_baseIpmiCmd)
         print cmd
         try:
@@ -299,11 +303,12 @@ class OpTestIPMI():
 
         try:
             self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'sol deactivate')
+            sol.terminate()
         except subprocess.CalledProcessError:
             l_msg = 'SOL already deactivated'
             print l_msg
+            sol.terminate()
             raise OpTestError(l_msg)
-
         return BMC_CONST.FW_SUCCESS
 
 

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1214,3 +1214,14 @@ class OpTestIPMI():
             return 0
         else:
             raise OpTestError("Failure setting bootdev to bios: " + str(l_output))
+
+    ##
+    # @brief Set boot device to be boot to disk (i.e. OS)
+    # @return 0 for success or throws exception
+    #
+    def ipmi_set_boot_to_disk(self):
+        l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'chassis bootdev disk')
+        if('Set Boot Device to disk' in l_output):
+            return 0
+        else:
+            raise OpTestError("Failure setting bootdev to disk: " + str(l_output))

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1062,6 +1062,7 @@ class OpTestIPMI():
         print  "running:%s sol activate" % self.cv_baseIpmiCmd
         try:
             l_con = pexpect.spawn('%s sol activate' % self.cv_baseIpmiCmd)
+            l_con.expect('SOL Session operational.  Use .. for help.')
         except pexpect.ExceptionPexpect:
             l_msg = "IPMI: sol activate failed"
             raise OpTestError(l_msg)
@@ -1075,10 +1076,7 @@ class OpTestIPMI():
     #
     def ipmi_get_console(self):
         self.ipmi_sol_deactivate()
-        # Waiting for a small time interval as latter versions of ipmi takes a bit of time to deactivate.
-        time.sleep(BMC_CONST.IPMI_SOL_DEACTIVATE_TIME)
         l_con = self.ipmi_sol_activate()
-        time.sleep(BMC_CONST.IPMI_SOL_ACTIVATE_TIME)
         count = 0
         while (not l_con.isalive()):
             l_con = self.ipmi_sol_activate()

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -277,18 +277,8 @@ class OpTestIPMI():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def ipl_wait_for_working_state(self, timeout=10):
-
-        ''' WORKAROUND FOR AMI BUG
-         A sleep is required here because Host status sensor is set incorrectly
-         to working state right after power on '''
         sol = self._ipmi_sol_capture()
-        time.sleep(60)
-
         timeout = time.time() + 60*timeout
-
-        ''' AMI BUG is fixed now
-         After updating the AMI level the Host Status sensor works as expected.
-         '''
         cmd = 'sdr elist |grep \'Host Status\''
         while True:
             output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + cmd)

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -144,14 +144,20 @@ class OpTestIPMI():
 
         output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'sel clear')
         if 'Clearing SEL' in output:
-            time.sleep(BMC_CONST.SHORT_WAIT_IPL)
-            output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'sel elist')
-            if 'no entries' in output:
-                return BMC_CONST.FW_SUCCESS
-            else:
-                l_msg = "Sensor data still has entries!"
-                print l_msg
-                raise OpTestError(l_msg)
+            # FIXME: This code should instead check for 'erasure completed'
+            #        and the status of the erasure, rather than this crude loop
+            retries = 20
+            while (retries > 0):
+                output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'sel elist')
+                if 'no entries' in output:
+                    return BMC_CONST.FW_SUCCESS
+                else:
+                    l_msg = "Sensor data still has entries!"
+                    print l_msg
+                    retries -= 1
+                    if (retries == 0):
+                        raise OpTestError(l_msg)
+                    time.sleep(1)
         else:
             l_msg = "Clearing the sensor data Failed"
             print l_msg

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -165,7 +165,6 @@ class OpTestIPMI():
     #
     def ipmi_power_off(self):
         output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + 'chassis power off')
-        time.sleep(BMC_CONST.LONG_WAIT_IPL)
         if 'Down/Off' in output:
             return BMC_CONST.FW_SUCCESS
         else:

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1079,8 +1079,9 @@ class OpTestIPMI():
         l_con = self.ipmi_sol_activate()
         count = 0
         while (not l_con.isalive()):
+            if (count > 0):
+                time.sleep(BMC_CONST.IPMI_SOL_ACTIVATE_TIME)
             l_con = self.ipmi_sol_activate()
-            time.sleep(BMC_CONST.IPMI_SOL_ACTIVATE_TIME)
             count += 1
             if count > 120:
                 l_msg = "IPMI: not able to get sol console"

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1050,13 +1050,8 @@ class OpTestIPMI():
     # @return l_con @type Object: it is a object of pexpect.spawn class or raise OpTestError
     #
     def ipmi_sol_deactivate(self):
-        print "running:%s sol deactivate" % self.cv_baseIpmiCmd
-        try:
-            l_con = pexpect.spawn('%s sol deactivate' % self.cv_baseIpmiCmd)
-        except pexpect.ExceptionPexpect:
-            l_msg = "IPMI: sol deactivate failed"
-            raise OpTestError(l_msg)
-        return l_con
+        self._ipmitool_cmd_run('%s sol deactivate' % self.cv_baseIpmiCmd)
+        return 0
 
     ##
     # @brief This function will activates ipmi sol console

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1081,6 +1081,7 @@ class OpTestIPMI():
         while (not l_con.isalive()):
             if (count > 0):
                 time.sleep(BMC_CONST.IPMI_SOL_ACTIVATE_TIME)
+            self.ipmi_sol_deactivate()
             l_con = self.ipmi_sol_activate()
             count += 1
             if count > 120:

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1008,7 +1008,7 @@ class OpTestSystem():
 
         # Exiting to petitboot shell
         self.console.expect('Petitboot', timeout=BMC_CONST.PETITBOOT_TIMEOUT)
-        time.sleep(20)
+        self.console.expect('x=exit', timeout=10)
         # Exiting to petitboot
         self.console.sendcontrol('l')
         self.console.send('\x1b[B')

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -265,7 +265,7 @@ class OpTestSystem():
 
         # Check if partition is active
         try:
-            self.util.PingFunc(self.cv_HOST.ip)
+            self.util.PingFunc(self.cv_HOST.ip, totalSleepTime=2)
             self.cv_HOST.host_get_OS_Level()
         except OpTestError as e:
             print("Trying to recover partition after error: %s" % (e) )

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1002,6 +1002,8 @@ class OpTestSystem():
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
+
+        self.cv_IPMI.ipmi_set_boot_to_petitboot()
         self.cv_IPMI.ipmi_power_on()
 
         # Exiting to petitboot shell

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -268,7 +268,7 @@ class OpTestSystem():
             self.util.PingFunc(self.cv_HOST.ip)
             self.cv_HOST.host_get_OS_Level()
         except OpTestError as e:
-            print("Trying to recover partition")
+            print("Trying to recover partition after error: %s" % (e) )
             try:
                 self.cv_IPMI.ipmi_power_off()
                 self.cv_IPMI.ipmi_power_on()

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -56,7 +56,7 @@ class OpTestUtil():
     # @return   BMC_CONST.PING_SUCCESS when PASSED or
     #           raise OpTestError when FAILED
     #
-    def PingFunc(self, i_ip, i_try=1):
+    def PingFunc(self, i_ip, i_try=1, totalSleepTime=BMC_CONST.HOST_BRINGUP_TIME):
 	sleepTime = 0;
         while(i_try != 0):
             p1 = subprocess.Popen(["ping", "-c 2", str(i_ip)],
@@ -69,10 +69,10 @@ class OpTestUtil():
                 return BMC_CONST.PING_SUCCESS
 
             else:
-                print "%s is not pinging (Waited %d of %d, %d tries remaining)" % (i_ip, sleepTime, BMC_CONST.HOST_BRINGUP_TIME, i_try)
+                print "%s is not pinging (Waited %d of %d, %d tries remaining)" % (i_ip, sleepTime, totalSleepTime, i_try)
 		time.sleep(1)
 		sleepTime += 1
-		if (sleepTime == BMC_CONST.HOST_BRINGUP_TIME):
+		if (sleepTime == totalSleepTime):
 			i_try -= 1
 			sleepTime = 0
 

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -57,27 +57,24 @@ class OpTestUtil():
     #           raise OpTestError when FAILED
     #
     def PingFunc(self, i_ip, i_try=1):
-
-        arglist = "ping -c 2 " + str(i_ip)
+	sleepTime = 0;
         while(i_try != 0):
-
-            try:
-                p1 = subprocess.Popen(
-                    arglist, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-                stdout_value, stderr_value = p1.communicate()
-            except:
-                l_msg = "Ping Test Failed."
-                print l_msg
-                raise OpTestError(l_msg)
+            p1 = subprocess.Popen(["ping", "-c 2", str(i_ip)],
+                                  stdin=subprocess.PIPE,
+                                  stdout=subprocess.PIPE)
+            stdout_value, stderr_value = p1.communicate()
 
             if(stdout_value.__contains__("2 received")):
                 print (i_ip + " is pinging")
                 return BMC_CONST.PING_SUCCESS
 
             else:
-                print (i_ip + " is not pinging")
-                i_try -= 1
-                time.sleep(BMC_CONST.HOST_BRINGUP_TIME)
+                print "%s is not pinging (Waited %d of %d, %d tries remaining)" % (i_ip, sleepTime, BMC_CONST.HOST_BRINGUP_TIME, i_try)
+		time.sleep(1)
+		sleepTime += 1
+		if (sleepTime == BMC_CONST.HOST_BRINGUP_TIME):
+			i_try -= 1
+			sleepTime = 0
 
         print stderr_value
         raise OpTestError(stderr_value)

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -98,7 +98,6 @@ class OpTestPCI():
         with open(filename, 'r') as f:
             self.pci_good_data = f.read().replace('\n', '')
         print self.pci_good_data
-        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         self.test_skiroot_pci_devices()
         self.test_host_pci_devices()
 


### PR DESCRIPTION
There are a few cleanups in this patch series, as well as starting to move over individual tests to be run out of the python unittest code, which makes them *much* easier to run on their own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/80)
<!-- Reviewable:end -->
