### PR TITLE
OPAL Lids flashing support in FSP/AMI/OpenBMC systems.

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -104,7 +104,9 @@ class OpTestConfiguration():
         imagegroup = parser.add_argument_group('Images', 'Firmware LIDs/images to flash')
         imagegroup.add_argument("--firmware-images", help="Firmware images directory")
         imagegroup.add_argument("--host-pnor", help="PNOR image to flash")
-        imagegroup.add_argument("--host-lid", help="Skiboot LID to flash")
+        imagegroup.add_argument("--host-skiboot", help="Skiboot LID to flash")
+        imagegroup.add_argument("--host-skiroot-kernel", help="Skiroot Kernel LID to flash")
+        imagegroup.add_argument("--host-skiroot-initrd", help="Skiroot initramfs LID to flash")
         imagegroup.add_argument("--host-hpm", help="HPM image to flash")
         imagegroup.add_argument("--host-img-url", help="URL to Host Firmware image to flash on FSP systems (Must be URL accessible petitboot shell on the host)")
 

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -42,6 +42,11 @@ from OpTestIPMI import OpTestIPMI
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
 from OpTestWeb import OpTestWeb
+from Exceptions import CommandFailed
+
+class SSHConnectionState():
+    DISCONNECTED = 0
+    CONNECTED = 1
 
 class OpTestBMC():
     def __init__(self, ip=None, username=None, password=None, i_ffdcDir=None, ipmi=None, rest=None, web=None):
@@ -52,6 +57,7 @@ class OpTestBMC():
         self.cv_IPMI = ipmi
         self.rest = rest
         self.cv_WEB = web
+        self.state = SSHConnectionState.DISCONNECTED
 
     def bmc_host(self):
         return self.cv_bmcIP
@@ -65,71 +71,83 @@ class OpTestBMC():
     def get_host_console(self):
         return self.cv_IPMI.get_host_console()
 
-    ##
-    # @brief This function runs a command on the BMC
-    #
-    # @param logFile: File where the command output will be written.
-    #        All command output files are placed in the FFDC directory as configured
-    #        in the config file.
-    # @param timeout @type int: Command timeout in seconds. If not specified, the
-    #        default timeout value is 60 seconds.
-    #
-    # @return int -- the return code, 0: success,
-    #                or raises: OpTestError
-    #
-    def _cmd_run(self, cmdStr, timeout=60, logFile=None):
+    def new_pxssh(self):
+        # pxssh has a nice 'echo=False' mode, but only
+        # on more recent distros, so we can't use it :(
+        p = pxssh.pxssh()
+        # Work-around for old pxssh not having options= parameter
+        p.SSH_OPTS = p.SSH_OPTS + " -o 'StrictHostKeyChecking=no'"
+        p.SSH_OPTS = p.SSH_OPTS + " -o 'UserKnownHostsFile /dev/null' "
+        p.force_password = True
+        p.logfile = sys.stdout
+        p.PROMPT = '# '
+        self.pxssh = p
+        return p
 
-        ''' Add -k to the SSH options '''
-        hostname = self.cv_bmcIP + " -k"
+    def terminate(self):
+        if self.state == SSHConnectionState.CONNECTED:
+            self.pxssh.terminate()
+            self.state = SSHConnectionState.DISCONNECTED
 
+    def connect(self):
+        if self.state == SSHConnectionState.CONNECTED:
+            self.pxssh.terminate()
+            self.state = SSHConnectionState.DISCONNECTED
+
+        print "#SSH CONNECT"
+        p = self.new_pxssh()
+        p.login(self.cv_bmcIP, self.cv_bmcUser, self.cv_bmcPasswd, auto_prompt_reset=False)
+        p.sendline()
+        p.prompt(timeout=60)
+        p.sendcontrol('l')
+        p.expect(r'.+#')
+        p.sendline('PS1=[PEXPECT]\#')
+        p.expect("\n") # from us, because echo
+        l_rc = p.expect("\[PEXPECT\]#$")
+        if l_rc == 0:
+            print "Shell prompt changed"
+        else:
+            raise Exception("Failed during change of shell prompt")
+        self.state = SSHConnectionState.CONNECTED
+
+
+    def get_console(self):
+        if self.state == SSHConnectionState.DISCONNECTED:
+            self.connect()
+
+        count = 0
+        while (not self.pxssh.isalive()):
+            print '# Reconnecting'
+            if (count > 0):
+                time.sleep(2)
+            self.connect()
+            count += 1
+            if count > 120:
+                raise Exception("Cannot login via SSH")
+
+        return self.pxssh
+
+    def run_command(self, command, timeout=300):
+        c = self.get_console()
+        c.sendline(command)
+        c.expect("\n") # from us
+        c.expect("\[PEXPECT\]#$", timeout=timeout)
+        output = c.before.splitlines()
+        c.sendline("echo $?")
+        c.expect("\[PEXPECT\]#$", timeout=timeout)
+        exitcode = int(''.join(c.before.splitlines()[1:]))
+        if exitcode != 0:
+            raise CommandFailed(command, output, exitcode)
+        return output
+
+    # This command just runs and returns the ouput & ignores the failure
+    def run_command_ignore_fail(self, command, timeout=60):
         try:
-            p = pxssh.pxssh()
+            output = self.run_command(command, timeout)
+        except CommandFailed as cf:
+            output = cf.output
+        return output
 
-            # Work-around for old pxssh not having options= parameter
-            p.SSH_OPTS = p.SSH_OPTS + " -o 'StrictHostKeyChecking=no'"
-            p.SSH_OPTS = p.SSH_OPTS + " -o 'UserKnownHostsFile /dev/null' "
-            p.force_password = True
-
-            p.logfile = sys.stdout
-            p.PROMPT = '# '
-
-            ''' login but do not try to change the prompt since the AMI bmc
-                busybox does support it '''
-
-            # http://superuser.com/questions/839878/how-to-solve-python-bug-without-root-permission
-            p.login(hostname, self.cv_bmcUser, self.cv_bmcPasswd, login_timeout=timeout, auto_prompt_reset=False)
-            p.sendline()
-            p.prompt(timeout=60)
-            print 'At BMC %s prompt...' % self.cv_bmcIP
-
-            p.sendline(cmdStr)
-            p.prompt(timeout=timeout)
-
-            ''' if optional argument is set, save command output to file '''
-
-            if logFile is not None and self.cv_ffdcDir is not None:
-                fn = self.cv_ffdcDir + "/" + logFile
-                with open(fn, 'w') as f:
-                    f.write(p.before)
-
-            p.sendline('echo $?')
-            index = p.expect(['0', '1', pexpect.TIMEOUT])
-        except IOError as hell:
-            raise hell
-
-        if index == 0:
-            rc = 0
-        elif index == 1:
-            l_msg = "Command not on BMC or failed"
-            print l_msg
-            raise OpTestError(l_msg)
-        elif index == 2:
-            l_msg = 'Non-zero return code detected, command failed'
-            print l_msg
-            raise OpTestError(l_msg)
-            #rc = p.before
-
-        return rc
 
     ##
     # @brief This function issues the reboot command on the BMC console.  It then
@@ -144,7 +162,7 @@ class OpTestBMC():
 
         retries = 0
         try:
-            self._cmd_run('reboot', logFile='bmc_reboot.log')
+            self.run_command('reboot')
         except pexpect.EOF:
             pass
         print 'Sent reboot command now waiting for reboot to complete...'
@@ -169,14 +187,14 @@ class OpTestBMC():
         return BMC_CONST.FW_SUCCESS
 
     ##
-    # @brief This function copies the PNOR image to the BMC /tmp dir
+    # @brief This function copies the given image to the BMC /tmp dir
     #
     # @return the rsync command return code
     #
-    def pnor_img_transfer(self,i_imageDir,i_imageName):
+    def image_transfer(self,i_imageDir,i_imageName):
 
-        pnor_path = i_imageDir + i_imageName
-        rsync_cmd = 'rsync -v -e "ssh -k -o StrictHostKeyChecking=no" %s %s@%s:/tmp' % (pnor_path,
+        img_path = i_imageDir + i_imageName
+        rsync_cmd = 'rsync -v -e "ssh -k -o StrictHostKeyChecking=no" %s %s@%s:/tmp' % (img_path,
                                                             self.cv_bmcUser,
                                                             self.cv_bmcIP)
 
@@ -211,25 +229,34 @@ class OpTestBMC():
     #
     def pnor_img_flash_ami(self, i_pflash_dir, i_imageName):
         cmd = i_pflash_dir + '/pflash -e -f -p /tmp/%s' % i_imageName
-        rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
+        rc = self.run_command(cmd, timeout=1800)
         return rc
 
     # on openbmc systems pflash tool available
     def pnor_img_flash_openbmc(self, i_imageName):
         cmd = 'pflash -E -f -p /tmp/%s' % i_imageName
-        rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
+        rc = self.run_command(cmd, timeout=1800)
         return rc
 
     def skiboot_img_flash_ami(self, i_pflash_dir, i_imageName):
         cmd = i_pflash_dir + '/pflash -p /tmp/%s -e -f -P PAYLOAD' % i_imageName
-        rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
+        rc = self.run_command(cmd, timeout=1800)
+        return rc
+
+    def skiroot_img_flash_ami(self, i_pflash_dir, i_imageName):
+        cmd = i_pflash_dir + '/pflash -p /tmp/%s -e -f -P BOOTKERNEL' % i_imageName
+        rc = self.run_command(cmd, timeout=1800)
         return rc
 
     def skiboot_img_flash_openbmc(self, i_imageName):
         cmd = 'pflash -p /tmp/%s -e -f -P PAYLOAD' % i_imageName
-        rc = self._cmd_run(cmd, timeout=1800, logFile='pflash.log')
+        rc = self.run_command(cmd, timeout=1800)
         return rc
 
+    def skiroot_img_flash_openbmc(self, i_imageName):
+        cmd = 'pflash -p /tmp/%s -e -f -P BOOTKERNEL' % i_imageName
+        rc = self.run_command(cmd, timeout=1800)
+        return rc
 
     ##
     # @brief This function validates presence of pflash tool, which will be
@@ -242,12 +269,8 @@ class OpTestBMC():
     def validate_pflash_tool(self, i_dir):
         l_cmd = "which " + i_dir + "/pflash"
         try:
-            l_res = self._cmd_run(l_cmd)
-        except OpTestError:
-            l_msg = "Either pflash tool is not available in BMC or Command execution failed"
+            l_res = self.run_command(l_cmd)
+        except CommandFailed:
+            l_msg = "pflash tool is not available in BMC busybox"
             print l_msg
             raise OpTestError(l_msg)
-        if l_res == BMC_CONST.FW_SUCCESS:
-            print "pflash tool is available on the BMC"
-            return BMC_CONST.FW_SUCCESS
-

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -506,14 +506,17 @@ class OpTestOpenBMC():
         # After a BMC reboot REST API needs login again
         self.rest_api.login()
 
-    def pnor_img_transfer(self, i_pflash_dir, i_imageName):
-        self.bmc.pnor_img_transfer(i_pflash_dir, i_imageName)
+    def image_transfer(self, i_pflash_dir, i_imageName):
+        self.bmc.image_transfer(i_pflash_dir, i_imageName)
 
     def pnor_img_flash_openbmc(self, pnor_name):
         self.bmc.pnor_img_flash_openbmc(pnor_name)
 
     def skiboot_img_flash_openbmc(self, lid_name):
         self.bmc.skiboot_img_flash_openbmc(lid_name)
+
+    def skiroot_img_flash_openbmc(self, lid_name):
+        self.bmc.skiroot_img_flash_openbmc(lid_name)
 
     def bmc_host(self):
         return self.hostname

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -61,6 +61,9 @@ class OpTestFlashBase(unittest.TestCase):
         self.platform = conf.platform()
         self.util = OpTestUtil()
         self.bmc_type = conf.args.bmc_type
+        self.bmc_ip = conf.args.bmc_ip
+        self.bmc_username = conf.args.bmc_username
+        self.bmc_password = conf.args.bmc_password
 
     def validate_side_activated(self):
         l_bmc_side, l_pnor_side = self.cv_IPMI.ipmi_get_side_activated()
@@ -87,6 +90,9 @@ class OpTestFlashBase(unittest.TestCase):
 
         return True
 
+    def scp_file(self, src_file_path, dst_file_path):
+        self.util.copyFilesToDest(src_file_path, self.bmc_username, self.bmc_ip,
+                                  dst_file_path, self.bmc_password, "2", BMC_CONST.SCP_TO_REMOTE)
 
 class PNORFLASH(OpTestFlashBase):
     def setUp(self):
@@ -106,7 +112,7 @@ class PNORFLASH(OpTestFlashBase):
             self.validate_side_activated()
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
         self.cv_SYSTEM.sys_sdr_clear()
-        self.cv_BMC.pnor_img_transfer(self.images_dir, self.pnor_name)
+        self.cv_BMC.image_transfer(self.images_dir, self.pnor_name)
         if "AMI" in self.bmc_type:
             self.cv_BMC.pnor_img_flash_ami("/tmp", self.pnor_name)
         elif "OpenBMC" in self.bmc_type:
@@ -118,31 +124,80 @@ class PNORFLASH(OpTestFlashBase):
         self.cv_SYSTEM.sys_sel_check()
 
 
-class SkibootLidFLASH(OpTestFlashBase):
+class OpalLidsFLASH(OpTestFlashBase):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.images_dir = conf.args.firmware_images
-        self.lid_name = conf.args.host_lid
-        self.lid_path = os.path.join(self.images_dir, self.lid_name)
-        self.assertNotEqual(os.path.exists(self.lid_path), 0,
-            "Skiboot lid %s not doesn't exist" % self.lid_path)
-        super(SkibootLidFLASH, self).setUp()
+        self.skiboot = conf.args.host_skiboot
+        self.skiroot_kernel = conf.args.host_skiroot_kernel
+        self.skiroot_initramfs = conf.args.host_skiroot_initrd
+        self.ext_lid_test_path = "/opt/extucode/lid_test"
+        for lid in [self.skiboot, self.skiroot_kernel, self.skiroot_initramfs]:
+            if lid:
+                self.lid_path = os.path.join(self.images_dir, lid)
+                self.assertNotEqual(os.path.exists(self.lid_path), 0,
+                    "OPAL lid %s not doesn't exist" % self.lid_path)
+        super(OpalLidsFLASH, self).setUp()
 
     def runTest(self):
-        if any(s in self.bmc_type for s in ("FSP", "QEMU")):
-            self.skipTest("OP AMI/OpenBMC PNOR Flash test")
+        self.assertIsNotNone(self.skiboot, "No skiboot/OPAL lid provided")
+
         if "AMI" in self.bmc_type:
             self.cv_BMC.validate_pflash_tool("/tmp")
             self.validate_side_activated()
+
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
         self.cv_SYSTEM.sys_sdr_clear()
-        self.cv_BMC.pnor_img_transfer(self.images_dir, self.lid_name)
+        if "FSP" in self.bmc_type:
+            self.cv_BMC.fsp_get_console()
+            if not self.cv_BMC.mount_exists():
+                raise OpTestError("Please mount NFS and retry the test")
+            self.cv_BMC.fsp_run_command("/usr/sbin/sshd")
+            cmd = "rm -fr {0} 2> dev/null; mkdir -p {0}".format(self.ext_lid_test_path)
+            self.cv_BMC.fsp_run_command(cmd)
+            if self.skiboot:
+                self.cv_BMC.fsp_run_command("cp /opt/extucode/80f00100.lid %s/80f00100_bkp.lid" % self.ext_lid_test_path)
+                print "Backup of skiboot lid is in %s/80f00100_bkp.lid" % self.ext_lid_test_path
+                self.lid_path = os.path.join(self.images_dir, self.skiboot)
+                self.scp_file(self.lid_path, self.ext_lid_test_path + "/80f00100.lid")
+                self.cv_BMC.fsp_run_command("cp %s/80f00100.lid /opt/extucode/" % self.ext_lid_test_path)
+
+            if not self.skiroot_kernel and not self.skiroot_initramfs:
+                print "No skiroot lids provided, Flashing only skiboot"
+            else:
+                self.cv_BMC.fsp_run_command("cp /opt/extucode/80f00101.lid %s/80f00101_bkp.lid" % self.ext_lid_test_path)
+                print "Backup of skiroot kernel lid is in %s/80f00101_bkp.lid" % self.ext_lid_test_path
+                self.cv_BMC.fsp_run_command("cp /opt/extucode/80f00102.lid %s/80f00102_bkp.lid" % self.ext_lid_test_path)
+                print "Backup of skiroot initrd lid is in %s/80f00102_bkp.lid" % self.ext_lid_test_path
+                self.lid_path = os.path.join(self.images_dir, self.skiroot_kernel)
+                self.scp_file(self.lid_path, self.ext_lid_test_path + "/80f00101.lid")
+                self.lid_path = os.path.join(self.images_dir, self.skiroot_initramfs)
+                self.scp_file(self.lid_path, self.ext_lid_test_path + "/80f00102.lid")
+                self.cv_BMC.fsp_run_command("cp %s/80f00101.lid /opt/extucode/" % self.ext_lid_test_path)
+                self.cv_BMC.fsp_run_command("cp %s/80f00102.lid /opt/extucode/" % self.ext_lid_test_path)
+            print "Regenerating the hashes by running command cupdmfg -opt"
+            self.cv_BMC.fsp_run_command("cupdmfg -opt")
+
         if "AMI" in self.bmc_type:
-            self.cv_BMC.skiboot_img_flash_ami("/tmp", self.lid_name)
-        elif "OpenBMC" in self.bmc_type:
-            self.cv_BMC.skiboot_img_flash_openbmc(self.lid_name)
+            self.cv_BMC.image_transfer(self.images_dir, self.skiboot)
+            self.cv_BMC.skiboot_img_flash_ami("/tmp", self.skiboot)
+            if self.skiroot_kernel:
+                self.cv_BMC.image_transfer(self.images_dir, self.skiroot_kernel)
+                self.cv_BMC.skiroot_img_flash_ami("/tmp", self.skiroot_kernel)
+            else:
+                print "No skiroot lid provided, flashed only Skiboot"
+
+        if "OpenBMC" in self.bmc_type:
+            self.cv_BMC.image_transfer(self.images_dir, self.skiboot)
+            self.cv_BMC.skiboot_img_flash_openbmc(self.skiboot)
+            if self.skiroot_kernel:
+                self.cv_BMC.image_transfer(self.images_dir, self.skiroot_kernel)
+                self.cv_BMC.skiroot_img_flash_openbmc("/tmp", self.skiroot_kernel)
+            else:
+                print "No skiroot lid provided, flashed only Skiboot"
+
         console = self.cv_SYSTEM.console.get_console()
-        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         if "AMI" in self.bmc_type:
             self.validate_side_activated()
         self.cv_SYSTEM.sys_sel_check()


### PR DESCRIPTION
This patch supports for flashing OPAL Lids(Both skiboot and skiroot lids)
on all the BMC types. skiboot is manadatory and skiroot is optional.

And also re-structured the code of BMC access functions in OpTestBMC
to use new state machine. So this new code is now more stable.

For OpenBMC also has added two formats of flashing(PNOR and OPAL Lids),
but as per OpenBMC team host firmware updates are going to change. The
new update method's are going to use REST API instead of pflash tool.

TODO: Change the update methods for OpenBMC systems, until then we can
use old method.

Reference command's for FSP systems:
a. To flash both skiboot & skiroot lids:
./op-test --bmc-type FSP  ........
--firmware-images images/ --host-skiboot skiboot.lid --host-skiroot-kernel zImage.epapr
--host-skiroot-initrd rootfs.cpio.xz --run testcases.OpTestFlash.OpalLidsFLASH

b. To flash only skiboot lid:
./op-test --bmc-type FSP  ........
--firmware-images images/ --host-skiboot skiboot.lid --run testcases.OpTestFlash.OpalLidsFLASH

Same commands we can use for other BMC systems as well. So here skiboot is manadatory
and skiroot is optional.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/152)
<!-- Reviewable:end -->
