### PR TITLE
Adding BMC Type options to be provided while using op-test command line to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ From skiboot, you will need the xscom-utils and gard installed:
 Gets you help on what you can run. You will need to (at a minimum) provide
 BMC and host login information. For example, to run the default test suite:
 
-    ./op-test --bmc-ip bmc.example.com   \
+    ./op-test --bmc-type AMI             \
+              --bmc-ip bmc.example.com   \
     	      --bmc-username sysadmin    \
 	      --bmc-password superuser   \
 	      --bmc-usernameipmi ADMIN   \
@@ -77,7 +78,7 @@ The default test suite will then run.
 
 To get a list of test suites:
 
-    ./op-test --list-suites
+    ./op-test --bmc-type AMI --list-suites
 
 You cun run one or more suites by using the `--run-suite` command line option.
 For example, you can choose to run tests that are only at the petitboot
@@ -88,7 +89,8 @@ You can also run individual tests by using the `--run` option.
 
 For example:
 
-      ./op-test --bmc-ip bmc.example.com \
+      ./op-test --bmc-type AMI           \
+                --bmc-ip bmc.example.com \
       		--bmc-username sysadmin  \
 		--bmc-password superuser \
 		--bmc-usernameipmi ADMIN \


### PR DESCRIPTION
Updating the command line option with --bmc-type in the README while executing ./op-test to run the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/130)
<!-- Reviewable:end -->
