### PR TITLE
Firmware flash tests.

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -66,6 +66,12 @@ class OpTestConfiguration():
         ffdcgroup = parser.add_argument_group('FFDC', 'First Failure Data Capture')
         ffdcgroup.add_argument("--ffdcdir", help="FFDC directory")
 
+        imagegroup = parser.add_argument_group('Images', 'Firmware lids/images to flash')
+        imagegroup.add_argument("--firmware-images", help="Firmware images directory")
+        imagegroup.add_argument("--host-pnor", help="PNOR image to flash")
+        imagegroup.add_argument("--host-lid", help="Skiboot lid to flash")
+        imagegroup.add_argument("--host-hpm", help="HPM image to flash")
+
         self.args , self.remaining_args = parser.parse_known_args(argv)
         stateMap = { 'UNKNOWN' : OpSystemState.UNKNOWN,
                      'OFF' : OpSystemState.OFF,
@@ -136,7 +142,7 @@ class OpTestConfiguration():
         return
 
     def bmc(self):
-        return self.op_system.bmc()
+        return self.op_system.bmc
     def system(self):
         return self.op_system
     def host(self):

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -178,7 +178,7 @@ class OpTestBMC():
         rsync.logfile = sys.stdout
         rsync.expect('assword: ')
         rsync.sendline(self.cv_bmcPasswd)
-        rsync.expect('total size is', timeout=150)
+        rsync.expect('total size is', timeout=900)
         rsync.expect(pexpect.EOF)
         rsync.close()
         return rsync.exitstatus
@@ -204,6 +204,11 @@ class OpTestBMC():
     #
     def pnor_img_flash(self, i_pflash_dir, i_imageName):
         cmd = i_pflash_dir + '/pflash -e -f -p /tmp/%s' % i_imageName
+        rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
+        return rc
+
+    def skiboot_img_flash(self, i_pflash_dir, i_imageName):
+        cmd = i_pflash_dir + '/pflash -p /tmp/%s -e -f -P PAYLOAD' % i_imageName
         rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
         return rc
 

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -63,8 +63,11 @@ class IPMITool():
         s += ' '
         return s
 
-    def run(self, cmd, background=False):
-        cmd = self.binary + self.arguments() + cmd
+    def run(self, cmd, background=False, cmdprefix=None):
+        if cmdprefix:
+            cmd = cmdprefix + self.binary + self.arguments() + cmd
+        else:
+            cmd = self.binary + self.arguments() + cmd
         print cmd
         if background:
             try:
@@ -597,7 +600,7 @@ class OpTestIPMI():
         try:
             # FIXME: This is currently broken with the ipmitool rework
             # We're likely to timeout waiting for the user to hit 'y'
-            rc = self.ipmitool.run(l_cmd)
+            rc = self.ipmitool.run(l_cmd, background=False, cmdprefix = "echo y |")
             print rc
             self.ipmi_cold_reset()
 

--- a/op-test
+++ b/op-test
@@ -51,6 +51,7 @@ from testcases import OpTestInbandIPMI
 from testcases import OpTestInbandUsbInterface
 from testcases import OpTestNVRAM
 from testcases import HostLogin
+from testcases import OpTestFlash
 import testcases
 
 args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestFlash.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+#  @package OpTestFlash
+#  Firmware flash tests for OpenPower testing.
+#
+#  This class contains the OpenPower Firmware flashing scripts for
+#  AMI platforms 
+#
+#   PNOR Flash Update
+#   Lid Updates(Currently skiboot lid) TODO: Add skiroot lid support
+#   Out-of-band HPM Update
+#   In-band HPM Update
+# 
+#  pre-requistes pflash tool should be in /tmp directory of BMC busy box
+#
+
+
+import os
+import unittest
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+
+
+class OpTestFlashBase(unittest.TestCase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.cv_SYSTEM = conf.system()
+        self.cv_BMC = conf.bmc()
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.platform = conf.platform()
+        self.bmc_type = conf.args.bmc_type
+
+    def validate_side_activated(self):
+        l_bmc_side, l_pnor_side = self.cv_IPMI.ipmi_get_side_activated()
+        self.assertIn(BMC_CONST.PRIMARY_SIDE, l_bmc_side, "BMC: Primary side is not active")
+        # TODO force setting of primary side to BIOS Golden side sensor
+        self.assertIn(BMC_CONST.PRIMARY_SIDE, l_pnor_side, "PNOR: Primary side is not active")
+
+    def get_pnor_level(self):
+        rc = self.cv_IPMI.ipmi_get_PNOR_level()
+        print rc
+
+
+class PNORFLASH(OpTestFlashBase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.images_dir = conf.args.firmware_images
+        self.pnor_name = conf.args.host_pnor
+        self.pnor_path = os.path.join(self.images_dir, self.pnor_name)
+        self.assertNotEqual(os.path.exists(self.pnor_path), 0,
+            "PNOR image %s not doesn't exist" % self.pnor_path)
+        super(PNORFLASH, self).setUp()
+
+    def runTest(self):
+        if "AMI" not in self.bmc_type:
+            self.skipTest("OP AMI BMC PNOR Flash test")
+        self.cv_BMC.validate_pflash_tool("/tmp")
+        self.validate_side_activated()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.sys_sdr_clear()
+        self.cv_BMC.pnor_img_transfer(self.images_dir, self.pnor_name)
+        self.cv_BMC.pnor_img_flash("/tmp", self.pnor_name)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.validate_side_activated()
+        self.cv_SYSTEM.sys_sel_check()
+
+
+class SkibootLidFLASH(OpTestFlashBase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.images_dir = conf.args.firmware_images
+        self.lid_name = conf.args.host_lid
+        self.lid_path = os.path.join(self.images_dir, self.lid_name)
+        self.assertNotEqual(os.path.exists(self.lid_path), 0,
+            "Skiboot lid %s not doesn't exist" % self.lid_path)
+        super(SkibootLidFLASH, self).setUp()
+
+    def runTest(self):
+        if "AMI" not in self.bmc_type:
+            self.skipTest("OP AMI BMC Skiboot lid flash test")
+        self.cv_BMC.validate_pflash_tool("/tmp")
+        self.validate_side_activated()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.sys_sdr_clear()
+        self.cv_BMC.pnor_img_transfer(self.images_dir, self.lid_name)
+        self.cv_BMC.skiboot_img_flash("/tmp", self.lid_name)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.validate_side_activated()
+        self.cv_SYSTEM.sys_sel_check()
+
+class OOBHpmFLASH(OpTestFlashBase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.images_dir = conf.args.firmware_images
+        self.hpm_name = conf.args.host_hpm
+        self.hpm_path = os.path.join(self.images_dir, self.hpm_name)
+        self.assertNotEqual(os.path.exists(self.hpm_path), 0,
+            "HPM File %s not doesn't exist" % self.hpm_path)
+        super(OOBHpmFLASH, self).setUp()
+
+    def runTest(self):
+        if "AMI" not in self.bmc_type:
+            self.skipTest("OP AMI BMC Out-of-band firmware Update test")
+        self.cv_SYSTEM.sys_sdr_clear()
+        self.validate_side_activated()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_IPMI.ipmi_code_update(self.hpm_path, str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.validate_side_activated()
+        self.cv_SYSTEM.sys_sel_check()
+
+
+class InbandHpmFLASH(OpTestFlashBase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.images_dir = conf.args.firmware_images
+        self.hpm_name = conf.args.host_hpm
+        self.hpm_path = os.path.join(self.images_dir, self.hpm_name)
+        self.assertNotEqual(os.path.exists(self.hpm_path), 0,
+            "HPM File %s not doesn't exist" % self.hpm_path)
+        super(InbandHpmFLASH, self).setUp()
+
+    def runTest(self):
+        if "AMI" not in self.bmc_type:
+            self.skipTest("OP AMI BMC In-band firmware Update test")
+        self.cv_SYSTEM.sys_sdr_clear()
+        self.validate_side_activated()
+        self.cv_HOST.host_code_update(self.hpm_path, str(BMC_CONST.BMC_FWANDPNOR_IMAGE_UPDATE))
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.validate_side_activated()
+        self.cv_SYSTEM.sys_sel_check()


### PR DESCRIPTION
   PNOR Flash Update
   Lid Updates(Currently skiboot lid) TODO: Add skiroot lid support
   Out-of-band HPM Update
   In-band HPM Update

pre-requistes: pflash tool should be in /tmp directory of BMC busy box

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/104)
<!-- Reviewable:end -->
