### PR TITLE
Fix BMC FW image flash test according to OpenBMC Implementation.

### DIFF
--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -684,6 +684,18 @@ class HostManagement():
         print repr(output)
         return output['data']['Priority']
 
+    """
+    Set the image priority
+    curl -b cjar -k -H "Content-Type: application/json" -X PUT -d '{"data":0}'
+    https://$BMC_IP/xyz/openbmc_project/software/061c4bdb/attr/Priority
+    """
+    def set_image_priority(self, id, level):
+        obj = "/xyz/openbmc_project/software/%s/attr/Priority" % id
+        data =  '\'{\"data\":%s}\'' % level
+        self.curl.feed_data(dbus_object=obj, operation='rw', command="PUT", data=data)
+        self.curl.run()
+
+
     def image_ready_for_activation(self, id, timeout=10):
         timeout = time.time() + 60*timeout
         while True:
@@ -874,6 +886,31 @@ class HostManagement():
         self.curl.feed_data(dbus_object=obj, operation='rw', command="PUT", data=data)
         return json.loads(self.curl.run())
 
+    """
+    1. functional boot side validation for both BMC and PNOR.
+    $ curl -c cjar -b cjar -k -H "Content-Type: application/json" https://$BMC_IP/xyz/openbmc_project/software/functional
+    {
+    "data": {
+        "endpoints": [
+        "/xyz/openbmc_project/software/061c4bdb",
+        "/xyz/openbmc_project/software/608e9ebe"
+        ]
+    }
+    """
+    def validate_functional_bootside(self, id):
+        obj = "/xyz/openbmc_project/software/functional"
+        self.curl.feed_data(dbus_object=obj, operation='rw', command="GET")
+        output = self.curl.run()
+        print output
+        if id in output:
+            return True
+        return False
+
+    def is_image_already_active(self, id):
+        output = self.image_data(id)
+        if output['data']['Activation'] == 'xyz.openbmc_project.Software.Activation.Activations.Active':
+            return True
+        return False
 
 class OpTestOpenBMC():
     def __init__(self, ip=None, username=None, password=None, ipmi=None, rest_api=None, logfile=sys.stdout):

--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -46,6 +46,17 @@ class RestAPI(unittest.TestCase):
         if "OpenBMC" not in self.bmc_type:
             self.skipTest("OpenBMC specific Rest API Tests")
         self.curltool.log_result()
+        # System power cap enable/disable tests
+        self.rest.power_cap_enable()
+        PowerCapEnable, PowerCap =self.rest.get_power_cap_settings()
+        self.assertEqual(int(PowerCapEnable), 1, "system power cap enable failed")
+        self.rest.power_cap_disable()
+        PowerCapEnable, PowerCap =self.rest.get_power_cap_settings()
+        self.assertEqual(int(PowerCapEnable), 0, "system power cap disable failed")
+        # OCC Active state tests using RestAPI
+        ids = self.rest.get_occ_ids()
+        for id in ids:
+            self.assertTrue(self.rest.is_occ_active(id), "OCC%s is not in active state" % id)
         # Field mode tests
         self.rest.software_enumerate()
         self.rest.has_field_mode_set()


### PR DESCRIPTION
OpenBMC just does a no operation when updating a code level of 'X'
on a system which is having already code level 'X'.

So we need to follow below procedure to have all scenarios.

1. User requested for flashing image ID 'X'
2. Upload the BMC image.
3. Get the list of BMC image ID's.
4. If 'X' is found in the list
   ---> check if it is Active or Ready
	if it is Ready ---> Activate the image and do a BMC reboot
	if it is already Active
	---> Check whether it is functional(BMC boot side is 'X') or not.
	     if it is functional ---> return
	     if it is non functional ---> Set it's priority to 0, do a BMC reboot
					  and make it functional
5. At the end verify whether BMC boots in right code which we requested for flash.

The idea is to do a no op when updating code 'X' on having system which also has
level of 'X'

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>