### PR TITLE
Support for addons to define additional test suites

### DIFF
--- a/op-test
+++ b/op-test
@@ -324,6 +324,10 @@ suites = {
     'full' : FullSuite(),
 }
 
+# Loop through the addons and load in suites defined there
+for opt in OpTestConfiguration.optAddons:
+    suites = OpTestConfiguration.optAddons[opt].addSuites(suites)
+
 if OpTestConfiguration.conf.args.list_suites:
     print '{0:34}{1}'.format('Test Suite', 'Description')
     print '{0:34}{1}'.format('----------', '-----------')


### PR DESCRIPTION
- New function, addSuites, that will add dict entries to define
  additional test suites
- Suite definition and testcase import done in addon setup file

Signed-off-by: Jason Albert <albertj@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/149)
<!-- Reviewable:end -->
