### PR TITLE
Fixes for enabling the test cases on other non-ibm openpower platforms

### DIFF
--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -163,6 +163,7 @@ class OpTestConstants():
     FW_SUCCESS = 0
     FW_FAILED = 1
     FW_INVALID = 2
+    FW_PARAMETER = 4
 
     # PingFunc Constants
     PING_FAILED = 0

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -290,6 +290,9 @@ class OpTestIPMI():
         sol = self._ipmi_sol_capture()
         timeout = time.time() + 60*timeout
         cmd = 'sdr elist |grep \'Host Status\''
+        output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + cmd)
+        if not "Host Status" in output:
+            return BMC_CONST.FW_PARAMETER
         while True:
             output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + cmd)
             if 'S0/G0: working' in output:
@@ -351,6 +354,9 @@ class OpTestIPMI():
     def ipmi_wait_for_standby_state(self, i_timeout=120):
         l_timeout = time.time() + i_timeout
         l_cmd = 'sdr elist |grep \'Host Status\''
+        output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
+        if not "Host Status" in output:
+            return BMC_CONST.FW_PARAMETER
         while True:
             l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
             if BMC_CONST.CHASSIS_SOFT_OFF in l_output:
@@ -380,6 +386,9 @@ class OpTestIPMI():
     def ipmi_wait_for_os_boot_complete(self, i_timeout=10):
         l_timeout = time.time() + 60*i_timeout
         l_cmd = 'sdr elist |grep \'OS Boot\''
+        output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
+        if not "OS Boot" in output:
+            return BMC_CONST.FW_PARAMETER
         while True:
             l_output = self._ipmitool_cmd_run(self.cv_baseIpmiCmd + l_cmd)
             if BMC_CONST.OS_BOOT_COMPLETE in l_output:

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -291,8 +291,12 @@ class OpTestSystem():
     def sys_hard_reboot(self):
         print "Performing a IPMI Power OFF Operation"
         self.cv_IPMI.ipmi_power_off()
-        if int(self.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -309,13 +313,21 @@ class OpTestSystem():
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def sys_check_host_status(self):
-        if int(self.sys_ipl_wait_for_working_state()) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.sys_ipl_wait_for_working_state())
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System booted to working state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skip wait for IPL runtime check"
         else:
             l_msg = "System failed to boot"
             raise OpTestError(l_msg)
-        if int(self.sys_wait_for_os_boot_complete()) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.sys_wait_for_os_boot_complete())
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System booted to Host OS"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "OS Boot sensor is not available"
+            print "Skip wait for wait for OS boot complete check"
         else:
             l_msg = "System failed to boot Host OS"
             raise OpTestError(l_msg)

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -123,8 +123,12 @@ class OpTestEnergyScale():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -204,8 +208,12 @@ class OpTestEnergyScale():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -259,8 +267,12 @@ class OpTestEnergyScale():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -307,8 +319,12 @@ class OpTestEnergyScale():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)

--- a/testcases/OpTestFWTS.py
+++ b/testcases/OpTestFWTS.py
@@ -116,18 +116,7 @@ class OpTestFWTS():
     #
     def test_system_reboot(self):
         print "Testing FWTS: Booting system to OS"
-        print "Performing a IPMI Power OFF Operation"
-        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
-        self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
+        self.cv_SYSTEM.sys_hard_reboot()
         self.cv_IPMI.clear_ssh_keys(self.cv_HOST.ip)
 
         print "Gathering the OPAL msg logs"

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -179,12 +179,7 @@ class OpTestHMIHandling():
     def clearGardEntries(self):
         self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         # Power off and on the system.
-        self.cv_IPMI.ipmi_power_off()
-        self.cv_IPMI.ipmi_power_on()
-        if int(self.cv_SYSTEM.sys_ipl_wait_for_working_state()):
-            l_msg = "System failed to boot host OS"
-            raise OpTestError(l_msg)
-        time.sleep(BMC_CONST.HOST_BRINGUP_TIME)
+        self.cv_SYSTEM.sys_hard_reboot()
 
         # Clearing gard entries after host comes up
         self.cv_HOST.host_get_OS_Level()
@@ -212,12 +207,8 @@ class OpTestHMIHandling():
         self.cv_IPMI.run_host_cmd_on_ipmi_console(l_cmd)
 
         # Rebooting the system again to make use of garded hardware
-        self.cv_IPMI.ipmi_power_off()
-        self.cv_IPMI.ipmi_power_on()
-        if int(self.cv_SYSTEM.sys_ipl_wait_for_working_state()):
-            l_msg = "System failed to boot host OS"
-            raise OpTestError(l_msg)
-        time.sleep(BMC_CONST.HOST_BRINGUP_TIME)
+        self.cv_SYSTEM.sys_hard_reboot()
+
         self.cv_HOST.host_get_OS_Level()
         self.cv_SYSTEM.sys_ipmi_close_console(l_con)
 

--- a/testcases/OpTestIPMIReprovision.py
+++ b/testcases/OpTestIPMIReprovision.py
@@ -105,8 +105,12 @@ class OpTestIPMIReprovision():
         print "IPMI_Reprovision: Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "IPMI_Reprovision: System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "IPMI_Reprovision: Host Status sensor is not available"
+            print "IPMI_Reprovision: Skipping stand-by state check"
         else:
             l_msg = "IPMI_Reprovision: System failed to reach standby/Soft-off state after pnor reprovisioning"
             raise OpTestError(l_msg)
@@ -143,8 +147,12 @@ class OpTestIPMIReprovision():
         print "IPMI_Reprovision: Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "IPMI_Reprovision: System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "IPMI_Reprovision: Host Status sensor is not available"
+            print "IPMI_Reprovision: Skipping stand-by state check"
         else:
             l_msg = "IPMI_Reprovision: System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -178,8 +186,12 @@ class OpTestIPMIReprovision():
         print "IPMI_Reprovision: Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "IPMI_Reprovision: System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "IPMI_Reprovision: Host Status sensor is not available"
+            print "IPMI_Reprovision: Skipping stand-by state check"
         else:
             l_msg = "IPMI_Reprovision: System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)

--- a/testcases/OpTestOCC.py
+++ b/testcases/OpTestOCC.py
@@ -82,15 +82,7 @@ class OpTestOCC():
     def test_occ_reset_functionality(self):
         self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Performing a IPMI Power OFF Operation"
-        # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state"
             #raise OpTestError(l_msg)
@@ -125,14 +117,7 @@ class OpTestOCC():
             l_msg = "OCC's are not in active state, rebooting the system"
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state"
             raise OpTestError(l_msg)
@@ -148,14 +133,7 @@ class OpTestOCC():
         self.cv_SYSTEM.sys_bmc_power_on_validate_host()
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state after rebooting"
             raise OpTestError(l_msg)
@@ -179,16 +157,8 @@ class OpTestOCC():
             print "OPAL-PRD: occ query reset reload count"
             self.cv_HOST.host_run_command(BMC_CONST.OCC_QUERY_RESET_COUNTS)
 
-        print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state after rebooting"
             raise OpTestError(l_msg)
@@ -201,16 +171,8 @@ class OpTestOCC():
     #
     def test_occ_enable_disable_functionality(self):
         self.cv_SYSTEM.sys_bmc_power_on_validate_host()
-        print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state"
             raise OpTestError(l_msg)
@@ -223,16 +185,8 @@ class OpTestOCC():
             if self.check_occ_status() == BMC_CONST.FW_FAILED:
                 l_msg = "OCC's are not in active state"
                 #raise OpTestError(l_msg)
-        print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
-        self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
-            print "System is in standby/Soft-off state"
-        else:
-            l_msg = "System failed to reach standby/Soft-off state"
-            raise OpTestError(l_msg)
-        self.cv_IPMI.ipmi_power_on()
-        self.cv_SYSTEM.sys_check_host_status()
+        self.cv_SYSTEM.sys_hard_reboot()
         if self.check_occ_status() == BMC_CONST.FW_FAILED:
             l_msg = "OCC's are not in active state"
             raise OpTestError(l_msg)

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -102,8 +102,12 @@ class OpTestSystemBootSequence():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -141,8 +145,12 @@ class OpTestSystemBootSequence():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == 0:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -181,8 +189,12 @@ class OpTestSystemBootSequence():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -225,8 +237,12 @@ class OpTestSystemBootSequence():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)
@@ -269,8 +285,12 @@ class OpTestSystemBootSequence():
         print "Performing a IPMI Power OFF Operation"
         # Perform a IPMI Power OFF Operation(Immediate Shutdown)
         self.cv_IPMI.ipmi_power_off()
-        if int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY)) == BMC_CONST.FW_SUCCESS:
+        rc = int(self.cv_SYSTEM.sys_wait_for_standby_state(BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
+        if rc == BMC_CONST.FW_SUCCESS:
             print "System is in standby/Soft-off state"
+        elif rc == BMC_CONST.FW_PARAMETER:
+            print "Host Status sensor is not available"
+            print "Skipping stand-by state check"
         else:
             l_msg = "System failed to reach standby/Soft-off state"
             raise OpTestError(l_msg)


### PR DESCRIPTION
In some openpower platforms (example: SuperMicro) there are no
'Host Status' and 'OS Boot' sensors available.

Currently due to above issue below test cases are failing in SuperMicro
Systems

OpTestEnergyScale
OpTestFWTS
OpTestHMIHandling
OpTestIPMIReprovision
OpTestOCC
OpTestSystemBootSequence

So, this patch fixes the above mentioned issue. And also optimized
boot code by adding the API (self.cv_SYSTEM.sys_hard_reboot)

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>
Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/97)
<!-- Reviewable:end -->
