### PR TITLE
BMC Firmware upgrade tests for both OpenBMC/SMC P9 systems.

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -124,6 +124,7 @@ class OpTestConfiguration():
                                choices=['unknown','habanero','firestone','garrison','firenze','p9dsu'])
 
         imagegroup = parser.add_argument_group('Images', 'Firmware LIDs/images to flash')
+        imagegroup.add_argument("--bmc-image", help="BMC image to flash(*.tar in OpenBMC, *.bin in SMC)")
         imagegroup.add_argument("--host-pnor", help="PNOR image to flash")
         imagegroup.add_argument("--host-hpm", help="HPM image to flash")
         imagegroup.add_argument("--host-img-url", help="URL to Host Firmware image to flash on FSP systems (Must be URL accessible petitboot shell on the host)")

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -744,6 +744,19 @@ class HostManagement():
         print "Host Image IDS: %s" % repr(l)
         return l
 
+    def bmc_image_ids(self):
+        l = self.get_list_of_image_ids()
+        for id in l[:]:
+            i = self.image_data(id)
+            # Here, we assume that if we don't have 'Purpose' it's something special
+            # like the 'active' or (new) 'functional'.
+            # Adriana has promised me that this is safe.
+            print repr(i)
+            if i['data'].get('Purpose') != 'xyz.openbmc_project.Software.Version.VersionPurpose.BMC':
+                l.remove(id)
+        print "BMC Image IDS: %s" % repr(l)
+        return l
+
 
 class OpTestOpenBMC():
     def __init__(self, ip=None, username=None, password=None, ipmi=None, rest_api=None, logfile=sys.stdout):

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -594,10 +594,11 @@ class HostManagement():
         obj = "/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition"
         self.curl.feed_data(dbus_object=obj, operation='rw', command="PUT", data=data)
         self.curl.run()
-        time.sleep(10)
+        # Wait for BMC to go down.
+        self.util.ping_fail_check(self.hostname)
+        # Wait for BMC to ping back.
         self.util.PingFunc(self.hostname, BMC_CONST.PING_RETRY_FOR_STABILITY)
-        time.sleep(5) # Need some stablity here
-        self.login()
+        # Wait for BMC ready state.
         self.wait_for_bmc_runtime()
 
     def get_bmc_state(self):
@@ -613,8 +614,8 @@ class HostManagement():
                 self.login()
             try:
                 output = self.get_bmc_state()
-            except:
-                pass
+            except FailedCurlInvocation as cf:
+                output = cf.output
             if '"data": "xyz.openbmc_project.State.BMC.BMCState.Ready"' in output:
                 print "BMC is UP & Ready"
                 break
@@ -791,8 +792,8 @@ class OpTestOpenBMC():
 
     def reboot(self):
         self.bmc.reboot()
-        # After a BMC reboot REST API needs login again
-        self.rest_api.login()
+        # After a BMC reboot, wait for it to reach ready state
+        self.rest_api.wait_for_bmc_runtime()
 
     def image_transfer(self, i_imageName):
         self.bmc.image_transfer(i_imageName)

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -36,6 +36,7 @@ import select
 import time
 import pty
 import pexpect
+import commands
 
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
@@ -196,3 +197,19 @@ class OpTestUtil():
 
         print(list)
         return list
+
+    # It waits for a ping to fail, Ex: After a BMC/FSP reboot
+    def ping_fail_check(self, i_ip):
+        cmd = "ping -c 1 " + i_ip + " 1> /dev/null; echo $?"
+        count = 0
+        while count < 500:
+            output = commands.getstatusoutput(cmd)
+            if output[1] != '0':
+                print "IP %s Comes down" % i_ip
+                break
+            count = count + 1
+            time.sleep(2)
+        else:
+            print "IP %s keeps on pinging up" % i_ip
+            return False
+        return True

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -41,7 +41,6 @@
 import os
 import re
 import time
-import commands
 import unittest
 import tarfile
 
@@ -80,19 +79,7 @@ class OpTestFlashBase(unittest.TestCase):
         print rc
 
     def bmc_down_check(self):
-        cmd = "ping -c 1 " + self.cv_BMC.host_name + " 1> /dev/null; echo $?"
-        count = 0
-        while count < 500:
-            output = commands.getstatusoutput(cmd)
-            if output[1] != '0':
-                print "FSP/BMC Comes down"
-                break
-            count = count + 1
-            time.sleep(2)
-        else:
-            self.assertTrue(False, "FSP/BMC keeps on pinging up")
-
-        return True
+        self.assertTrue(self.util.ping_fail_check(self.cv_BMC.host_name), "FSP/BMC keeps on pinging up")
 
     def scp_file(self, src_file_path, dst_file_path):
         self.util.copyFilesToDest(src_file_path, self.bmc_username, self.bmc_ip,


### PR DESCRIPTION
This patch adds support for the BMC FW upgrade procedures for
both OpenBMC/SMC systems. As we have for AMI systems already
covered in HPM update tests.

User just need to provide the BMC FW image to parameter --bmc-image
and run the test testcases.OpTestFlash.BmcImageFlash
(Not added by default yet)

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>