### PR TITLE
Add new code update method for OpenBMC systems.

### DIFF
--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -44,6 +44,10 @@ class RestAPI(unittest.TestCase):
         if "OpenBMC" not in self.bmc_type:
             self.skipTest("OpenBMC specific Rest API Tests")
         self.curltool.log_result()
+        # Upload image
+        self.rest.upload_image(os.path.basename("README.md"))
+        # Software enumerate
+        self.rest.software_enumerate()
         # FRU Inventory
         self.rest.get_inventory()
         # Sensors


### PR DESCRIPTION
This patch adds support for updating PNOR code via new
methods which uses REST API instead of pflash tool.

And this will determine first whether openbmc has the newer
code or not. If there is no code it will fall back to old
pflash method.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/154)
<!-- Reviewable:end -->
