### PR TITLE
Explicitly use python2 instead of /usr/bin/python

### DIFF
--- a/addons/__init__.py
+++ b/addons/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/Exceptions.py
+++ b/common/Exceptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/common/OpTestASM.py
+++ b/common/OpTestASM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # encoding=utf8
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestError.py
+++ b/common/OpTestError.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestFSP.py
+++ b/common/OpTestFSP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # encoding=utf8
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # encoding=utf8
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # OpenPOWER Automated Test Project
 #

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestTConnection.py
+++ b/common/OpTestTConnection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # encoding=utf8
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/OpTestWeb.py
+++ b/common/OpTestWeb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/BmcPageConstants.py
+++ b/common/util/web/BmcPageConstants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/FWUpdatePage.py
+++ b/common/util/web/FWUpdatePage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/LoginPage.py
+++ b/common/util/web/LoginPage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/MaintenancePage.py
+++ b/common/util/web/MaintenancePage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/Page.py
+++ b/common/util/web/Page.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/common/util/web/seleniumimports.py
+++ b/common/util/web/seleniumimports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/op-test
+++ b/op-test
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/AT24driver.py
+++ b/testcases/AT24driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/BMCResetTorture.py
+++ b/testcases/BMCResetTorture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2015,2017

--- a/testcases/BootTorture.py
+++ b/testcases/BootTorture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2015,2017

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/ConsoleBug150765.py
+++ b/testcases/ConsoleBug150765.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/DPO.py
+++ b/testcases/DPO.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/EPOW.py
+++ b/testcases/EPOW.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/FWTS.py
+++ b/testcases/FWTS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2015,2017

--- a/testcases/HelloWorld.py
+++ b/testcases/HelloWorld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/HostLogin.py
+++ b/testcases/HostLogin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/IpmiTorture.py
+++ b/testcases/IpmiTorture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/KernelLog.py
+++ b/testcases/KernelLog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/LightPathDiagnostics.py
+++ b/testcases/LightPathDiagnostics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestDumps.py
+++ b/testcases/OpTestDumps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestEEH.py
+++ b/testcases/OpTestEEH.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestFastReboot.py
+++ b/testcases/OpTestFastReboot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestIPMIReprovision.py
+++ b/testcases/OpTestIPMIReprovision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestKernel.py
+++ b/testcases/OpTestKernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestNVRAM.py
+++ b/testcases/OpTestNVRAM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestOCC.py
+++ b/testcases/OpTestOCC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestOOBIPMI.py
+++ b/testcases/OpTestOOBIPMI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestPrdDaemon.py
+++ b/testcases/OpTestPrdDaemon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpalErrorLog.py
+++ b/testcases/OpalErrorLog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017

--- a/testcases/OpalUtils.py
+++ b/testcases/OpalUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/PetitbootDropbearServer.py
+++ b/testcases/PetitbootDropbearServer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/__init__.py
+++ b/testcases/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/fspTODCorruption.py
+++ b/testcases/fspTODCorruption.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/fspresetReload.py
+++ b/testcases/fspresetReload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
 # Contributors Listed Below - COPYRIGHT 2017


### PR DESCRIPTION
On systems with Python 3 as /usr/bin/python, nothing in op-test-framework
works.  Until everything is converted to work with both Python 2 and 3,
/usr/bin/python2 should be used instead.  Every major Linux distribution
has a python2 symlink.

Signed-off-by: Russell Currey <ruscur@russell.cc>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-test-framework/173)
<!-- Reviewable:end -->
