### PR TITLE
expect kexec: 'kexec_core: Starting new kernel' also valid

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1214,7 +1214,7 @@ class OpTestSystem(object):
     def wait_for_kexec(self):
         console = self.console.get_console()
         # Wait for kexec to start
-        console.expect('Performing kexec', timeout=60)
+        console.expect(['Performing kexec','kexec_core: Starting new kernel'], timeout=60)
 
     def petitboot_exit_to_shell(self):
         console = self.console.get_console()


### PR DESCRIPTION
Some kernels display 'kexec_core: Starting new kernel' to indicate
we're doing a kexec, so we should also expect that.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/116)
<!-- Reviewable:end -->
