### PR TITLE
Improve OSdeploy tests and add support for rhel and hostos

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -92,6 +92,11 @@ def get_parser():
     hostgroup.add_argument("--host-password", help="SSH password for Host")
     hostgroup.add_argument("--host-lspci", help="Known 'lspci -n -m' for host")
     hostgroup.add_argument("--host-scratch-disk", help="A block device we can erase", default="")
+    hostgroup.add_argument("--host-gateway", help="Host Gateway", default="")
+    hostgroup.add_argument("--host-submask", help="Host Subnet Mask", default="255.255.255.0")
+    hostgroup.add_argument("--host-mac", help="Host Mac address", default="")
+    hostgroup.add_argument("--host-dns", help="Host DNS", default="")
+    hostgroup.add_argument("--host-cmd", help="Shell command to run inside Host", default="")
     hostgroup.add_argument("--proxy", default="", help="proxy for the Host to access the internet. "
                            "Only needed for tests that install an OS")
     hostgroup.add_argument("--host-prompt", default="#",
@@ -102,8 +107,8 @@ def get_parser():
                            choices=['unknown','habanero','firestone','garrison','firenze','p9dsu'])
 
     osgroup = parser.add_argument_group('OS Images', 'OS Images to boot/install')
-    osgroup.add_argument("--ubuntu-cdrom", help="Ubuntu ppc64el CD/DVD install image")
-
+    osgroup.add_argument("--os-cdrom", help="OS CD/DVD install image", default="")
+    osgroup.add_argument("--os-repo", help="OS repo", default="")
     imagegroup = parser.add_argument_group('Images', 'Firmware LIDs/images to flash')
     imagegroup.add_argument("--bmc-image", help="BMC image to flash(*.tar in OpenBMC, *.bin in SMC)")
     imagegroup.add_argument("--host-pnor", help="PNOR image to flash")

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# OpTest Install Utils
+#
+
+import shutil
+import urllib2
+import os
+import threading
+import SocketServer
+import BaseHTTPServer
+import SimpleHTTPServer
+import commands
+import time
+from Exceptions import CommandFailed
+import OpTestConfiguration
+
+
+BASE_PATH = ""
+INITRD = ""
+VMLINUX = ""
+KS = ""
+DISK = ""
+USERNAME = ""
+PASSWORD = ""
+REPO = ""
+BOOTPATH = ""
+conf = OpTestConfiguration.conf
+
+
+class InstallUtil():
+    def __init__(self, base_path="", initrd="", vmlinux="",
+                 ks="", boot_path="", repo=""):
+        global BASE_PATH
+        global INITRD
+        global VMLINUX
+        global KS
+        global DISK
+        global USERNAME
+        global PASSWORD
+        global BOOTPATH
+        global REPO
+        self.conf = conf
+        self.host = conf.host()
+        self.system = conf.system()
+        self.system.host_console_unique_prompt()
+        self.console = self.system.sys_get_ipmi_console()
+        self.server = ""
+        self.repo = conf.args.os_repo
+        REPO = self.repo
+        DISK = self.host.get_scratch_disk()
+        USERNAME = self.host.username()
+        PASSWORD = self.host.password()
+        BOOTPATH = boot_path
+        BASE_PATH = base_path
+        INITRD = initrd
+        VMLINUX = vmlinux
+        KS = ks
+
+    def wait_for_network(self):
+        retry = 6
+        while retry > 0:
+            try:
+                self.console.run_command("ifconfig -a")
+                return True
+            except CommandFailed as cf:
+                if cf.exitcode is 1:
+                    time.sleep(5)
+                    retry = retry - 1
+                    pass
+                else:
+                    raise cf
+
+    def ping_network(self):
+        retry = 6
+        while retry > 0:
+            try:
+                cmd = "ping %s -c 1" % self.conf.args.host_gateway
+                self.console.run_command(cmd)
+                return True
+            except CommandFailed as cf:
+                if cf.exitcode is 1:
+                    time.sleep(5)
+                    retry = retry - 1
+                    pass
+                else:
+                    raise cf
+
+    def assign_ip_petitboot(self):
+        """
+        Assign host ip in petitboot
+        """
+        self.console.run_command("stty cols 300")
+        self.console.run_command("stty rows 30")
+        # Lets reduce timeout in petitboot
+        self.console.run_command("nvram --update-config petitboot,timeout=10")
+        cmd = "ip addr|grep -B1 -i %s|grep BROADCAST|awk -F':' '{print $2}'" % self.conf.args.host_mac
+        iface = self.console.run_command(cmd)[0].strip()
+        cmd = "ifconfig %s %s netmask %s" % (iface, self.host.ip, self.conf.args.host_submask)
+        self.console.run_command(cmd)
+        cmd = "route add default gateway %s" % self.conf.args.host_gateway
+        self.console.run_command_ignore_fail(cmd)
+        cmd = "echo 'nameserver %s' > /etc/resolv.conf" % self.conf.args.host_dns
+        self.console.run_command(cmd)
+
+    def get_server_ip(self):
+        """
+        Get IP of server where test runs
+        """
+        my_ip = ""
+        self.wait_for_network()
+        # Check if ip is assigned in petitboot
+        try:
+            self.ping_network()
+        except CommandFailed as cf:
+            self.assign_ip_petitboot()
+            self.ping_network()
+        try:
+            my_ip = self.system.get_my_ip_from_host_perspective()
+        finally:
+            self.console.run_command("ping %s -c 1" % my_ip)
+            return my_ip
+
+    def start_server(self, server_ip):
+        """
+        Start local http server
+        """
+        HOST, PORT = "0.0.0.0", 0
+        global REPO
+        self.server = ThreadedHTTPServer((HOST, PORT), ThreadedHTTPHandler)
+        ip, port = self.server.server_address
+        if not REPO:
+            REPO = "http://%s:%s/repo" % (server_ip, port)
+        print "# Listening on %s:%s" % (ip, port)
+        server_thread = threading.Thread(target=self.server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+        print "# Server running in thread:", server_thread.name
+        return port
+
+    def stop_server(self):
+        """
+        Stops local http server
+        """
+        self.server.shutdown()
+        self.server.server_close()
+        return
+
+    def setup_repo(self, cdrom):
+        """
+        Sets up repo from given cdrom.
+        Check if given cdrom is url or file
+        if url, download in the BASE_PATH and
+        mount to repo folder
+
+        :params cdrom: OS cdrom path local or remote
+        """
+        repo_path = os.path.join(BASE_PATH, 'repo')
+        abs_repo_path = os.path.abspath(repo_path)
+        # Clear already mount repo
+        if os.path.ismount(repo_path):
+            status, output = commands.getstatusoutput("umount %s" % abs_repo_path)
+            if status != 0:
+                print "failed to unmount", abs_repo_path
+                return ""
+        elif os.path.isdir(repo_path):
+            shutil.rmtree(repo_path)
+        else:
+            pass
+        if not os.path.isdir(repo_path):
+            os.makedirs(abs_repo_path)
+
+        if os.path.isfile(cdrom):
+            cdrom_path = cdrom
+        else:
+            cdrom_url = urllib2.urlopen(cdrom)
+            if not cdrom_url:
+                print "Unknown cdrom path %s" % cdrom
+                return ""
+            with open(os.path.join(BASE_PATH, "iso"), 'wb') as f:
+                f.write(cdrom_url.read())
+            cdrom_path = os.path.join(BASE_PATH, "iso")
+        cmd = "mount -t iso9660 -o loop %s %s" % (cdrom_path, abs_repo_path)
+        status, output = commands.getstatusoutput(cmd)
+        if status != 0:
+            print "Failed to mount iso %s on %s\n %s", (cdrom, abs_repo_path,
+                                                        output)
+            return ""
+        return abs_repo_path
+
+    def extract_install_files(self, repo_path):
+        """
+        extract the install file from given repo path
+
+        :params repo_path: os repo path either local or remote
+        """
+        vmlinux_src = os.path.join(repo_path, BOOTPATH, VMLINUX)
+        initrd_src = os.path.join(repo_path, BOOTPATH, INITRD)
+        vmlinux_dst = os.path.join(BASE_PATH, VMLINUX)
+        initrd_dst = os.path.join(BASE_PATH, INITRD)
+        # let us make sure, no old vmlinux, initrd
+        if os.path.isfile(vmlinux_dst):
+            os.remove(vmlinux_dst)
+        if os.path.isfile(initrd_dst):
+            os.remove(initrd_dst)
+
+        if os.path.isdir(repo_path):
+            try:
+                shutil.copyfile(vmlinux_src, vmlinux_dst)
+                shutil.copyfile(initrd_src, initrd_dst)
+            except Exception:
+                return False
+        else:
+            vmlinux_file = urllib2.urlopen(vmlinux_src)
+            initrd_file = urllib2.urlopen(initrd_src)
+            if not (vmlinux_file and initrd_file):
+                print "Unknown repo path %s, %s" % (vmlinux_src, initrd_src)
+                return False
+            try:
+                with open(vmlinux_dst, 'wb') as f:
+                    f.write(vmlinux_file.read())
+                with open(initrd_dst, 'wb') as f:
+                    f.write(initrd_file.read())
+            except Exception:
+                return False
+        return True
+
+    def set_bootable_disk(self, disk):
+        """
+        Sets the given disk as default bootable entry in petitboot
+        """
+        self.system.sys_set_bootdev_no_override()
+        self.system.host_console_unique_prompt()
+        self.console.run_command("stty cols 300")
+        self.console.run_command("stty rows 30")
+        # FIXME: wait till the device(disk) discovery in petitboot
+        time.sleep(60)
+        cmd = 'blkid %s-*' % disk
+        output = self.console.run_command(cmd)
+        uuid = output[0].split(':')[1].split('=')[1].replace("\"", "")
+        cmd = 'nvram --update-config "auto-boot?=true"'
+        output = self.console.run_command(cmd)
+        cmd = 'nvram --update-config petitboot,bootdevs=uuid:%s' % uuid
+        output = self.console.run_command(cmd)
+        cmd = 'nvram --print-config'
+        output = self.console.run_command(cmd)
+        return
+
+
+class ThreadedHTTPHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_HEAD(self):
+        # FIXME: Local repo unable to handle http request while installation
+        # Avoid using cdrom if your kickstart file needs repo, if installation
+        # just needs vmlinx and initrd from cdrom, cdrom still can be used.
+        if "repo" in self.path:
+            self.path = BASE_PATH + self.path
+            f = self.send_head()
+            if f:
+                f.close()
+        else:
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+
+    def do_GET(self):
+        if "repo" in self.path:
+            self.path = BASE_PATH + self.path
+            f = self.send_head()
+            if f:
+                try:
+                    self.copyfile(f, self.wfile)
+                finally:
+                    f.close()
+        else:
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            print "# Webserver was asked for: ", self.path
+            if self.path == "/%s" % VMLINUX:
+                f = open("%s/%s" % (BASE_PATH, VMLINUX), "r")
+                d = f.read()
+                self.wfile.write(d)
+                f.close()
+                return
+            elif self.path == "/%s" % INITRD:
+                f = open("%s/%s" % (BASE_PATH, INITRD), "r")
+                d = f.read()
+                self.wfile.write(d)
+                f.close()
+                return
+            elif self.path == "/%s" % KS:
+                f = open("%s/%s" % (BASE_PATH, KS), "r")
+                d = f.read()
+                if "hostos" in BASE_PATH:
+                    ps = d.format(REPO, PASSWORD, DISK, DISK, DISK)
+                elif "rhel" in BASE_PATH:
+                    ps = d.format(REPO, PASSWORD, DISK, DISK, DISK)
+                elif "ubuntu" in BASE_PATH:
+                    ps = d.format("openpower", "example.com",
+                                  PASSWORD, PASSWORD, DISK)
+                else:
+                    print "unknown distro"
+                self.wfile.write(ps)
+                return
+            else:
+                self.send_response(404)
+                return
+
+
+class ThreadedHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
+    pass

--- a/osimages/hostos/hostos.ks
+++ b/osimages/hostos/hostos.ks
@@ -1,0 +1,23 @@
+#HostOS Preseed for op-test
+%pre
+%end
+url --url={}
+text
+keyboard --vckeymap=us --xlayouts='us'
+services --enabled=NetworkManager,sshd
+lang en_US.UTF-8
+rootpw {}
+skipx
+timezone --utc America/New_York
+ignoredisk --only-use={}
+bootloader  --location=mbr  --append="console=tty0" --timeout=1 --boot-drive={}
+zerombr
+clearpart --all --initlabel  --drives={}
+autopart --type=lvm --fstype=ext4
+reboot
+%packages --ignoremissing
+@core
+open-power-host-os-all
+%end
+%post
+%end

--- a/osimages/rhel/rhel.ks
+++ b/osimages/rhel/rhel.ks
@@ -1,0 +1,22 @@
+# RHEL Preseed for op-test
+%pre
+%end
+url --url={}
+text
+keyboard --vckeymap=us --xlayouts='us'
+lang en_US.UTF-8
+rootpw --plaintext {}
+skipx
+timezone --utc America/New_York
+clearpart --all --initlabel --drives={}
+bootloader  --location=mbr  --boot-drive={}
+ignoredisk --only-use={}
+autopart --type=lvm --fstype=ext4
+services --enabled=NetworkManager,sshd
+reboot
+%packages
+@core
+kexec-tools
+telnet
+java
+%end

--- a/osimages/ubuntu/preseed.cfg
+++ b/osimages/ubuntu/preseed.cfg
@@ -1,0 +1,162 @@
+#Ubuntu Preseed for op-test
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+# Keyboard selection.
+# Disable automatic (interactive) keymap detection.
+d-i console-setup/ask_detect boolean false
+d-i console-setup/layoutcode string us
+d-i netcfg/get_hostname string {}
+d-i netcfg/get_domain string {}
+d-i netcfg/choose_interface select auto
+d-i netcfg/link_wait_timeout string 20
+
+d-i keyboard-configuration/xkb-keymap select us
+# If you select ftp, the mirror/country string does not need to be set.
+#d-i mirror/protocol string ftp
+d-i mirror/country string manual
+d-i mirror/http/hostname string ports.ubuntu.com
+d-i mirror/http/directory string /
+d-i mirror/http/proxy string
+
+# Alternatively: by default, the installer uses CC.archive.ubuntu.com where
+# CC is the ISO-3166-2 code for the selected country. You can preseed this
+# so that it does so without asking.
+#d-i mirror/http/mirror select CC.archive.ubuntu.com
+
+# Suite to install.
+#d-i mirror/suite string xenial
+# Suite to use for loading installer components (optional).
+#d-i mirror/udeb/suite string xenial
+# Components to use for loading installer components (optional).
+#d-i mirror/udeb/components multiselect main, restricted
+
+# Skip creation of a root account (normal user account will be able to
+# use sudo). The default is false; preseed this to true if you want to set
+# a root password.
+#d-i passwd/root-login boolean false
+# Alternatively, to skip creation of a normal user account.
+#d-i passwd/make-user boolean false
+
+# Root password, either in clear text
+#d-i passwd/root-password password
+#d-i passwd/root-password-again password
+# or encrypted using a crypt(3)  hash.
+#d-i passwd/root-password-crypted password [crypt(3) hash]
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean false
+d-i passwd/root-password password {}
+d-i passwd/root-password-again password {}
+
+# To create a normal user account.
+#d-i passwd/user-fullname string Ubuntu User
+#d-i passwd/username string
+# Normal user's password, either in clear text
+#d-i passwd/user-password password
+#d-i passwd/user-password-again password
+# or encrypted using a crypt(3) hash.
+#d-i passwd/user-password-crypted password [crypt(3) hash]
+# Create the first user with the specified UID instead of the default.
+#d-i passwd/user-uid string 1010
+# The installer will warn about weak passwords. If you are sure you know
+# what you're doing and want to override it, uncomment this.
+#d-i user-setup/allow-password-weak boolean true
+
+# The user account will be added to some standard initial groups. To
+# override that, use this.
+#d-i passwd/user-default-groups string audio cdrom video
+
+# Set to true if you want to encrypt the first user's home directory.
+d-i user-setup/encrypt-home boolean false
+
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string US/Eastern
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+# NTP server to use. The default is almost always fine here.
+#d-i clock-setup/ntp-server string ntp.example.com
+
+# Alternatively, you may specify a disk to partition. If the system has only
+# one disk the installer will default to using that, but otherwise the device
+# name must be given in traditional, non-devfs format (so e.g. /dev/sda
+# and not e.g. /dev/discs/disc0/disc).
+# For example, to use the first SCSI/SATA hard disk:
+d-i partman-auto/disk string {}
+# In addition, you'll need to specify the method to use.
+# The presently available methods are:
+# - regular: use the usual partition types for your architecture
+# - lvm:     use LVM to partition the disk
+# - crypto:  use LVM within an encrypted partition
+d-i partman-auto/method string regular
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+d-i partman/default_filesystem string ext4
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# Upgrade policy
+d-i pkgsel/upgrade select none
+
+# Update policy
+d-i pkgsel/update-policy select none
+
+# You can choose to install restricted and universe software, or to install
+# software from the backports repository.
+d-i apt-setup/restricted boolean true
+d-i apt-setup/universe boolean true
+
+# Select standard packages
+tasksel tasksel/first multiselect standard
+
+# Individual additional packages to install
+d-i pkgsel/include string openssh-server build-essential lvm2 ethtool \
+sg3-utils lsscsi libaio-dev libtime-hires-perl acpid tgt openjdk-8* zip git \
+automake python expect gcc g++ gdb python-dev p7zip python-stevedore \
+python-setuptools libvirt-dev numactl libosinfo-1.0-0 python-pip
+
+
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i debian-installer/add-kernel-opts string console=tty0 console=ttyS0,115200
+
+
+d-i apt-setup/security_host string
+base-config apt-setup/security-updates boolean false
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+d-i debian-installer/exit/halt boolean false
+d-i debian-installer/exit/poweroff boolean false
+d-i preseed/late_command string \
+echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
+echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
+echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub
+
+d-i preseed/late_command string \
+in-target sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
+in-target service ssh restart

--- a/testcases/InstallHostOS.py
+++ b/testcases/InstallHostOS.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+import unittest
+
+import OpTestConfiguration
+from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpSystemState
+from common import OpTestInstallUtil
+
+
+class InstallHostOS(unittest.TestCase):
+    def setUp(self):
+        self.conf = OpTestConfiguration.conf
+        self.host = self.conf.host()
+        self.ipmi = self.conf.ipmi()
+        self.system = self.conf.system()
+        self.bmc = self.conf.bmc()
+        self.util = OpTestUtil()
+        self.bmc_type = self.conf.args.bmc_type
+        if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
+            self.fail("Provide installation media for installation, --os-repo is missing")
+        if not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if not self.conf.args.host_scratch_disk:
+            self.fail("Provide proper host disk to install refer, --host-scratch-disk")
+
+    def runTest(self):
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        # Local path to keep install files
+        base_path = "osimages/hostos"
+        # relative path from repo where vmlinux and initrd is present
+        boot_path = "ppc/ppc64"
+        vmlinux = "vmlinuz"
+        initrd = "initrd.img"
+        ks = "hostos.ks"
+        OpIU = OpTestInstallUtil.InstallUtil(base_path=base_path,
+                                             vmlinux=vmlinux,
+                                             initrd=initrd,
+                                             ks=ks,
+                                             boot_path=boot_path)
+        my_ip = OpIU.get_server_ip()
+        if not my_ip:
+            self.fail("Unable to get the ip from host")
+
+        if self.conf.args.os_cdrom and not self.conf.args.os_repo:
+            repo = OpIU.setup_repo(self.conf.args.os_cdrom)
+        if self.conf.args.os_repo:
+            repo = self.conf.args.os_repo
+        if not repo:
+            self.fail("No valid repo to start installation")
+        if not OpIU.extract_install_files(repo):
+            self.fail("Unable to download install files")
+
+        OpIU.extract_install_files(repo)
+
+        # start our web server
+        port = OpIU.start_server(my_ip)
+
+        if "qemu" not in self.bmc_type:
+            ks_url = 'http://%s:%s/%s' % (my_ip, port, ks)
+            kernel_args = "ifname=net0:%s ip=%s::%s:%s:%s:net0:none nameserver=%s inst.ks=%s" % (self.conf.args.host_mac,
+                                                                                                 self.host.ip,
+                                                                                                 self.conf.args.host_gateway,
+                                                                                                 self.conf.args.host_submask,
+                                                                                                 self.host.hostname(),
+                                                                                                 self.conf.args.host_dns,
+                                                                                                 ks_url)
+            self.c = self.system.sys_get_ipmi_console()
+            self.system.host_console_unique_prompt()
+            cmd = "[ -f %s ]&& rm -f %s;[ -f %s ] && rm -f %s;true" % (vmlinux,
+                                                                       vmlinux,
+                                                                       initrd,
+                                                                       initrd)
+            self.c.run_command(cmd)
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, vmlinux))
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, initrd))
+            self.c.run_command("kexec -i %s -c \"%s\" %s -l" % (initrd,
+                                                                kernel_args,
+                                                                vmlinux))
+            rawc = self.c.get_console()
+            rawc.sendline("kexec -e")
+        else:
+            pass
+        # Do things
+        rawc = self.c.get_console()
+        rawc.expect('opal: OPAL detected', timeout=60)
+        r = None
+        while r != 0:
+            r = rawc.expect(['Running post-installation scripts',
+                             'Starting installer',
+                             'Setting up the installation environment',
+                             'Starting package installation process',
+                             'Performing post-installation setup tasks',
+                             'Configuring installed system'], timeout=1500)
+        rawc.expect('reboot: Restarting system', timeout=300)
+        self.system.set_state(OpSystemState.IPLing)
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        OpIU.stop_server()
+        OpIU.set_bootable_disk(self.host.get_scratch_disk())
+        self.system.goto_state(OpSystemState.OFF)
+        self.system.goto_state(OpSystemState.OS)
+        con = self.system.sys_get_ipmi_console()
+        self.system.host_console_login()
+        self.system.host_console_unique_prompt()
+        con.run_command("uname -a")
+        con.run_command("cat /etc/os-release")
+        self.host.host_gather_opal_msg_log()
+        self.host.host_gather_kernel_log()
+        # Run additional host commands if any from user
+        if self.conf.args.host_cmd:
+            con.run_command(self.conf.args.host_cmd)

--- a/testcases/InstallRhel.py
+++ b/testcases/InstallRhel.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+import unittest
+
+import OpTestConfiguration
+from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpSystemState
+from common import OpTestInstallUtil
+
+
+class InstallRhel(unittest.TestCase):
+    def setUp(self):
+        self.conf = OpTestConfiguration.conf
+        self.host = self.conf.host()
+        self.ipmi = self.conf.ipmi()
+        self.system = self.conf.system()
+        self.bmc = self.conf.bmc()
+        self.util = OpTestUtil()
+        self.bmc_type = self.conf.args.bmc_type
+        if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
+            self.fail("Provide installation media for installation, --os-repo is missing")
+        if not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if not self.conf.args.host_scratch_disk:
+            self.fail("Provide proper host disk to install refer, --host-scratch-disk")
+
+    def runTest(self):
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        # Local path to keep install files
+        base_path = "osimages/rhel"
+        # relative path from repo where vmlinux and initrd is present
+        boot_path = "ppc/ppc64"
+        vmlinux = "vmlinuz"
+        initrd = "initrd.img"
+        ks = "rhel.ks"
+        OpIU = OpTestInstallUtil.InstallUtil(base_path=base_path,
+                                             vmlinux=vmlinux,
+                                             initrd=initrd,
+                                             ks=ks,
+                                             boot_path=boot_path)
+        my_ip = OpIU.get_server_ip()
+        if not my_ip:
+            self.fail("Unable to get the ip from host")
+
+        if self.conf.args.os_cdrom and not self.conf.args.os_repo:
+            repo = OpIU.setup_repo(self.conf.args.os_cdrom)
+        if self.conf.args.os_repo:
+            repo = self.conf.args.os_repo
+        if not repo:
+            self.fail("No valid repo to start installation")
+        if not OpIU.extract_install_files(repo):
+            self.fail("Unable to download install files")
+
+        # start our web server
+        port = OpIU.start_server(my_ip)
+
+        if "qemu" not in self.bmc_type:
+            ks_url = 'http://%s:%s/%s' % (my_ip, port, ks)
+            kernel_args = "ifname=net0:%s ip=%s::%s:%s:%s:net0:none nameserver=%s inst.ks=%s" % (self.conf.args.host_mac,
+                                                                                                 self.host.ip,
+                                                                                                 self.conf.args.host_gateway,
+                                                                                                 self.conf.args.host_submask,
+                                                                                                 self.host.hostname(),
+                                                                                                 self.conf.args.host_dns,
+                                                                                                 ks_url)
+            self.c = self.system.sys_get_ipmi_console()
+            self.system.host_console_unique_prompt()
+            cmd = "[ -f %s ]&& rm -f %s;[ -f %s ] && rm -f %s;true" % (vmlinux,
+                                                                       vmlinux,
+                                                                       initrd,
+                                                                       initrd)
+            self.c.run_command(cmd)
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, vmlinux))
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, initrd))
+            self.c.run_command("kexec -i %s -c \"%s\" %s -l" % (initrd,
+                                                                kernel_args,
+                                                                vmlinux))
+            rawc = self.c.get_console()
+            rawc.sendline("kexec -e")
+        else:
+            pass
+        # Do things
+        rawc.expect('Sent SIGKILL to all processes', timeout=60)
+        r = None
+        while r != 0:
+            r = rawc.expect(['Running post-installation scripts',
+                             'Starting installer',
+                             'Setting up the installation environment',
+                             'Starting package installation process',
+                             'Performing post-installation setup tasks',
+                             'Configuring installed system'], timeout=1500)
+        rawc.expect(' Restarting system', timeout=300)
+        self.system.set_state(OpSystemState.IPLing)
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        OpIU.stop_server()
+        OpIU.set_bootable_disk(self.host.get_scratch_disk())
+        self.system.goto_state(OpSystemState.OFF)
+        self.system.goto_state(OpSystemState.OS)
+        con = self.system.sys_get_ipmi_console()
+        self.system.host_console_login()
+        self.system.host_console_unique_prompt()
+        con.run_command("uname -a")
+        con.run_command("cat /etc/os-release")
+        self.host.host_gather_opal_msg_log()
+        self.host.host_gather_kernel_log()
+        # Run additional host commands if any from user
+        if self.conf.args.host_cmd:
+            con.run_command(self.conf.args.host_cmd)

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -23,17 +23,12 @@
 import unittest
 import time
 import pexpect
-import socket
-import threading
-import SocketServer
-import BaseHTTPServer
-import subprocess
 
 import OpTestConfiguration
 from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
-from common.OpTestError import OpTestError
-from common.Exceptions import CommandFailed
+from common import OpTestInstallUtil
+
 
 class MyIPfromHost(unittest.TestCase):
     def setUp(self):
@@ -43,6 +38,7 @@ class MyIPfromHost(unittest.TestCase):
         self.system = conf.system()
         self.bmc = conf.bmc()
         self.util = OpTestUtil()
+
     def runTest(self):
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
         self.c = self.system.sys_get_ipmi_console()
@@ -50,15 +46,23 @@ class MyIPfromHost(unittest.TestCase):
         my_ip = self.system.get_my_ip_from_host_perspective()
         print "# FOUND MY IP: %s" % my_ip
 
+
 class InstallUbuntu(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
+        self.conf = conf
         self.host = conf.host()
         self.ipmi = conf.ipmi()
         self.system = conf.system()
         self.bmc = conf.bmc()
         self.util = OpTestUtil()
         self.bmc_type = conf.args.bmc_type
+        if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
+            self.fail("Provide installation media for installation, --os-repo is missing")
+        if not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if not self.conf.args.host_scratch_disk:
+            self.fail("Provide proper host disk to install refer, --host-scratch-disk")
 
     def select_petitboot_item(self, item):
         self.system.goto_state(OpSystemState.PETITBOOT)
@@ -67,7 +71,7 @@ class InstallUbuntu(unittest.TestCase):
         while r != 0:
             time.sleep(0.2)
             r = rawc.expect(['\*.*\s+' + item, '\*.*\s+', pexpect.TIMEOUT],
-                              timeout=1)
+                            timeout=1)
             if r == 0:
                 break
             rawc.send("\x1b[A")
@@ -76,61 +80,60 @@ class InstallUbuntu(unittest.TestCase):
 
     def runTest(self):
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.system.sys_get_ipmi_console()
-        self.system.host_console_unique_prompt()
 
-        retry = 30
-        while retry > 0:
-            try:
-                self.c.run_command("ifconfig -a")
-                break
-            except CommandFailed as cf:
-                if cf.exitcode is 1:
-                    time.sleep(1)
-                    retry = retry - 1
-                    pass
-                else:
-                    raise cf
+        # Set the install paths
+        base_path = "osimages/ubuntu"
+        boot_path = "ubuntu-installer/ppc64el"
+        vmlinux = "vmlinux"
+        initrd = "initrd.gz"
+        ks = "preseed.cfg"
+        OpIU = OpTestInstallUtil.InstallUtil(base_path=base_path,
+                                             vmlinux=vmlinux,
+                                             initrd=initrd,
+                                             ks=ks,
+                                             boot_path=boot_path)
+        my_ip = OpIU.get_server_ip()
+        if not my_ip:
+            self.fail("unable to get the ip from host")
 
-        retry = 30
-        while retry > 0:
-            try:
-                my_ip = self.system.get_my_ip_from_host_perspective()
-                self.c.run_command("ping %s -c 1" % my_ip)
-                break
-            except CommandFailed as cf:
-                if cf.exitcode is 1:
-                    time.sleep(1)
-                    retry = retry - 1
-                    pass
-                else:
-                    raise cf
-
-        scratch_disk_size = self.host.get_scratch_disk_size(self.c)
+        if self.conf.args.os_cdrom and not self.conf.args.os_repo:
+            repo = OpIU.setup_repo(self.conf.args.os_cdrom)
+        if self.conf.args.os_repo:
+            repo = self.conf.args.os_repo
+        if not repo:
+            self.fail("No valid repo to start installation")
+        if not OpIU.extract_install_files(repo):
+            self.fail("Unable to download install files")
 
         # start our web server
-        HOST, PORT = "0.0.0.0", 0
-        server = ThreadedHTTPServer((HOST, PORT), ThreadedHTTPHandler)
-        ip, port = server.server_address
-        print "# Listening on %s:%s" % (ip,port)
-        server_thread = threading.Thread(target=server.serve_forever)
-        server_thread.daemon = True
-        server_thread.start()
-        print "# Server running in thread:",server_thread.name
+        port = OpIU.start_server(my_ip)
 
-        my_ip = self.system.get_my_ip_from_host_perspective()
-        #self.c.run_command("wget -O- http://%s:%s" % (my_ip, port))
-        #time.sleep(10)
+        if not self.conf.args.os_repo:
+            repo = 'http://%s:%s/repo' % (my_ip, port)
 
-        kernel_args = (' auto=true priority=critical interface=auto '
+        kernel_args = (' auto console=ttyS0 '
+                       'interface=auto '
+                       'netcfg/disable_autoconfig=true '
+                       'netcfg/get_nameservers=%s '
+                       'netcfg/get_ipaddress=%s '
+                       'netcfg/get_netmask=%s '
+                       'netcfg/get_gateway=%s '
                        'debian-installer/locale=en_US '
                        'console-setup/ask_detect=false '
                        'console-setup/layoutcode=us '
                        'netcfg/get_hostname=ubuntu '
                        'netcfg/get_domain=example.com '
                        'netcfg/link_wait_timeout=60 '
-                       'preseed/url=http://%s:%s/preseed.cfg' % (my_ip, port))
-
+                       'partman-auto/disk=%s '
+                       'locale=en_US '
+                       'url=http://%s:%s/preseed.cfg' % (self.conf.args.host_dns,
+                                                         self.host.ip,
+                                                         self.conf.args.host_submask,
+                                                         self.conf.args.host_gateway,
+                                                         self.host.get_scratch_disk(),
+                                                         my_ip, port))
+        self.c = self.system.sys_get_ipmi_console()
+        self.system.host_console_unique_prompt()
         if "qemu" in self.bmc_type:
             kernel_args = kernel_args + ' netcfg/choose_interface=auto '
             # For Qemu, we boot from CDROM, so let's use petitboot!
@@ -140,240 +143,60 @@ class InstallUbuntu(unittest.TestCase):
             # In future, we should implement a method like this:
             #  self.petitboot_select_field('Boot arguments:')
             # But, in the meantime:
-            rawc.send('\t\t\t\t') # FIXME :)
-            rawc.send('\b\b\b\b') # remove ' ---'
-            rawc.send('\b\b\b\b\b') #remove 'quiet'
+            rawc.send('\t\t\t\t')  # FIXME :)
+            rawc.send('\b\b\b\b')  # remove ' ---'
+            rawc.send('\b\b\b\b\b')  # remove 'quiet'
             rawc.send(kernel_args)
             rawc.send('\t')
             rawc.sendline('')
             rawc.sendline('')
         else:
-            # With a "Normal" BMC rather than a simulator,
-            # we need to go and grab things from the network to netboot
+            kernel_args = kernel_args + ' netcfg/choose_interface=%s BOOTIF=01-%s' % (self.conf.args.host_mac,
+                                                                                      '-'.join(self.conf.args.host_mac.split(':')))
 
-            # We also need to work around an Ubuntu/Debian installer bug:
-            # https://bugs.launchpad.net/ubuntu/+source/netcfg/+bug/713385
-            arp = subprocess.check_output(['arp', self.host.hostname()]).split('\n')[1]
-            arp = arp.split()
-            host_mac_addr = arp[2]
-            print "# Found host mac addr %s", host_mac_addr
-            kernel_args = kernel_args + ' netcfg/choose_interface=%s ' % host_mac_addr
-
-            self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c.run_command("wget http://%s:%s/ubuntu/vmlinux" % (my_ip, port))
-            self.c.run_command("wget http://%s:%s/ubuntu/initrd.gz" % (my_ip, port))
-            self.c.run_command("kexec -i initrd.gz -c \"%s\" vmlinux -l" % kernel_args)
-            self.c.get_console().send("kexec -e\n")
-
-        self.system.wait_for_kexec()
+            cmd = "[ -f %s ]&& rm -f %s;[ -f %s ] && rm -f %s;true" % (vmlinux,
+                                                                       vmlinux,
+                                                                       initrd,
+                                                                       initrd)
+            self.c.run_command(cmd)
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, vmlinux))
+            self.c.run_command("wget http://%s:%s/%s" % (my_ip, port, initrd))
+            self.c.run_command("kexec -i %s -c \"%s\" %s -l" % (initrd,
+                                                                kernel_args,
+                                                                vmlinux))
+            rawc = self.c.get_console()
+            rawc.sendline("kexec -e")
 
         # Do things
-        rawc = self.c.get_console()
-        rawc.expect('Network autoconfiguration has succeeded',timeout=300)
-        rawc.expect('Loading additional components',timeout=300)
-        rawc.expect('Setting up the clock',timeout=300)
-        rawc.expect('Detecting hardware',timeout=300)
-        rawc.expect('Partitions formatting',timeout=300)
-        rawc.expect('Installing the base system',timeout=300)
+        rawc.expect('Sent SIGKILL to all processes', timeout=60)
+        rawc.expect('Loading additional components', timeout=300)
+        rawc.expect('Setting up the clock', timeout=300)
+        rawc.expect('Detecting hardware', timeout=300)
+        rawc.expect('Partitions formatting', timeout=300)
+        rawc.expect('Installing the base system', timeout=300)
         r = None
         while r != 0:
             r = rawc.expect(['Finishing the installation',
                              'Select and install software',
                              'Preparing', 'Configuring',
                              'Cleaning up'
-                             'Retrieving','Installing',
+                             'Retrieving', 'Installing',
                              'boot loader',
-                             'Running'], timeout=300)
+                             'Running'], timeout=600)
         rawc.expect('Requesting system reboot', timeout=300)
         self.system.set_state(OpSystemState.IPLing)
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-
-        server.shutdown()
-        server.server_close()
-
-class ThreadedHTTPHandler(BaseHTTPServer.BaseHTTPRequestHandler):
-    UBUNTU_PRESEED = """#Ubuntu Preseed for op-test
-# Preseeding only locale sets language, country and locale.
-d-i debian-installer/locale string en_US
-# Keyboard selection.
-# Disable automatic (interactive) keymap detection.
-d-i console-setup/ask_detect boolean false
-d-i console-setup/layoutcode string us
-d-i netcfg/get_hostname string {}
-d-i netcfg/get_domain string {}
-d-i netcfg/choose_interface select auto
-d-i netcfg/link_wait_timeout string 20
-
-d-i keyboard-configuration/xkb-keymap select us
-# If you select ftp, the mirror/country string does not need to be set.
-#d-i mirror/protocol string ftp
-d-i mirror/country string manual
-d-i mirror/http/hostname string ports.ubuntu.com
-d-i mirror/http/directory string /
-d-i mirror/http/proxy string {}
-
-# Alternatively: by default, the installer uses CC.archive.ubuntu.com where
-# CC is the ISO-3166-2 code for the selected country. You can preseed this
-# so that it does so without asking.
-#d-i mirror/http/mirror select CC.archive.ubuntu.com
-
-# Suite to install.
-#d-i mirror/suite string xenial
-# Suite to use for loading installer components (optional).
-#d-i mirror/udeb/suite string xenial
-# Components to use for loading installer components (optional).
-#d-i mirror/udeb/components multiselect main, restricted
-
-# Skip creation of a root account (normal user account will be able to
-# use sudo). The default is false; preseed this to true if you want to set
-# a root password.
-#d-i passwd/root-login boolean false
-# Alternatively, to skip creation of a normal user account.
-#d-i passwd/make-user boolean false
-
-# Root password, either in clear text
-d-i passwd/root-password password {}
-d-i passwd/root-password-again password {}
-# or encrypted using a crypt(3)  hash.
-#d-i passwd/root-password-crypted password [crypt(3) hash]
-
-# To create a normal user account.
-d-i passwd/user-fullname string Ubuntu User
-d-i passwd/username string {}
-# Normal user's password, either in clear text
-d-i passwd/user-password password {}
-d-i passwd/user-password-again password {}
-# or encrypted using a crypt(3) hash.
-#d-i passwd/user-password-crypted password [crypt(3) hash]
-# Create the first user with the specified UID instead of the default.
-#d-i passwd/user-uid string 1010
-# The installer will warn about weak passwords. If you are sure you know
-# what you're doing and want to override it, uncomment this.
-d-i user-setup/allow-password-weak boolean true
-
-# The user account will be added to some standard initial groups. To
-# override that, use this.
-#d-i passwd/user-default-groups string audio cdrom video
-
-# Set to true if you want to encrypt the first user's home directory.
-d-i user-setup/encrypt-home boolean false
-
-# Controls whether or not the hardware clock is set to UTC.
-d-i clock-setup/utc boolean true
-
-# You may set this to any valid setting for $TZ; see the contents of
-# /usr/share/zoneinfo/ for valid values.
-d-i time/zone string US/Eastern
-
-# Controls whether to use NTP to set the clock during the install
-d-i clock-setup/ntp boolean true
-# NTP server to use. The default is almost always fine here.
-#d-i clock-setup/ntp-server string ntp.example.com
-
-# Alternatively, you may specify a disk to partition. If the system has only
-# one disk the installer will default to using that, but otherwise the device
-# name must be given in traditional, non-devfs format (so e.g. /dev/sda
-# and not e.g. /dev/discs/disc0/disc).
-# For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string {}
-# In addition, you'll need to specify the method to use.
-# The presently available methods are:
-# - regular: use the usual partition types for your architecture
-# - lvm:     use LVM to partition the disk
-# - crypto:  use LVM within an encrypted partition
-d-i partman-auto/method string regular
-
-# If one of the disks that are going to be automatically partitioned
-# contains an old LVM configuration, the user will normally receive a
-# warning. This can be preseeded away...
-d-i partman-lvm/device_remove_lvm boolean true
-# The same applies to pre-existing software RAID array:
-d-i partman-md/device_remove_md boolean true
-# And the same goes for the confirmation to write the lvm partitions.
-d-i partman-lvm/confirm boolean true
-d-i partman-lvm/confirm_nooverwrite boolean true
-
-# You can choose one of the three predefined partitioning recipes:
-# - atomic: all files in one partition
-# - home:   separate /home partition
-# - multi:  separate /home, /var, and /tmp partitions
-#d-i partman-auto/choose_recipe select atomic
-#d-i partman/default_filesystem string ext4
-
-d-i partman-auto/expert_recipe string                         \
-      root ::                                                 \
-              8 1 8 prep                                      \
-              $primary{{ }}                                   \
-              $bootable{{ }}                                  \
-              method{{ prep }}                                \
-              .                                               \
-              500 10000 {} ext4                               \
-                      method{{ format }} format{{ }}          \
-                      use_filesystem{{ }} filesystem{{ ext4 }} \
-                      label {{ {} }} mountpoint{{ / }}        \
-              .                                               \
-              100% 512 64000 linux-swap                       \
-                      method{{ swap }} format{{ }}            \
-
-# This makes partman automatically partition without confirmation, provided
-# that you told it what to do using one of the methods above.
-d-i partman-partitioning/confirm_write_new_label boolean true
-d-i partman/choose_partition select finish
-d-i partman/confirm boolean true
-d-i partman/confirm_nooverwrite boolean true
-
-# You can choose to install restricted and universe software, or to install
-# software from the backports repository.
-d-i apt-setup/restricted boolean true
-d-i apt-setup/universe boolean true
-
-# Individual additional packages to install
-d-i pkgsel/include string {}
-
-# Avoid that last message about the install being complete.
-d-i finish-install/reboot_in_progress note
-"""
-    def do_HEAD(self):
-        self.send_response(200)
-        self.send_header("Content-type", "text/plain")
-        self.end_headers()
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-type", "text/plain")
-        self.end_headers()
-        conf = OpTestConfiguration.conf
-        host = conf.host()
-        packages_to_install = "linux-tools-common linux-tools-generic lm-sensors ipmitool i2c-tools pciutils opal-prd opal-utils"
-
-        print "# Webserver was asked for: ", self.path
-        if self.path == "/ubuntu/vmlinux":
-            f = open("osimages/ubuntu/vmlinux", "r")
-            d = f.read()
-            self.wfile.write(d)
-            f.close()
-            return
-
-        if self.path == "/ubuntu/initrd.gz":
-            f = open("osimages/ubuntu/initrd.gz", "r")
-            d = f.read()
-            self.wfile.write(d)
-            f.close()
-            return
-
-        host_username = host.username()
-        if host_username == "root":
-            host_username = "ubuntu"
-
-        ps = self.UBUNTU_PRESEED.format("openpower","example.com",
-                                        host.get_proxy(),
-                                        host.password(), host.password(),
-                                        host_username,
-                                        host.password(), host.password(),
-                                        host.get_scratch_disk(),
-                                        int((host.get_scratch_disk_size()/(1024*1024))/2),
-                                        "op-test-ubuntu-root",
-                                        packages_to_install)
-        self.wfile.write(ps)
-
-class ThreadedHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
-    pass
+        OpIU.stop_server()
+        OpIU.set_bootable_disk(self.host.get_scratch_disk())
+        self.system.goto_state(OpSystemState.OFF)
+        self.system.goto_state(OpSystemState.OS)
+        con = self.system.sys_get_ipmi_console()
+        self.system.host_console_login()
+        self.system.host_console_unique_prompt()
+        con.run_command("uname -a")
+        con.run_command("cat /etc/os-release")
+        self.host.host_gather_opal_msg_log()
+        self.host.host_gather_kernel_log()
+        # Run additional host commands if any from user
+        if self.conf.args.host_cmd:
+            con.run_command(self.conf.args.host_cmd)


### PR DESCRIPTION
This patch adds a new os install utility and adds support for baremetal os deploy for ubuntu, rhel and hostos.

Sample commandline:
```
./op-test \
--bmc-type XXX \
...
...
--run testcases.InstallUbuntu.InstallUbuntu \
--host-scratch-disk <disk path by-id>  \
--host-gateway <gw> \
--host-dns <host dns> \
--host-submask <subnet> \
--os-repo http://ports.ubuntu.com/ubuntu-ports/ubuntu-ports/dists/xenial-updates/main/installer-ppc64el/current/images/netboot
```