### PR TITLE
Improve host_check_command: check more than one command at once

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -338,14 +338,14 @@ class OpTestHost():
         return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief It will check existence of given linux command(i_cmd) on host
+    # @brief Check if one or more binaries are present on host
     #
-    # @param i_cmd @type string: linux command
+    # @param i_cmd @type string: binaries to check for
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def host_check_command(self, i_cmd):
-        l_cmd = 'which ' + i_cmd + '; echo $?'
+    def host_check_command(self, *i_cmd):
+        l_cmd = 'which ' + ' '.join(i_cmd) + '; echo $?'
         print l_cmd
         l_res = self.host_run_command(l_cmd)
         l_res = l_res.splitlines()
@@ -353,7 +353,7 @@ class OpTestHost():
         if (int(l_res[-1]) == 0):
             return BMC_CONST.FW_SUCCESS
         else:
-            l_msg = "%s command is not present on host" % i_cmd
+            l_msg = "host_check_command: (%s) not present on host. output of '%s': %s" % (','.join(i_cmd), l_cmd, '\n'.join(l_res))
             print l_msg
             raise OpTestError(l_msg)
 

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -674,27 +674,6 @@ class OpTestHost():
             print l_errmsg
             raise OpTestError(l_errmsg)
 
-
-    ##
-    # @brief It will check existence of given linux command(i_cmd) on host
-    #
-    # @param i_cmd @type string: linux command
-    #
-    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
-    #
-    def host_check_command(self, i_cmd):
-        l_cmd = 'which ' + i_cmd + '; echo $?'
-        print l_cmd
-        l_res = self.host_run_command(l_cmd)
-        l_res = l_res.splitlines()
-
-        if (int(l_res[-1]) == 0):
-            return BMC_CONST.FW_SUCCESS
-        else:
-            l_msg = "%s command is not present on host" % i_cmd
-            print l_msg
-            raise OpTestError(l_msg)
-
     ##
     # @brief It will get the linux kernel version on host
     #

--- a/testcases/OpTestAt24driver.py
+++ b/testcases/OpTestAt24driver.py
@@ -90,8 +90,7 @@ class OpTestAt24driver():
         self.cv_HOST.host_get_OS_Level()
 
         # Check whether i2cdump and hexdump commands are available on host
-        self.cv_HOST.host_check_command("i2cdump")
-        self.cv_HOST.host_check_command("hexdump")
+        self.cv_HOST.host_check_command("i2cdump", "hexdump")
 
         # Get Kernel Version
         l_kernel = self.cv_HOST.host_get_kernel_version()

--- a/testcases/OpTestI2Cdriver.py
+++ b/testcases/OpTestI2Cdriver.py
@@ -97,11 +97,8 @@ class OpTestI2Cdriver():
         # make sure install "i2c-tools" package in-order to run the test
 
         # Check whether i2cdump, i2cdetect and hexdump commands are available on host
-        self.cv_HOST.host_check_command("i2cdump")
-        self.cv_HOST.host_check_command("i2cdetect")
-        self.cv_HOST.host_check_command("hexdump")
-        self.cv_HOST.host_check_command("i2cget")
-        self.cv_HOST.host_check_command("i2cset")
+        self.cv_HOST.host_check_command("i2cdump", "i2cdetect", "hexdump",
+                                        "i2cget", "i2cset")
 
         # Get Kernel Version
         l_kernel = self.cv_HOST.host_get_kernel_version()

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -135,8 +135,7 @@ class OpTestPCI():
     # @return BMC_CONST.FW_SUCCESS or BMC_CONST.FW_FAILED
     #
     def test_host_pci_devices(self):
-        self.cv_HOST.host_check_command("lspci")
-        self.cv_HOST.host_check_command("lsusb")
+        self.cv_HOST.host_check_command("lspci", "lsusb")
         self.cv_HOST.host_list_pci_devices()
         self.cv_HOST.host_get_pci_verbose_info()
         self.cv_HOST.host_list_usb_devices()

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -219,8 +219,7 @@ class OpTestPrdDriver():
         self.cv_HOST.host_get_OS_Level()
 
         # Check whether git and gcc commands are available on host
-        self.cv_HOST.host_check_command("git")
-        self.cv_HOST.host_check_command("gcc")
+        self.cv_HOST.host_check_command("git", "gcc")
 
         # It will clone skiboot source repository 
         self.cv_HOST.host_clone_skiboot_source(BMC_CONST.CLONE_SKIBOOT_DIR)

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -88,8 +88,7 @@ class OpTestSwitchEndianSyscall():
         self.cv_HOST.host_get_OS_Level()
 
         # Check whether git and gcc commands are available on host
-        self.cv_HOST.host_check_command("git")
-        self.cv_HOST.host_check_command("gcc")
+        self.cv_HOST.host_check_command("git", "gcc")
 
         # Clone latest linux git repository into l_dir
         l_dir = "/tmp/linux"


### PR DESCRIPTION
It turns out we had both a duplicate host_check_command and we can trivially check for more than one command at once (reducing execution time, although not by much)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/86)
<!-- Reviewable:end -->
