### PR TITLE
Support for setting output location

### DIFF
--- a/op-test
+++ b/op-test
@@ -375,10 +375,10 @@ if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.
 xml_msg = ""
 def run_tests(t):
     try:
+        print("Output to be written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
         import xmlrunner  # requires unittest-xml-reporting package
-        xml_dir = 'test-reports'
-        res = xmlrunner.XMLTestRunner(output=xml_dir, verbosity=2).run(t)
-        xml_msg = ", XML output of tests available in %s directory" % xml_dir
+        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
+        print("Output written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
         return res
     except ImportError, err:
         sys.stderr.write("WARNING: xmlrunner module not available, falling back to using unittest...\n\n")


### PR DESCRIPTION
- Issue #157
- default dir of "test-results" preserved
- can be changed via cmdline -o/--output or env var OP_TEST_OUTPUT
  with cmdline taking precedence
- print output directory at start and end of run
  msg was being created, but never written to screen
- via --suffix allow changing of suffix added to files
  default still current time
- output and outsuffix load into conf so available to tests
  for use if needed

Signed-off-by: Jason Albert <albertj@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/161)
<!-- Reviewable:end -->
