### PR TITLE
op-test: run RestAPI testcase after defualt & IPL suites

### DIFF
--- a/op-test
+++ b/op-test
@@ -176,9 +176,9 @@ class FullSuite():
     '''Every stable test'''
     def __init__(self):
         self.s = unittest.TestSuite()
-        self.s.addTest(testRestAPI.RestAPI())
         self.s.addTest(BasicIPLSuite().suite())
         self.s.addTest(DefaultSuite().suite())
+        self.s.addTest(testRestAPI.RestAPI())
         self.s.addTest(OpalGard.OpalGard())
         self.s.addTest(OpalUtils.OpalUtils())
         self.s.addTest(OpTestRTCdriver.HostRTC())


### PR DESCRIPTION
After a host fw update, RestAPI testcase is running, which does some
BMC tests which makes BMC to have a reboot, which can cause previous
fw update invalid.

So to avoid such a situations, lets make it run after IPL & default
suites to make sure FW upgrade procedure is valid.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>