### PR TITLE
Add new testcases.

### DIFF
--- a/bvt/op-occ-fvt.xml
+++ b/bvt/op-occ-fvt.xml
@@ -36,6 +36,14 @@
         </test>
 
         <test>
+            <name>Test cpu slw info</name>
+            <testcase>
+                <cmd>../ci/source/op_occ_fvt.py OpalOCCTests.test_slw_info</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
             <name>Test cpu idle states</name>
             <testcase>
                 <cmd>../ci/source/op_occ_fvt.py OpalOCCTests.test_cpu_idle_states</cmd>

--- a/bvt/op-opal-fvt.xml
+++ b/bvt/op-opal-fvt.xml
@@ -347,5 +347,21 @@
             </testcase>
         </test>
 
+        <test>
+            <name>Test Kernel Crash plus full IPL</name>
+            <testcase>
+                <cmd>../ci/source/op_opal_fvt.py OpalKernelCrashTests.test_kernel_crash_kdump_disable</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
+        <test>
+            <name>Test Crash kernel plus full IPL</name>
+            <testcase>
+                <cmd>../ci/source/op_opal_fvt.py OpalKernelCrashTests.test_kernel_crash_kdump_enable</cmd>
+                <exitonerror>no</exitonerror>
+            </testcase>
+        </test>
+
     </platform>
 </integrationtest>

--- a/ci/source/op_occ_fvt.py
+++ b/ci/source/op_occ_fvt.py
@@ -168,6 +168,9 @@ class OpalOCCTests(unittest.TestCase):
         bmcCfg, testCfg, hostCfg = _config_read()
         test_init()
 
+    def test_slw_info(self):
+        opTestEM.test_slw_info()
+
     def test_cpu_idle_states(self):
         opTestEM.test_cpu_idle_states()
 

--- a/ci/source/op_opal_fvt.py
+++ b/ci/source/op_opal_fvt.py
@@ -66,6 +66,7 @@ from testcases.OpTestPCI import OpTestPCI
 from testcases.OpTestFastReboot import OpTestFastReboot
 from testcases.OpTestNVRAM import OpTestNVRAM
 from testcases.OpTestEEH import OpTestEEH
+from testcases.OpTestKernel import OpTestKernel
 
 
 def _config_read():
@@ -240,6 +241,14 @@ opTestEEH = OpTestEEH(bmcCfg['ip'], bmcCfg['username'],
                       bmcCfg.get('passwordipmi'),
                       testCfg['ffdcdir'], hostCfg['hostip'],
                       hostCfg['hostuser'], hostCfg['hostpasswd'])
+
+
+opTestKernel = OpTestKernel(bmcCfg['ip'], bmcCfg['username'],
+                            bmcCfg['password'],
+                            bmcCfg.get('usernameipmi'),
+                            bmcCfg.get('passwordipmi'),
+                            testCfg['ffdcdir'], hostCfg['hostip'],
+                            hostCfg['hostuser'], hostCfg['hostpasswd'])
 
 def test_init():
     """This function validates the test config before running other functions
@@ -486,6 +495,7 @@ def test_list_pci_device_info():
 import os
 import unittest
 import xmlrunner
+import sys
 
 import ConfigParser
 from common.OpTestSystem import OpTestSystem
@@ -497,6 +507,9 @@ import ci.source.op_fwts_fvt as op_fwts_fvt
 import ci.source.op_outofband_firmware_update as op_outofband_firmware_update
 import ci.source.op_firmware_component_update as op_firmware_component_update
 import ci.source.op_bmc_web_update as op_bmc_web_update
+
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class OpalPCI(unittest.TestCase):
     def setUp(self):
@@ -667,6 +680,17 @@ class OpalEEH(unittest.TestCase):
 
     def test_basic_frozen_pe(self):
         opTestEEH.test_basic_frozen_pe()
+
+class OpalKernelCrashTests(unittest.TestCase):
+    def setUp(self):
+        bmcCfg, testCfg, hostCfg = _config_read()
+        test_init()
+
+    def test_kernel_crash_kdump_disable(self):
+        opTestKernel.test_kernel_crash_kdump_disable()
+
+    def test_kernel_crash_kdump_enable(self):
+        opTestKernel.test_kernel_crash_kdump_enable()
 
 if __name__ == '__main__':
     unittest.main(testRunner=xmlrunner.XMLTestRunner(output='%s/test-reports' % full_path))

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -1284,3 +1284,35 @@ class OpTestHost():
         with open(fn, 'w') as f:
             f.write(l_data)
         return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function disables kdump service
+    #
+    # @param os_level: string output of /etc/os-release
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def host_disable_kdump_service(self, os_level):
+        if "Ubuntu" in os_level:
+            self.host_run_command("systemctl stop kdump-tools.service")
+            self.host_run_command("systemctl status kdump-tools.service")
+        else:
+            self.host_run_command("systemctl stop kdump.service")
+            self.host_run_command("systemctl status kdump.service")
+
+    ##
+    # @brief This function disables kdump service
+    #
+    # @param os_level: string output of /etc/os-release
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def host_enable_kdump_service(self, os_level):
+        if "Ubuntu" in os_level:
+            self.host_run_command("systemctl stop kdump-tools.service")
+            self.host_run_command("systemctl start kdump-tools.service")
+            self.host_run_command("systemctl status kdump-tools.service")
+        else:
+            self.host_run_command("systemctl stop kdump.service")
+            self.host_run_command("systemctl start kdump.service")
+            self.host_run_command("service status kdump.service")

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -311,6 +311,34 @@ class OpTestIPMI():
             raise OpTestError(l_msg)
         return BMC_CONST.FW_SUCCESS
 
+    ##
+    # @brief This function waits for the IPL to end. The marker for IPL completion is the
+    #        Host Status sensor which reflects the ACPI power state of the system.  When it
+    #        reads S0/G0: working it means that the petitboot is has began loading.
+    #
+    # @param timeout @type int: The number of minutes to wait for IPL to complete,
+    #       i.e. How long to poll the ACPI sensor for working state before giving up.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def ipmi_ipl_wait_for_working_state_v1(self, timeout=10):
+        timeout = time.time() + 60*timeout
+        cmd = 'sdr elist |grep \'Host Status\''
+        output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + cmd)
+        if not "Host Status" in output:
+            return BMC_CONST.FW_PARAMETER
+
+        while True:
+            if 'S0/G0: working' in output:
+                print "Host Status is S0/G0: working, IPL finished"
+                break
+            if time.time() > timeout:
+                l_msg = "IPL timeout"
+                print l_msg
+                raise OpTestError(l_msg)
+            time.sleep(5)
+            output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + cmd)
+        return BMC_CONST.FW_SUCCESS
 
     def ipmi_ipl_wait_for_login(self, l_con, timeout=10):
         l_rc = l_con.expect_exact(BMC_CONST.IPMI_SOL_CONSOLE_ACTIVATE_OUTPUT, timeout=120)
@@ -390,6 +418,37 @@ class OpTestIPMI():
                 print l_msg
                 raise OpTestError(l_msg)
             time.sleep(BMC_CONST.SHORT_WAIT_IPL)
+
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function waits for the Host OS Boot(IPL) to end. The
+    #        marker for IPL completion is the OS Boot sensor which reflects status
+    #        of host OS Boot. When it reads boot completed it means that the
+    #        Host OS Booted successfully.
+    #
+    # @param i_timeout @type int: The number of minutes to wait for IPL to complete or Boot time,
+    #       i.e. How long to poll the OS Boot sensor for working state before giving up.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def ipmi_wait_for_os_boot_complete_v1(self, i_timeout=10):
+        l_timeout = time.time() + 60*i_timeout
+        l_cmd = 'sdr elist |grep \'OS Boot\''
+        l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
+        if not "OS Boot" in l_output:
+            return BMC_CONST.FW_PARAMETER
+
+        while True:
+            if BMC_CONST.OS_BOOT_COMPLETE in l_output:
+                print "Host OS is booted"
+                break
+            if time.time() > l_timeout:
+                l_msg = "IPL timeout"
+                print l_msg
+                raise OpTestError(l_msg)
+            time.sleep(BMC_CONST.SHORT_WAIT_IPL)
+            l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
 
         return BMC_CONST.FW_SUCCESS
 

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -322,6 +322,24 @@ class OpTestSystem():
 
         return BMC_CONST.FW_SUCCESS
 
+    ##
+    # @brief This function will check for system status and wait for
+    #        FW and Host OS Boot progress to complete.
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def sys_check_host_status_v1(self):
+        if int(self.cv_IPMI.ipmi_ipl_wait_for_working_state_v1()) == BMC_CONST.FW_SUCCESS:
+            print "System booted to working state"
+        else:
+            print "There is no Host Status sensor...."
+        if int(self.cv_IPMI.ipmi_wait_for_os_boot_complete_v1()) == BMC_CONST.FW_SUCCESS:
+            print "System booted to Host OS"
+        else:
+            print "There is no OS Boot sensor..."
+
+        return BMC_CONST.FW_SUCCESS
+
 
     ##
     # @brief Issue IPMI PNOR Reprovision request command

--- a/run
+++ b/run
@@ -156,6 +156,8 @@ sub get_platform_name {
     if ($platform eq "tyan,palmetto" ||
         $platform eq "tyan,habanero" ||
         $platform eq "ibm,firestone" ||
+        $platform eq "ibm,firenze"   ||
+        $platform eq "ibm,powernv"   ||
         $platform eq "ibm,garrison")
     {
         my $platformname = (split ',',$platform)[1];
@@ -169,7 +171,7 @@ sub get_platform_name {
 sub print_init_param {
     my ($f,$a,$m,$p) = @_;
     my $value = ($m->findnodes($p))->to_literal;
-    print $f "$a = ".$value."\n" if $value;
+    print $f "$a = ".$value."\n";
 }
 
 sub create_config_file {

--- a/testcases/OpTestEEH.py
+++ b/testcases/OpTestEEH.py
@@ -146,7 +146,7 @@ class OpTestEEH():
         self.cv_IPMI.run_host_cmd_on_ipmi_console("dmesg -D")
         self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
         self.cv_IPMI.run_host_cmd_on_ipmi_console("cat /etc/os-release")
-        for i in range(0,1):
+        for i in range(0,2):
             for domain in pci_domains:
                 self.prepare_logs()
                 cmd = "echo 0x8000000000000000 > /sys/kernel/debug/powerpc/%s/err_injct_outbound; lspci;" % domain

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -72,6 +72,22 @@ class OpTestEM():
         self.util = OpTestUtil()
 
     ##
+    # @brief This function just gathers the host CPU SLW info
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_slw_info(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+        # Get OS level
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
+        # Get kernel version
+        l_kernel = self.cv_HOST.host_get_kernel_version()
+        self.cv_HOST.host_check_command("cpupower")
+        self.cv_HOST.host_run_command("cpupower idle-info")
+        self.cv_HOST.host_run_command("hexdump -c /proc/device-tree/ibm,enabled-idle-states")
+        self.cv_HOST.host_run_command("cat /sys/firmware/opal/msglog | grep -i slw")
+
+    ##
     # @brief This function will cover following test steps
     #        1. It will get the OS and kernel versions.
     #        2. Check the cpupower utility is available in host.

--- a/testcases/OpTestKernel.py
+++ b/testcases/OpTestKernel.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestKernel.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2017
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestKernel.py
+#  This module can contain testcases related to FW & Kernel Interactions.
+#   Ex: 1. Trigger a kernel crash(Both by enabling and disabling the kdump)
+#       2. Check Firmware boot progress
+
+import time
+import subprocess
+import commands
+import re
+import sys
+import pexpect
+
+from common.OpTestBMC import OpTestBMC
+from common.OpTestIPMI import OpTestIPMI
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestError import OpTestError
+from common.OpTestHost import OpTestHost
+from common.OpTestSystem import OpTestSystem
+from common.OpTestUtil import OpTestUtil
+
+
+class OpTestKernel():
+    ##  Initialize this object
+    #  @param i_bmcIP The IP address of the BMC
+    #  @param i_bmcUser The userid to log into the BMC with
+    #  @param i_bmcPasswd The password of the userid to log into the BMC with
+    #  @param i_bmcUserIpmi The userid to issue the BMC IPMI commands with
+    #  @param i_bmcPasswdIpmi The password of BMC IPMI userid
+    #  @param i_ffdcDir Optional param to indicate where to write FFDC
+    #
+    # "Only required for inband tests" else Default = None
+    # @param i_hostIP The IP address of the HOST
+    # @param i_hostuser The userid to log into the HOST
+    # @param i_hostPasswd The password of the userid to log into the HOST with
+    #
+    def __init__(self, i_bmcIP, i_bmcUser, i_bmcPasswd,
+                 i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir=None, i_hostip=None,
+                 i_hostuser=None, i_hostPasswd=None):
+        self.cv_BMC = OpTestBMC(i_bmcIP, i_bmcUser, i_bmcPasswd, i_ffdcDir)
+        self.cv_IPMI = OpTestIPMI(i_bmcIP, i_bmcUserIpmi, i_bmcPasswdIpmi,
+                                  i_ffdcDir, i_hostip, i_hostuser, i_hostPasswd)
+        self.cv_HOST = OpTestHost(i_hostip, i_hostuser, i_hostPasswd, i_bmcIP)
+        self.cv_SYSTEM = OpTestSystem(i_bmcIP, i_bmcUser, i_bmcPasswd,
+                         i_bmcUserIpmi, i_bmcPasswdIpmi, i_ffdcDir, i_hostip,
+                         i_hostuser, i_hostPasswd)
+        self.util = OpTestUtil()
+
+    ##
+    # @brief This function will test the kernel crash followed by system
+    #        reboot. it has below steps
+    #        1. Enable reboot on kernel panic: echo 10  > /proc/sys/kernel/panic
+    #        2. Trigger kernel crash: echo c > /proc/sysrq-trigger
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_kernel_crash(self):
+        self.cv_SYSTEM.sys_bmc_power_on_validate_host()
+
+        # Get OS level
+        self.cv_HOST.host_get_OS_Level()
+
+        # Get Kernel Version
+        l_kernel = self.cv_HOST.host_get_kernel_version()
+
+        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_IPMI.ipmi_host_login(l_con)
+        self.cv_IPMI.ipmi_host_set_unique_prompt(l_con)
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("uname -a")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("cat /etc/os-release")
+        self.cv_IPMI.run_host_cmd_on_ipmi_console("echo 10  > /proc/sys/kernel/panic")
+        l_con.sendline("echo c > /proc/sysrq-trigger")
+        try:
+            l_con.expect('Petitboot', timeout=BMC_CONST.PETITBOOT_TIMEOUT)
+            self.cv_IPMI.ipmi_close_console(l_con)
+        except pexpect.EOF:
+            print "Waiting for system to IPL...."
+        except pexpect.TIMEOUT:
+            raise OpTestError("System failed to reach Petitboot")
+        self.cv_SYSTEM.sys_check_host_status_v1()
+        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        print "System booted fine to host OS..."
+        return BMC_CONST.FW_SUCCESS
+
+    ##
+    # @brief This function will test the kernel crash followed by crash kernel dump
+    #        and subsequent system IPL
+    #        1. Make sure kdump service is started before test
+    #        2. Trigger kernel crash: echo c > /proc/sysrq-trigger
+    #        3. Check for crash kernel boot followed full system IPL
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_kernel_crash_kdump_enable(self):
+        self.cv_HOST.host_check_command("kdump")
+        os_level = self.cv_HOST.host_get_OS_Level()
+        self.cv_HOST.host_enable_kdump_service(os_level)
+        self.test_kernel_crash()
+
+    ##
+    # @brief This function will test the kernel crash followed by system IPL
+    #        1. Make sure kdump service is stopped before test
+    #        2. Trigger kernel crash: echo c > /proc/sysrq-trigger
+    #        3. Check for system booting
+    #
+    # @return BMC_CONST.FW_SUCCESS or raise OpTestError
+    #
+    def test_kernel_crash_kdump_disable(self):
+        self.cv_HOST.host_check_command("kdump")
+        os_level = self.cv_HOST.host_get_OS_Level()
+        self.cv_HOST.host_disable_kdump_service(os_level)
+        self.test_kernel_crash()


### PR DESCRIPTION
This patch contains below new testcases.

1. Trigger the kernel crash and check system boots fine or not in both
kdump enabled and disabled environments
a. if kdump is disabled
	Trigger kernel crash and check for full system IPL
b. if kdump is enabled
	Trigger kernel crash and check for crash kernel & full system IPL

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/95)
<!-- Reviewable:end -->
