### PR TITLE
Move test case test_tod_errors_on_single_core to end

### DIFF
--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -579,8 +579,18 @@ class OpalHMI(unittest.TestCase):
         opTestHMIHandling.testHMIHandling(BMC_CONST.TOD_ERRORS)
 
     def test_tod_errors_on_single_core(self):
-        opTestHMIHandling.host_enable_single_core()
-        opTestHMIHandling.testHMIHandling(BMC_CONST.TOD_ERRORS)
+        # Preserving the number of cores
+        no_of_cores = opTestHMIHandling.host_get_present_cores()
+        # Set number of cores to '1'
+        opTestHMIHandling.host_enable_set_cores("1")
+        # Run the test
+        try:
+            opTestHMIHandling.testHMIHandling(BMC_CONST.TOD_ERRORS)
+        except OpTestError as e:
+            self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_FOR_STABILITY)
+
+        # Set number of cores to the earlier value
+        opTestHMIHandling.host_enable_set_cores(no_of_cores)
 
     def test_hmi_proc_recv_done(self):
         opTestHMIHandling.testHMIHandling(BMC_CONST.HMI_PROC_RECV_DONE)

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -1217,12 +1217,22 @@ class OpTestHost():
         self.host_run_command(BMC_CONST.HOST_LIST_USB_DEVICES3)
 
     ##
-    # @brief This function enable only a single core
-    #
+    # @brief This function enable given number of cores
+    # @i_cores is the value of the cores to be enabled
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def host_enable_single_core(self):
-        self.host_run_command("ppc64_cpu --cores-on=1")
+    def host_set_cores(self, i_cores):
+        l_cmd = "ppc64_cpu --cores-on=%s" % i_cores
+        self.host_run_command(l_cmd)
+
+    ##
+    # @brief This function get the number of cores
+    #
+    # @return number of cores present
+    #
+    def host_get_cores(self):
+        out_put = self.host_run_command("ppc64_cpu --cores-present | cut -d'=' -f2")
+        return out_put.strip()
 
     ##
     # @brief This function is used to get list of PCI PHB domains.

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -536,9 +536,17 @@ class OpTestHMIHandling():
         return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief This function enables a single core
-    #
+    # @brief This function enables given number of cores
+    # @i_cores number of cores to set
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def host_enable_single_core(self):
-        self.cv_HOST.host_enable_single_core()
+    def host_enable_set_cores(self, i_cores):
+        self.cv_HOST.host_set_cores(i_cores)
+
+    ##
+    # @brief This function get the available cpu cores
+    #
+    # @return number of cpu cores
+    #
+    def host_get_present_cores(self):
+        return self.cv_HOST.host_get_cores()


### PR DESCRIPTION
Move test case named test_tod_errors_on_single_core to end
by that changing core to 1 won't effect other testcases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/90)
<!-- Reviewable:end -->
