### PR TITLE
Fix system dump test case by enabling the dump policy.

### DIFF
--- a/op-test
+++ b/op-test
@@ -308,6 +308,9 @@ if OpTestConfiguration.conf.args.list_suites:
         print '{0:34}{1}'.format(key, suites[key].__doc__)
     exit(0)
 
+reload(sys)
+sys.setdefaultencoding("utf8")
+
 t = unittest.TestSuite()
 
 if OpTestConfiguration.conf.args.run_suite:

--- a/op-test
+++ b/op-test
@@ -60,6 +60,7 @@ from testcases import OpTestMCColdResetEffects
 from testcases import OpTestDumps
 from testcases import HostLogin
 from testcases import OpalMsglog
+from testcases import KernelLog
 from testcases import OpTestFlash
 from testcases import OpalErrorLog
 from testcases import LightPathDiagnostics
@@ -101,6 +102,7 @@ class SkirootSuite():
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())
         self.s.addTest(OpalMsglog.Skiroot())
+        self.s.addTest(KernelLog.Skiroot())
         self.s.addTest(DPO.DPOSkiroot())
 #        self.s.addTest(OpTestEnergyScale.runtime_suite())
     def suite(self):
@@ -126,6 +128,7 @@ class HostSuite():
         self.s.addTest(OpTestSensors.OpTestSensors())
         self.s.addTest(OpalErrorLog.BasicTest())
         self.s.addTest(OpalMsglog.Host())
+        self.s.addTest(KernelLog.Host())
         self.s.addTest(OpTestPrdDaemon.OpTestPrdDaemon())
     def suite(self):
         return self.s

--- a/testcases/KernelLog.py
+++ b/testcases/KernelLog.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2017
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+import unittest
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+
+class KernelLog():
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+
+    def runTest(self):
+        self.setup_test()
+        if "skiroot" in self.test:
+            cmd = "dmesg -r|grep '<[4321]>'"
+        elif "host" in self.test:
+            cmd = "dmesg -T --level=alert,crit,err,warn"
+        else:
+            raise Exception("Unknow test type")
+
+        log_entries = self.c.run_command(cmd)
+        msg = '\n'.join(filter(None, log_entries))
+        self.assertTrue( len(log_entries) == 0, "Warnings/Errors in Kernel log:\n%s" % msg)
+
+class Skiroot(KernelLog, unittest.TestCase):
+    def setup_test(self):
+        self.test = "skiroot"
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_SYSTEM.host_console_unique_prompt()
+
+class Host(KernelLog, unittest.TestCase):
+    def setup_test(self):
+        self.test = "host"
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.c = self.cv_SYSTEM.host().get_ssh_connection()

--- a/testcases/fspresetReload.py
+++ b/testcases/fspresetReload.py
@@ -174,7 +174,10 @@ class fspresetReload(unittest.TestCase):
         self.assertTrue(self.check_for_inbandipmi(), "inband ipmi interface failed after fsp rr")
         self.assertTrue(self.check_for_sensors(), "inband sensors failed after fsp rr")
         self.assertTrue(self.check_for_nvram(), "nvram interface failed after fsp rr")
-        self.check_for_sol_console()
+        try:
+            self.check_for_sol_console()
+        except:
+            pass
 
 
     def look_for_in_opal_log(self, pattern):
@@ -245,6 +248,10 @@ class HIRTorture(HIR):
     def number_of_resets(self):
         return 20
 
+class SIRTorture(SIR):
+    def number_of_resets(self):
+        return 20
+
 def suite():
     s = unittest.TestSuite()
     s.addTest(FIR())
@@ -255,4 +262,5 @@ def torture_suite():
     s = unittest.TestSuite()
     s.addTest(FIRTorture())
     s.addTest(HIRTorture())
+    s.addTest(SIRTorture())
     return s


### PR DESCRIPTION
Currently our testcase directly triggers the system dump
even the dump policy for it is disabled, which results in
our testcase won't trigger any system dump and just simply
system IPL's without dumping system files(OPAL, printk, hbrt log)

So this patch fixes this issue by enabling the system dump policy
before triggering any system dump. And also this adds conditions
to retrieve individual files after dump is generated and make
sure the three files(OPAL, hbrt log and printk log) collected
properly.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/140)
<!-- Reviewable:end -->
