### PR TITLE
New support for addons, allowing for dynamic loading of bmc types

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -15,6 +15,27 @@ from common.OpTestOpenBMC import HostManagement
 from common.OpTestWeb import OpTestWeb
 import argparse
 
+# Look at the addons dir for any additional OpTest supported types
+# If new type was called Kona, the layout would be as follows
+# op-test-framework/addons/Kona/
+#                              /OpTestKona.py
+#                              /OpTestKonaSystem.py
+#                              /OpTestKonaSetup.py
+#
+# OpTestKona and OpTestKonaSystem follow the same format the other supported type modules
+# OpTestKonaSetup is unique for the addons and contains 2 helper functions:
+# addBMCType - used to populate the choices list for --bmc-type
+# createSystem - does creation of bmc and op_system objects
+
+import importlib
+import os
+import addons
+optAddons = dict() # Store all addons found.  We'll loop through it a couple time below
+# Look at the top level of the addons for any directories and load their Setup modules
+for dir in (os.walk('addons').next()[1]):
+    print(dir)
+    optAddons[dir] = importlib.import_module("addons." + dir + ".OpTest" + dir + "Setup")
+
 class OpTestConfiguration():
     def __init__(self):
         self.args = []
@@ -42,8 +63,13 @@ class OpTestConfiguration():
 
         bmcgroup = parser.add_argument_group('BMC',
                                              'Options for Service Processor')
+        # The default supported BMC choices in --bmc-type
+        bmcChoices = ['AMI','FSP', 'OpenBMC', 'qemu']
+        # Loop through any addons let it append the extra bmcChoices
+        for opt in optAddons:
+            bmcChoices = optAddons[opt].AddBMCType(bmcChoices)
         bmcgroup.add_argument("--bmc-type",
-                              choices=['AMI','FSP', 'OpenBMC', 'qemu'],
+                              choices=bmcChoices,
                               help="Type of service processor")
         bmcgroup.add_argument("--bmc-ip", help="BMC address")
         bmcgroup.add_argument("--bmc-username", help="SSH username for BMC")
@@ -161,6 +187,10 @@ class OpTestConfiguration():
                              self.args.kernel,
                              self.args.initramfs)
             self.op_system = OpTestQemuSystem(host=host, bmc=bmc)
+        # Check that the bmc_type exists in our loaded addons then create our objects
+        elif self.args.bmc_type in optAddons:
+            print repr(self.args)
+            (bmc, self.op_system) = optAddons[self.args.bmc_type].createSystem(self, host)
         else:
             raise Exception("Unsupported BMC Type")
 

--- a/addons/__init__.py
+++ b/addons/__init__.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/__init__.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG


### PR DESCRIPTION
- dynamic importing of OpTest modules found in addons dir
  that following naming convention described in comments
- no impact on existing defined types

Signed-off-by: Jason Albert <albertj@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/146)
<!-- Reviewable:end -->
