### PR TITLE
Added a varient of TOD error injection test

### DIFF
--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -148,6 +148,14 @@
         </test>
 
         <test>
+            <name>Test Chip TOD Error Injections with single core</name>
+            <testcase>
+                <cmd>../ci/source/op_opal_fvt.py OpalHMI.test_tod_errors_on_single_core</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
             <name>Test HMI Processor Recovery Done</name>
             <testcase>
                 <cmd>../ci/source/op_opal_fvt.py OpalHMI.test_hmi_proc_recv_done</cmd>

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -569,6 +569,10 @@ class OpalHMI(unittest.TestCase):
     def test_tod_errors(self):
         opTestHMIHandling.testHMIHandling(BMC_CONST.TOD_ERRORS)
 
+    def test_tod_errors_on_single_core(self):
+        opTestHMIHandling.host_enable_single_core()
+        opTestHMIHandling.testHMIHandling(BMC_CONST.TOD_ERRORS)
+
     def test_hmi_proc_recv_done(self):
         opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_PROC_RECV_DONE)
 

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -1211,3 +1211,11 @@ class OpTestHost():
         self.host_run_command(BMC_CONST.HOST_LIST_USB_DEVICES1)
         self.host_run_command(BMC_CONST.HOST_LIST_USB_DEVICES2)
         self.host_run_command(BMC_CONST.HOST_LIST_USB_DEVICES3)
+
+    ##
+    # @brief This function enable only a single core
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def host_enable_single_core(self):
+        self.host_run_command("ppc64_cpu --cores-on=1")

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -543,3 +543,11 @@ class OpTestHMIHandling():
             raise OpTestError(l_msg)
         time.sleep(BMC_CONST.HMI_TEST_CASE_SLEEP_TIME)
         return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function enables a single core
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def host_enable_single_core(self):
+        self.cv_HOST.host_enable_single_core()


### PR DESCRIPTION
Running TOD error injection on a 2S machine with a single core
enabled.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/89)
<!-- Reviewable:end -->
