### PR TITLE
Fix for ssl unverif context not supported in python < 2.7.9

### DIFF
--- a/common/OpTestASM.py
+++ b/common/OpTestASM.py
@@ -44,7 +44,11 @@ import urllib
 import urllib2
 import re
 import ssl
-ssl._create_default_https_context = ssl._create_unverified_context
+# Work around issues with python < 2.7.9
+try:
+    ssl._create_default_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
 
 class OpTestASM:
 


### PR DESCRIPTION
Signed-off-by: Jason Albert <albertj@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/170)
<!-- Reviewable:end -->
