### PR TITLE
Add python logger and handler infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ python:
   - "2.7"
 install:
  - "pip install -r requirements.txt"
- - pip install Sphinx
+ - "pip install -r doc/requirements.txt"
 script:
   - python op-test --help
   - python op-test --bmc-type AMI --run testcases.HelloWorld

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -15,9 +15,12 @@ from common.OpTestOpenBMC import HostManagement
 from common.OpTestWeb import OpTestWeb
 import argparse
 import time
+from datetime import datetime
 import subprocess
 import sys
 import ConfigParser
+import OpTestLogger
+import logging
 
 # Look at the addons dir for any additional OpTest supported types
 # If new type was called Kona, the layout would be as follows
@@ -34,6 +37,7 @@ import ConfigParser
 import importlib
 import os
 import addons
+
 optAddons = dict() # Store all addons found.  We'll loop through it a couple time below
 # Look at the top level of the addons for any directories and load their Setup modules
 
@@ -63,6 +67,7 @@ def get_parser():
 
     # Options to set the output directory and suffix on the output
     parser.add_argument("-o", "--output", help="Output directory for test reports.  Can also be set via OP_TEST_OUTPUT env variable.")
+    parser.add_argument("-l", "--logdir", help="Output directory for log files.  Can also be set via OP_TEST_LOGDIR env variable.")
     parser.add_argument("--suffix", help="Suffix to add to all reports.  Default is current time.")
 
     bmcgroup = parser.add_argument_group('BMC',
@@ -186,6 +191,19 @@ class OpTestConfiguration():
         if (not os.path.exists(self.output)):
             os.makedirs(self.output)
 
+        if (self.args.logdir):
+            logdir = self.args.logdir
+        elif ("OP_TEST_LOGDIR" in os.environ):
+            logdir = os.environ["OP_TEST_LOGDIR"]
+        else:
+            logdir = self.output
+
+        self.logdir = os.path.abspath(logdir)
+        if (not os.path.exists(self.logdir)):
+            os.makedirs(self.logdir)
+
+        OpTestLogger.optest_logger_glob.logdir = self.logdir
+
         # Grab the suffix, if not given use current time
         if (self.args.suffix):
             self.outsuffix = self.args.suffix
@@ -193,23 +211,32 @@ class OpTestConfiguration():
             self.outsuffix = time.strftime("%Y%m%d%H%M%S")
 
         # set up where all the logs go
-        logfile = os.path.join(self.output,"%s.log" % self.outsuffix)
-        print "Log file: %s" % logfile
+        logfile = os.path.join(self.output, "%s.log" % self.outsuffix)
+
         logcmd = "tee %s" % (logfile)
         # we use 'cat -v' to convert control characters
         # to something that won't affect the user's terminal
         if self.args.quiet:
             logcmd = logcmd + "> /dev/null"
+            # save sh_level for later refresh loggers
+            OpTestLogger.optest_logger_glob.sh_level = logging.ERROR
+            OpTestLogger.optest_logger_glob.sh.setLevel(logging.ERROR)
         else:
             logcmd = logcmd + "| sed -u -e 's/\\r$//g'|cat -v"
+            # save sh_level for later refresh loggers
+            OpTestLogger.optest_logger_glob.sh_level = logging.INFO
+            OpTestLogger.optest_logger_glob.sh.setLevel(logging.INFO)
 
-        print "logcmd: %s" % logcmd
+        OpTestLogger.optest_logger_glob.setUpLoggerFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.main.log')
+        OpTestLogger.optest_logger_glob.setUpLoggerDebugFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.debug.log')
+        OpTestLogger.optest_logger_glob.optest_logger.info('TestCase Log files: {}/*{}*'.format(self.output, self.outsuffix))
+        OpTestLogger.optest_logger_glob.optest_logger.info('StreamHandler setup {}'.format('quiet' if self.args.quiet else 'normal'))
+
         self.logfile_proc = subprocess.Popen(logcmd,
                                              stdin=subprocess.PIPE,
                                              stderr=sys.stderr,
                                              stdout=sys.stdout,
                                              shell=True)
-        print repr(self.logfile_proc)
         self.logfile = self.logfile_proc.stdin
 
         if self.args.machine_state == None:

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -36,13 +36,14 @@ import os
 import addons
 optAddons = dict() # Store all addons found.  We'll loop through it a couple time below
 # Look at the top level of the addons for any directories and load their Setup modules
-for dir in (os.walk('addons').next()[1]):
-    optAddons[dir] = importlib.import_module("addons." + dir + ".OpTest" + dir + "Setup")
 
 class OpTestConfiguration():
     def __init__(self):
         self.args = []
         self.remaining_args = []
+        for dir in (os.walk('addons').next()[1]):
+            optAddons[dir] = importlib.import_module("addons." + dir + ".OpTest" + dir + "Setup")
+
         return
 
     def parse_args(self, argv=None):
@@ -70,6 +71,10 @@ class OpTestConfiguration():
             pass
 
         parser.set_defaults(**defaults)
+
+        qemu_default = "qemu-system-ppc64"
+        if defaults.get('qemu_binary'):
+            qemu_default = defaults['qemu_binary']
 
         tgroup = parser.add_argument_group('Test',
                                            'Tests to run')
@@ -108,7 +113,7 @@ class OpTestConfiguration():
         bmcgroup.add_argument("--bmc-prompt", default="#",
                               help="Prompt for BMC ssh session")
         bmcgroup.add_argument("--smc-presshipmicmd")
-        bmcgroup.add_argument("--qemu-binary", default="qemu-system-ppc64",
+        bmcgroup.add_argument("--qemu-binary", default=qemu_default,
                               help="[QEMU Only] qemu simulator binary")
 
         hostgroup = parser.add_argument_group('Host', 'Installed OS information')
@@ -324,4 +329,3 @@ class OpTestConfiguration():
         return self.args.platform
 
 global conf
-conf = OpTestConfiguration()

--- a/OpTestLogger.py
+++ b/OpTestLogger.py
@@ -1,0 +1,124 @@
+
+# This implements all the python logger setup for op-test
+
+import os
+import sys
+from datetime import datetime
+import logging
+from logging.handlers import RotatingFileHandler
+
+class OpTestLogger():
+    '''
+    This class is used as the main global logger and handler initialization module.
+
+    See common/HelloWorld.py as an example for the usage within an op-test module.
+    '''
+    def __init__(self):
+        '''
+        Provide defaults and setup the minimal StreamHandlers
+        '''
+        self.parent_logger = 'op-test'
+        self.maxBytes_logger_file = 2000000
+        self.maxBytes_logger_debug_file = 2000000
+        self.backupCount_logger_files = 5
+        self.backupCount_debug_files = 5
+        self.logdir = os.getcwd()
+        self.logger_file = 'main.log'
+        self.logger_debug_file = 'debug.log'
+        self.optest_logger = logging.getLogger(self.parent_logger)
+        # clear the logger of any handlers in this shell
+        self.optest_logger.handlers = []
+        # need to set the logger to deepest level, handlers will filter
+        self.optest_logger.setLevel(logging.DEBUG)
+        # we need to init stream handler as special case to keep all happy
+        self.sh = logging.StreamHandler()
+        # save the sh level for later refreshes
+        self.sh_level = logging.ERROR
+        self.sh.setLevel(self.sh_level)
+        self.sh.setFormatter(logging.Formatter('\n%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.sh)
+        self.fh = None
+        self.dh = None
+
+    def __del__(self):
+        '''
+        Cleanup handlers and close files.
+        '''
+        handlers = self.optest_logger.handlers[:]
+        for handler in handlers:
+          handler.close()
+          self.optest_logger.removeHandler(handler)
+
+    def refreshLoggers(self, purgeOld=True):
+        '''
+        Provide a method that allows individual modules the capability to set the parent logger
+        to a customized implementation and log file locations.
+
+        :param purgeOld: Boolean to indicate to cleanup old loggers.
+        '''
+        # we always need to keep the stream as special case to keep all happy
+        # Example usage (such as to place in HelloWorld.py)
+        # OpTestLogger.optest_logger_glob.parent_logger = 'mynew-parent'
+        # OpTestLogger.optest_logger_glob.logdir = '/home/myuser/op-test-framework/hello'
+        # OpTestLogger.optest_logger_glob.logger_file = 'my_main.log'
+        # OpTestLogger.optest_logger_glob.logger_debug_file = 'my_debug.log'
+        # OpTestLogger.optest_logger_glob.refreshLoggers()
+
+        self.optest_logger.info('Preparing to refresh location of loggers to {}'.format(self.logdir))
+        if purgeOld:
+          handlers = self.optest_logger.handlers[:]
+          for handler in handlers:
+            handler.close()
+            self.optest_logger.removeHandler(handler)
+          self.optest_logger.handlers = []
+          self.fh = None
+          self.dh = None
+          # get a new optest_logger to start clean
+          self.optest_logger = logging.getLogger(self.parent_logger)
+          # need to set the logger to deepest level, handlers will filter
+          self.optest_logger.setLevel(logging.DEBUG)
+          self.sh = logging.StreamHandler()
+          self.sh.setLevel(self.sh_level)
+          self.sh.setFormatter(logging.Formatter('\n%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+          self.optest_logger.addHandler(self.sh)
+        self.setUpLoggerFile(self.logger_file)
+        self.setUpLoggerDebugFile(self.logger_debug_file)
+        self.optest_logger.debug('refreshLoggers done')
+
+    def setUpLoggerFile(self, logger_file):
+        '''
+        Provide a method that allows setting up of a file handler with customized file rotation and formatting.
+
+        :param logger_file: File name to use for logging the main log records.
+        '''
+        # need to log that location of logging may be changed
+        self.optest_logger.info('Preparing to set location of Log File to {}'.format(os.path.join(self.logdir, logger_file)))
+        self.logger_file = logger_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.fh = RotatingFileHandler(os.path.join(self.logdir, self.logger_file), maxBytes=self.maxBytes_logger_file, backupCount=self.backupCount_logger_files)
+        self.fh.setLevel(logging.INFO)
+        self.fh.setFormatter(logging.Formatter('\n%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.fh)
+        self.optest_logger.debug('FileHandler settings updated')
+        self.optest_logger.info('Log file: {}'.format(os.path.join(self.logdir, self.logger_file)))
+
+    def setUpLoggerDebugFile(self, logger_debug_file):
+        '''
+        Provide a method that allows setting up of a debug file handler with customized file rotation and formatting.
+
+        :param logger_debug_file: File name to use for logging the debug log records.
+        '''
+        self.optest_logger.info('Preparing to set location of Debug Log File to {}'.format(os.path.join(self.logdir, logger_debug_file)))
+        self.logger_debug_file = logger_debug_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.dh = RotatingFileHandler(os.path.join(self.logdir, self.logger_debug_file), maxBytes=self.maxBytes_logger_debug_file, backupCount=self.backupCount_debug_files)
+        self.dh.setLevel(logging.DEBUG)
+        self.dh.setFormatter(logging.Formatter('\n%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.dh)
+        self.optest_logger.debug('DebugHandler settings updated')
+        self.optest_logger.info('Debug Log file: {}'.format(os.path.join(self.logdir, self.logger_debug_file)))
+
+global optest_logger_glob
+optest_logger_glob = OpTestLogger()

--- a/common/Exceptions.py
+++ b/common/Exceptions.py
@@ -67,6 +67,10 @@ class KernelModuleNotLoaded(Exception):
         return "Kernel module %s not loaded" % (self.module)
 
 class KernelConfigNotSet(Exception):
+    '''
+    A kernel config option needed by the test was not set for the running
+    kernel.
+    '''
     def __init__(self, opt):
         self.opt = opt
     def __str__(self):
@@ -85,6 +89,9 @@ class KernelSoftLockup(Exception):
         return "Soft lockup (machine in state %s): %s" % (self.state, self.log)
 
 class KernelHardLockup(Exception):
+    '''
+    We detected a hard lockup from the running kernel.
+    '''
     def __init__(self, state, log):
         self.log = log
         self.state = state
@@ -106,6 +113,9 @@ class KernelBug(Exception):
         return "Kernel bug in state %s: %s" % (self.state, self.log)
 
 class SkibootAssert(Exception):
+    '''
+    We detected an assert from OPAL (skiboot) firmware.
+    '''
     def __init__(self, state, log):
         self.log = log
         self.state = state

--- a/common/OPexpect.py
+++ b/common/OPexpect.py
@@ -17,16 +17,27 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-#
-# OPexpect
-# A wrapper around pexpect, but expects a bunch of common failures
-# so that each expect call doesn't have to watch out for them.
-# Things like OPAL asserts, kernel crashes, RCU stalls etc.
-#
+"""
+The OPexpect module is a wrapper around the standard Python pexpect module
+that will *always* look for certain error conditions for OpenPOWER machines.
+
+This is to enable op-test test cases to fail *quickly* in the event of errors
+such as kernel panics, RCU stalls, machine checks, firmware crashes etc.
+
+In the event of error, the failure_callback function will be called, which
+typically will be set up to set the machine state to UNKNOWN, so that when
+the next test starts executing, we re-IPL the system to get back to a clean
+slate.
+
+When developing test cases, use OPexpect over pexpect. If you *intend* for
+certain error conditions to occur, you can catch the exceptions that OPexpect
+throws.
+"""
 
 import pexpect
 from Exceptions import *
 import OpTestSystem
+
 
 class spawn(pexpect.spawn):
     def __init__(self, command, args=[], timeout=30, maxread=2000,

--- a/common/OpTestError.py
+++ b/common/OpTestError.py
@@ -24,15 +24,15 @@
 #
 # IBM_PROLOG_END_TAG
 
-## @package OpTestError
-#  BMC package which contains all BMC related Errors
+"""
+A catch-all exception.
 
-#
-# @par Class description:
-# Exception Class, for the raising Bmc related Exceptions
-#
-# Attributes: @li ExceptionCode -- Code to indicate the error \n @li Reason -- explanation of the error
-##
+Use of this exception is **DEPRECATED** and will be removed in the future.
+
+Some existing code uses this, and it should be gradually converted to use
+more specialized exceptions.
+"""
+
 class OpTestError(Exception):
     pass
 

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -78,7 +78,7 @@ class QemuConsole():
         if self.ubuntu_cdrom is not None:
             cmd = cmd + " -cdrom %s" % (self.ubuntu_cdrom)
         cmd = cmd + " -netdev user,id=u1 -device e1000,netdev=u1"
-
+        cmd = cmd + " -device ipmi-bmc-sim,id=bmc0 -device isa-ipmi-bt,bmc=bmc0,irq=10"
         print cmd
         solChild = OPexpect.spawn(cmd,logfile=self.logfile)
         self.state = ConsoleState.CONNECTED
@@ -125,6 +125,14 @@ class QemuConsole():
             res = res.split(command)
             return res[-1].splitlines()
 
+    # This command just runs and returns the ouput & ignores the failure
+    def run_command_ignore_fail(self, command, timeout=60):
+        try:
+            output = self.run_command(command, timeout)
+        except CommandFailed as cf:
+            output = cf.output
+        return output
+
 class QemuIPMI():
     def __init__(self, console):
         self.console = console
@@ -139,6 +147,9 @@ class QemuIPMI():
         return 0
 
     def ipmi_sel_check(self, i_string="Transition to Non-recoverable"):
+        pass
+
+    def sys_set_bootdev_no_override(self):
         pass
 
 class OpTestQemu():
@@ -169,3 +180,12 @@ class OpTestQemu():
 
     def get_rest_api(self):
         return None
+
+    def has_os_boot_sensor(self):
+        return False
+
+    def has_occ_active_sensor(self):
+        return False
+
+    def has_host_status_sensor(self):
+        return False

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -18,7 +18,9 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Support testing against Qemu simulator
+"""
+Support testing against Qemu simulator
+"""
 
 import atexit
 import sys
@@ -35,6 +37,10 @@ class ConsoleState():
     CONNECTED = 1
 
 class QemuConsole():
+    """
+    A 'connection' to the Qemu Console involves *launching* qemu.
+    Terminating a connection will *terminate* the qemu process.
+    """
     def __init__(self, qemu_binary=None, skiboot=None, kernel=None, initramfs=None, logfile=sys.stdout, hda=None, ubuntu_cdrom=None):
         self.qemu_binary = qemu_binary
         self.skiboot = skiboot
@@ -134,13 +140,21 @@ class QemuConsole():
         return output
 
 class QemuIPMI():
+    """
+    Qemu has fairly limited IPMI capability, and we probably need to
+    extend the capability checks so that more of the IPMI test suite
+    gets skipped.
+
+    """
     def __init__(self, console):
         self.console = console
 
     def ipmi_power_off(self):
+        """For Qemu, this just kills the simulator"""
         self.console.terminate()
 
     def ipmi_wait_for_standby_state(self, i_timeout=10):
+        """For Qemu, we just kill the simulator"""
         self.console.terminate()
 
     def ipmi_set_boot_to_petitboot(self):

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1424,7 +1424,7 @@ class OpTestQemuSystem(OpTestSystem):
         # Ensure we grab host console early, in order to not miss
         # any messages
         self.console = bmc.get_host_console()
-        if host.scratch_disk is None:
+        if host.scratch_disk in [None,'']:
             host.scratch_disk = "/dev/sda"
         super(OpTestQemuSystem, self).__init__(host=host,
                                                bmc=bmc,
@@ -1442,3 +1442,6 @@ class OpTestQemuSystem(OpTestSystem):
 
     def get_my_ip_from_host_perspective(self):
         return "10.0.2.2"
+
+    def has_host_accessible_eeprom(self):
+        return False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,12 +31,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages']
+              'sphinx.ext.doctest',
+              'sphinx.ext.intersphinx',
+              'sphinx.ext.todo',
+              'sphinx.ext.coverage',
+              'sphinx.ext.viewcode',
+              'sphinx.ext.githubpages',
+              'sphinxarg.ext',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,13 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'github_user' : 'open-power',
+    'github_repo' : 'op-test-framework',
+    'github_button' : True,
+    'github_banner' : True,
+    'travis_button' : True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -108,6 +114,8 @@ html_static_path = ['_static']
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
+        'about.html',
+        'navigation.html',
         'relations.html',  # needs 'show_related': True theme option to display
         'searchbox.html',
     ]

--- a/doc/programming.rst
+++ b/doc/programming.rst
@@ -11,6 +11,12 @@ Exceptions
    :members:
    :undoc-members:
 
+OpTestError
+^^^^^^^^^^^
+.. automodule:: common.OpTestError
+   :members:
+   :undoc-members:
+
 OPExpect
 --------
 

--- a/doc/programming.rst
+++ b/doc/programming.rst
@@ -83,3 +83,9 @@ OpTestQemu
 .. automodule:: common.OpTestQemu
    :members:
    :undoc-members:
+
+Firmware Flashing
+=================
+
+.. automodule:: testcases.OpTestFlash
+   :members:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinx-argparse

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -3,6 +3,19 @@
 op-test User Guide
 ==================
 
+.. _commandline:
+
+Command Line Options
+--------------------
+
+All configuration options can be specified via the command line or in a
+configuration file (see :ref:`config-file`).
+
+.. argparse::
+   :module: OpTestConfiguration
+   :func: get_parser
+   :prog: op-test
+
 .. _config-file:
 
 Configuration Files and Command Line Options

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -1,6 +1,202 @@
+.. _user-guide:
+
 op-test User Guide
 ==================
 
+.. _config-file:
+
+Configuration Files and Command Line Options
+--------------------------------------------
+
+When working with `op-test`, you can specify every configuration option on
+the command line, or you can save some in a configuration file. Typically,
+you may keep a configuration file per-machine you test against, to save on
+typing out all the IP addresses and login credentials.
+
+For example, this ``witherspoon.conf`` file will connect to a Witherspoon
+machine: ::
+
+  [op-test]
+  bmc_type=OpenBMC
+  bmc_ip=10.0.0.1
+  bmc_username=root
+  bmc_password=0penBmc
+  host_ip=10.0.0.2
+  host_user=root
+  host_password=abc123
+
+It can be used as such: ::
+
+  ./op-test --config-file witherspoon.conf
+
+Other options can also be specified on the commandline, such as ``--host-pnor``
+which is documented in :ref:`flashing-firmware`.
+
+There is also a *per user* configuration file, at ``~/.op-test-framework.conf``
+where you can store global options, for example: ::
+
+  [op-test]
+  smc_presshipmicmd=foo
+  pupdate=~/pupdate
+  pflash=~/pflash
+  ubuntu-cdrom=~/ubuntu-18.04-ppc64el.iso
+
+This per user configuration file will be loaded in *addition* to the config
+file provided on the command line.
+
+.. _flashing-firmware:
+
+Flashing Firmware with op-test
+------------------------------
+
+In the future, there may be some standard interface for flashing firmware
+onto OpenPOWER machines. We are not yet in that future, so the method of
+flashing firmware varies somewhat between platforms.
+
+There is code in `op-test` to hide these differences from you, and just
+provide easy ways to say "flash this firmware and run the test suite". This
+functionality is *primarily* focused towards firmware developers.
+
+By default, `op-test` will flash any firmware provided *before* running
+any tests. You can change this behaviour with the ``--no-flash`` or
+`-only-flash`` command line options (which should be fairly self-explanatory).
+
+To flash a full PNOR image, you will need one in the correct format:
+
+AMI BMC based systems (e.g. Palmetto, Habanero, Firestone and Garrison)
+  A raw PNOR file (`palmetto.pnor`, `habanero.pnor` etc) as produced by
+  `op-build` should be provided to the ``--host-pnor`` command line option.
+  `op-test` will use this with `pflash` on the BMC to write the whole PNOR
+  image to flash. It will **NOT** preserve *anything* from what was previously
+  flashed (e.g. NVRAM, GUARD records).
+  Since most AMI BMCs do not ship with `pflash` you will need to tell `op-test`
+  where to find a pflash binary compiled for the BMC with the ``--pflash``
+  option
+IBM FSP based systems (e.g. Tuleta, ZZ)
+  The only current method that `op-test` supports for flashing a full FSP
+  image is in-band, fetching the image over the network.
+  You need to specify the URL to the full firmware image to the
+  ``--host-image-url`` command line option.
+OpenBMC based systems (e.g. Witherspoon, Romulus)
+  There are two ways for OpenBMC systems to store PNOR, either using the
+  full NOR chip for the PNOR, or using the vPNOR (Virtual PNOR) method.
+  The normal PNOR method needs a ``.pnor`` file, e.g. ``romulus.pnor``.
+  The vPNOR method needs a ``.squashfs.tar`` file,
+  e.g. ``witherspoon.pnor.squashfs.tar``.
+  If you provide the incorrect format, `op-test` will error out.
+
+For *BMC* firmware, you also need the machine specific BMC firmware image
+format to supply to the ``--bmc-image`` command line option. For some BMCs,
+you may need an external utility. For example, Supermicro (SMC) BMCs need
+the ``pUpdate`` utility, which you can point `op-test` at with the ``--pupdate``
+command line option.
+
+OpenBMC/Witherspoon Examples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These examples are for the Witherspoon system, which uses OpenBMC as a BMC
+and the vPNOR implementation. For Romulus (which does not use vPNOR), instead
+of `witherspoon.pnor.squashfs.tar` you may need to use `witherspoon.pnor`.
+
+**FIXME** Confirm details on Romulus.
+
+For example, this command will use the ``witherspoon.conf`` configuration file
+(see :ref:`config-file`) for login credentials to a Witherspoon machine, and
+will flash *host* firmware before running the default test suite: ::
+
+  ./op-test --config-file witherspoon.conf \
+  --host-pnor ~/op-build/output/images/witherspoon.pnor.squashfs.tar
+
+In this example we've provided the *full* path to a witherspoon firmware image
+that we've built using `op-build`.
+
+If you *also* want to flash BMC firmware, you can do that with the addition of the ``--bmc-image`` command line option: ::
+
+  ./op-test --config-file witherspoon.conf \
+  --bmc-image obmc-phosphor-image-witherspoon.ubi.mtd.tar \
+  --host-pnor ~/op-build/output/images/witherspoon.pnor.squashfs.tar
+
+In this example, `op-test` will first update the BMC firmware, then update the host firmware and *then* run the test suite.
+
+If you're a skiboot/OPAL developer and wanting to test your latest code when
+applied on top of a known-good BMC and PNOR image, you can use the
+``--flash-skiboot`` command line option to instruct `op-test` to, as a final
+step, overwrite the `PAYLOAD` partition with your skiboot: ::
+
+  ./op-test --config-file witherspoon.conf \
+  --bmc-image obmc-phosphor-image-witherspoon.ubi.mtd.tar \
+  --host-pnor ~/op-build/output/images/witherspoon.pnor.squashfs.tar \
+  --flash-skiboot ~/skiboot/skiboot.lid.xz.stb
+
+In this case, if "field mode" is enabled on the BMC, `op-test` will disable
+it for you to allow for overriding host firmware with the skiboot image you
+aksed it to use.
+
+Since the Witherspoon platform has Secure Boot enabled, you will need the
+`.stb` variant of skiboot (i.e. with the Secure and Trusted Boot header),
+and since we're an OpenPOWER system, we need the `.xz` compressed version,
+and this is why we provide `skiboot.lid.xz.stb` to `op-test` for this system.
+
+**Note** that with Secure Boot enabled, by default we only sign with *imprint*
+keys.
+
+AMI BMC/POWER8 OpenPOWER sytems examples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For machines such as Palmetto, Habanero, Firestone and Garrison.
+
+**TODO** Document BMC flashing.
+
+These systems have an AMI BMC and `op-test` will use `pflash` on the BMC
+to write host firmware. You will need to point `op-test` towards a `pflash`
+binary compiled for the BMC for `op-test` to copy over and use to flash
+firmware.
+
+**TODO** Document HPM flashing.
+
+An example of flashing a full `habanero.pnor` image and running the default
+test suite is: ::
+
+  ./op-test --config-file hab4.conf \
+  --host-pnor ~/op-build/output/images/habanero.pnor
+
+Just like on other systems, if you're an OPAL/skiboot developer and you want
+to test your changes along with a known-good full PNOR image, you'd do that
+the same way, using the ``--flash-skiboot`` parameter: ::
+
+  ./op-test --config-file hab4.conf \
+  --host-pnor ~/op-build/output/images/habanero.pnor \
+  --flash-skiboot ~/skiboot/skiboot.lid.xz
+
+We need to provide the `skiboot.lid.xz` file as all POWER8 OpenPOWER systems
+need the compressed payload in order to fit in flash. It is only *very* old
+Hostboots that do not support this and require the raw `skiboot.lid`.
+
+IBM FSP System examples
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For machines such as Tuleta and ZZ (firenze class).
+
+Your FSP must have an NFS mount and be configured correctly for this operation.
+
+Currently, flashing a full FSP image is only supported by doing it from
+the host. In future, we may support out of band methods.
+
+The primary use `op-test` on Tuleta/ZZ is for flashing new OPAL LIDs onto
+an existing FSP image. Unlike OpenPOWER machines, the kernel and initramfs
+are split up into two separate LIDs, and must be pointed to separately.
+
+This example will run the stest suite against our ZZ machine *after* flashing
+our skiboot, kernel and initramfs built fresh from `op-build` (with the
+configuration `zz_defconfig`). ::
+
+  ./op-test --config-file zz.conf \
+  --flash-skiboot ~/op-build/output/images/skiboot.lid \
+  --flash-kernel ~/op-build/output/images/zImage.epapr \
+  --flash-initramfs ~/op-build/output/images/rootfs.cpio.xz
+
+For FSP based systems, the *uncompressed* `skiboot.lid` is needed, as the FSP
+will load this image directly into memory and start executing it.
 
 
 op-test and Qemu
@@ -9,3 +205,32 @@ op-test and Qemu
 You can use the 'qemu' BMC type to run many tests using the qemu simulator.
 This can be useful for test development/debug as well as testing the qemu
 simulator itself.
+
+It may be useful to keep a configuration file with your qemu configuration
+in it for running tests. An example of such a configuration file is below: ::
+
+  [op-test]
+  bmc_type=qemu
+  qemu_binary=~/qemu/ppc64-softmmu/qemu-system-ppc64
+  flash_skiboot=~/skiboot/skiboot.lid
+  flash_kernel=zImage.epapr
+  flash_initramfs=rootfs.cpio
+  host_user=ubuntu
+  host_password=abc123
+  ubuntu_cdrom=osimages/ubuntu-17.10-server-ppc64el.iso
+
+Note that for `qemu` we want the *uncompressed* `skiboot.lid` for `qemu` to
+load, and while it's not *required*, using the uncompressed `rootfs.cpio`
+does *significantly* improve boot time to Petitboot.
+
+In this configuration file example, we point to a `qemu` development tree
+rather than using the system default `qemu-system-ppc64` binary.
+
+To run the "boot to petitboot" test in qemu with the above configuration file,
+you can do so like this: ::
+
+  ./op-test --config-file qemu.conf \
+  --run testcases.BasicIPL.BootToPetitbootShell
+
+Not all tests currently pass in `qemu`, and running tests in `qemu` should be
+considered somewhat experimental.

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -14,7 +14,9 @@ you may keep a configuration file per-machine you test against, to save on
 typing out all the IP addresses and login credentials.
 
 For example, this ``witherspoon.conf`` file will connect to a Witherspoon
-machine: ::
+machine:
+
+.. code-block:: ini
 
   [op-test]
   bmc_type=OpenBMC
@@ -33,7 +35,9 @@ Other options can also be specified on the commandline, such as ``--host-pnor``
 which is documented in :ref:`flashing-firmware`.
 
 There is also a *per user* configuration file, at ``~/.op-test-framework.conf``
-where you can store global options, for example: ::
+where you can store global options, for example:
+
+.. code-block:: ini
 
   [op-test]
   smc_presshipmicmd=foo
@@ -207,7 +211,9 @@ This can be useful for test development/debug as well as testing the qemu
 simulator itself.
 
 It may be useful to keep a configuration file with your qemu configuration
-in it for running tests. An example of such a configuration file is below: ::
+in it for running tests. An example of such a configuration file is below:
+
+.. code-block:: ini
 
   [op-test]
   bmc_type=qemu

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -27,7 +27,9 @@ machine:
   host_user=root
   host_password=abc123
 
-It can be used as such: ::
+It can be used as such:
+
+.. code-block:: bash
 
   ./op-test --config-file witherspoon.conf
 
@@ -106,7 +108,9 @@ of `witherspoon.pnor.squashfs.tar` you may need to use `witherspoon.pnor`.
 
 For example, this command will use the ``witherspoon.conf`` configuration file
 (see :ref:`config-file`) for login credentials to a Witherspoon machine, and
-will flash *host* firmware before running the default test suite: ::
+will flash *host* firmware before running the default test suite:
+
+.. code-block:: bash
 
   ./op-test --config-file witherspoon.conf \
   --host-pnor ~/op-build/output/images/witherspoon.pnor.squashfs.tar
@@ -114,7 +118,9 @@ will flash *host* firmware before running the default test suite: ::
 In this example we've provided the *full* path to a witherspoon firmware image
 that we've built using `op-build`.
 
-If you *also* want to flash BMC firmware, you can do that with the addition of the ``--bmc-image`` command line option: ::
+If you *also* want to flash BMC firmware, you can do that with the addition of the ``--bmc-image`` command line option:
+
+.. code-block:: bash
 
   ./op-test --config-file witherspoon.conf \
   --bmc-image obmc-phosphor-image-witherspoon.ubi.mtd.tar \
@@ -125,7 +131,9 @@ In this example, `op-test` will first update the BMC firmware, then update the h
 If you're a skiboot/OPAL developer and wanting to test your latest code when
 applied on top of a known-good BMC and PNOR image, you can use the
 ``--flash-skiboot`` command line option to instruct `op-test` to, as a final
-step, overwrite the `PAYLOAD` partition with your skiboot: ::
+step, overwrite the `PAYLOAD` partition with your skiboot:
+
+.. code-block:: bash
 
   ./op-test --config-file witherspoon.conf \
   --bmc-image obmc-phosphor-image-witherspoon.ubi.mtd.tar \
@@ -159,14 +167,18 @@ firmware.
 **TODO** Document HPM flashing.
 
 An example of flashing a full `habanero.pnor` image and running the default
-test suite is: ::
+test suite is:
+
+.. code-block:: bash
 
   ./op-test --config-file hab4.conf \
   --host-pnor ~/op-build/output/images/habanero.pnor
 
 Just like on other systems, if you're an OPAL/skiboot developer and you want
 to test your changes along with a known-good full PNOR image, you'd do that
-the same way, using the ``--flash-skiboot`` parameter: ::
+the same way, using the ``--flash-skiboot`` parameter:
+
+  .. code-block:: bash
 
   ./op-test --config-file hab4.conf \
   --host-pnor ~/op-build/output/images/habanero.pnor \
@@ -192,7 +204,9 @@ are split up into two separate LIDs, and must be pointed to separately.
 
 This example will run the stest suite against our ZZ machine *after* flashing
 our skiboot, kernel and initramfs built fresh from `op-build` (with the
-configuration `zz_defconfig`). ::
+configuration `zz_defconfig`).
+
+.. code-block:: bash
 
   ./op-test --config-file zz.conf \
   --flash-skiboot ~/op-build/output/images/skiboot.lid \
@@ -233,7 +247,9 @@ In this configuration file example, we point to a `qemu` development tree
 rather than using the system default `qemu-system-ppc64` binary.
 
 To run the "boot to petitboot" test in qemu with the above configuration file,
-you can do so like this: ::
+you can do so like this:
+
+.. code-block:: bash
 
   ./op-test --config-file qemu.conf \
   --run testcases.BasicIPL.BootToPetitbootShell

--- a/op-test
+++ b/op-test
@@ -38,6 +38,7 @@ except ImportError:
   pass
 
 
+import OpTestLogger
 import OpTestConfiguration
 OpTestConfiguration.conf = OpTestConfiguration.OpTestConfiguration()
 
@@ -94,12 +95,11 @@ import testcases
 args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
 OpTestConfiguration.conf.objs()
 
-print args
-
 class StandbySuite():
     '''Machine at standby. Focused on BMC'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of StandbySuite')
 #        self.s.addTest(OpTestEnergyScale.standby_suite())
     def suite(self):
         return self.s
@@ -108,6 +108,7 @@ class SkirootSuite():
     '''Tests in Petitboot environment'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of SkirootSuite')
         self.s.addTest(DeviceTreeWarnings.Skiroot())
         self.s.addTest(OpTestEM.skiroot_suite())
         self.s.addTest(OpTestInbandIPMI.skiroot_full_suite())
@@ -137,6 +138,7 @@ class HostSuite():
     '''Tests run in booted OS'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of HostSuite')
         self.s.addTest(HostLogin.OOBHostLogin())
         self.s.addTest(DeviceTreeWarnings.Host())
         self.s.addTest(OpTestPrdDriver.OpTestPrdDriver())
@@ -168,6 +170,7 @@ class ExperimentalSuite():
     '''Tests that need further development'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of ExperimentalSuite')
         self.s.addTest(OpTestEEH.suite())
         # SwitchEndian is here as we need to resolve issue of running
         # kernel self-tests as part of op-test or not.
@@ -178,12 +181,14 @@ class ExperimentalSuite():
 class BasicIPLSuite():
     '''Basic boot/reboot power on/off'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of BasicIPLSuite')
         return BasicIPL.suite()
 
 class DefaultSuite():
     '''Basic regression tests'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of DefaultSuite')
         self.s.addTest(SkirootSuite().suite())
         self.s.addTest(HostSuite().suite())
     def suite(self):
@@ -203,6 +208,7 @@ class FullSuite():
     '''Every stable test'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of FullSuite')
         self.s.addTest(BasicIPLSuite().suite())
         self.s.addTest(DefaultSuite().suite())
         self.s.addTest(testRestAPI.RestAPI())
@@ -226,6 +232,7 @@ class OpTestEMSuite():
     '''Energy Management'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of OpTestEMSuite')
     def suite(self):
         self.s.addTest(OpTestEM.host_suite())
         self.s.addTest(OpTestEM.skiroot_suite())
@@ -234,29 +241,35 @@ class OpTestEMSuite():
 class BasicPCISuite():
     '''Basic PCI tests'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of BasicPCISuite')
         return OpTestPCI.suite()
 
 class OpTestEEHSuite():
     '''PCI EEH error recovery'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of OpTestEEHSuite')
         return OpTestEEH.suite()
 
 class HMISuite():
     '''HMI handling'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of HMISuite')
         return OpTestHMIHandling.suite()
 
 class ExperimentalHMISuite():
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of ExperimentalHMISuite')
         return OpTestHMIHandling.experimental_suite()
 
 class UnrecoverableHMISuite():
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of UnrecoverableHMISuite')
         return OpTestHMIHandling.unrecoverable_suite()
 
 class OpTestEnergyScaleSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of OpTestEnergyScaleSuite')
         self.s.addTest(OpTestEnergyScale.standby_suite())
         self.s.addTest(OpTestEnergyScale.runtime_suite())
     def suite(self):
@@ -264,15 +277,18 @@ class OpTestEnergyScaleSuite():
 
 class BrokenReprovisionSuite():
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of BrokenReprovisionSuite')
         return OpTestIPMIReprovision.broken_suite()
 
 class ExperimentalReprovisionSuite():
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of ExperimentalReprovisionIPMISuite')
         return OpTestIPMIReprovision.experimental_suite()
 
 class InbandIPMISuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of InbandIPMISuite')
         self.s.addTest(OpTestInbandIPMI.basic_suite())
         self.s.addTest(OpTestInbandIPMI.full_suite())
         self.s.addTest(OpTestInbandUsbInterface.basic_suite())
@@ -288,6 +304,7 @@ class OutofbandIPMISuite():
     '''Out of band IPMI'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of OutofbandIPMISuite')
         self.s.addTest(OpTestOOBIPMI.basic_suite())
         self.s.addTest(OpTestOOBIPMI.standby_suite())
         self.s.addTest(OpTestOOBIPMI.runtime_suite())
@@ -298,6 +315,7 @@ class OCCSuite():
     '''OCC Test Suite'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of OCCSuite')
         self.s.addTest(OpTestOCC.OCC_RESET())
         self.s.addTest(OpTestOCC.basic_suite())
         self.s.addTest(OpTestOCC.full_suite())
@@ -308,16 +326,19 @@ class OCCSuite():
 class SystemIPLSuite():
     '''System IPL's'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of SystemIPLSuite')
         return OpTestSystemBootSequence.suite()
 
 class CrashSuite():
     '''Crash Test Suite'''
     def suite(self):
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of CrashSuite')
         return OpTestKernel.crash_suite()
 
 class FspOpalSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of FspOpalSuite')
         self.s.addTest(OpTestDumps.suite())
         self.s.addTest(OpalErrorLog.BasicTest())
         self.s.addTest(OpalErrorLog.FullTest())
@@ -332,6 +353,7 @@ class FspOpalSuite():
 class KnownBugs():
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of KnownBugs')
         self.s.addTest(Console.Console32k())
         self.s.addTest(Console.ControlC())
     def suite(self):
@@ -340,6 +362,7 @@ class KnownBugs():
 class FlashFirmware():
     def __init__(self):
         self.s = unittest.TestSuite()
+        OpTestLogger.optest_logger_glob.optest_logger.debug('addSuite of FlashFirmware')
         self.s.addTest(testcases.OpTestFlash.FSPFWImageFLASH())
         self.s.addTest(testcases.OpTestFlash.BmcImageFlash())
         self.s.addTest(testcases.OpTestFlash.PNORFLASH())
@@ -378,6 +401,7 @@ suites = {
 # Loop through the addons and load in suites defined there
 for opt in OpTestConfiguration.optAddons:
     suites = OpTestConfiguration.optAddons[opt].addSuites(suites)
+    OpTestLogger.optest_logger_glob.optest_logger.debug('addSuites of {}'.format(opt))
 
 if OpTestConfiguration.conf.args.list_suites:
     print '{0:34}{1}'.format('Test Suite', 'Description')
@@ -393,45 +417,59 @@ t = unittest.TestSuite()
 
 if OpTestConfiguration.conf.args.run_suite:
     for suite in OpTestConfiguration.conf.args.run_suite:
+        OpTestLogger.optest_logger_glob.optest_logger.debug('conf args addSuites of {}'.format(suite))
         t.addTest(suites[suite].suite())
 
 if OpTestConfiguration.conf.args.run:
+    OpTestLogger.optest_logger_glob.optest_logger.debug('conf args run addTest of {}'.format(OpTestConfiguration.conf.args.run))
     t.addTest(unittest.TestLoader().loadTestsFromNames(OpTestConfiguration.conf.args.run))
 
 if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.args.run:
     if not OpTestConfiguration.conf.args.only_flash:
-        print "RUNNING DEFAULT SUITE"
+	OpTestLogger.optest_logger_glob.optest_logger.info('RUNNING DEFAULT SUITE')
         t.addTest(suites['default'].suite())
 
 xml_msg = ""
 def run_tests(t):
+    OpTestLogger.optest_logger_glob.optest_logger.debug('Start of run_tests')
     try:
-        print("Output to be written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
         import xmlrunner  # requires unittest-xml-reporting package
-        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
-        print("Output written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
-        return res
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            OpTestLogger.optest_logger_glob.optest_logger.debug('Calling XMLTestRunner')
+            res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, stream=main_logfile, verbosity=2).run(t)
+            OpTestLogger.optest_logger_glob.optest_logger.debug('Back from XMLTestRunner')
+            return res
     except ImportError, err:
-        sys.stderr.write("WARNING: xmlrunner module not available, falling back to using unittest...\n\n")
-        res = unittest.TextTestRunner(verbosity=2).run(t)
-        return res
+        OpTestLogger.optest_logger_glob.optest_logger.warning('xmlrunner module not available, falling back to using unittest...\n')
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            OpTestLogger.optest_logger_glob.optest_logger.debug('Calling TextTestRunner')
+            res = unittest.TextTestRunner(main_logfile, verbosity=2).run(t)
+            OpTestLogger.optest_logger_glob.optest_logger.debug('Back from TextTestRunner')
+            return res
 
 res = None
-if not OpTestConfiguration.conf.args.noflash:
-    res = run_tests(FlashFirmware().suite())
 
-print repr(res)
+if not OpTestConfiguration.conf.args.noflash:
+    OpTestLogger.optest_logger_glob.optest_logger.debug('Calling run_tests FlashFirmware in noflash')
+    res = run_tests(FlashFirmware().suite())
+    OpTestLogger.optest_logger_glob.optest_logger.debug('Back form run_tests FlashFirmware in noflash')
+
+OpTestLogger.optest_logger_glob.optest_logger.debug('Print res {}'.format(repr(res)))
 
 if OpTestConfiguration.conf.args.only_flash:
     if res != None:
+        OpTestLogger.optest_logger_glob.optest_logger.error('Exit with Result errors="{}" and failures="{}" from only_flash'.format(len(res.errors), len(res.failures)))
         exit(len(res.errors + res.failures))
     else:
+        OpTestLogger.optest_logger_glob.optest_logger.debug('Exit normal')
         exit(0)
 
 if not res or (res and not (res.errors or res.failures)):
     res = run_tests(t)
 else:
-    print "Skipping main tests as flashing failed"
+    OpTestLogger.optest_logger_glob.optest_logger.error('Skipping main tests as flashing failed')
     exit(-1)
 
+OpTestLogger.optest_logger_glob.optest_logger.info('Exit with Result errors="{}" and failures="{}"'.format(len(res.errors), len(res.failures)))
+OpTestLogger.optest_logger_glob.optest_logger.info('See Main Log File for Results')
 exit(len(res.errors + res.failures))

--- a/op-test
+++ b/op-test
@@ -88,6 +88,7 @@ from testcases import SbePassThrough
 from testcases import DeviceTreeValidation
 from testcases import DeviceTreeWarnings
 from testcases import PciSlotLocCodes
+from testcases import InstallUbuntu
 import testcases
 
 args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
@@ -184,6 +185,16 @@ class DefaultSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
         self.s.addTest(SkirootSuite().suite())
+        self.s.addTest(HostSuite().suite())
+    def suite(self):
+        return self.s
+
+class QemuSuite():
+    '''Basic regression tests'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+#        self.s.addTest(SkirootSuite().suite())
+        self.s.addTest(InstallUbuntu.InstallUbuntu())
         self.s.addTest(HostSuite().suite())
     def suite(self):
         return self.s
@@ -341,6 +352,7 @@ suites = {
     'skiroot' : SkirootSuite(),
     'host'    : HostSuite(),
     'default' : DefaultSuite(),
+    'qemu' : QemuSuite(),
     'BasicIPL' : BasicIPLSuite(),
     'BasicPCI' : BasicPCISuite(),
     'em' :       OpTestEMSuite(),

--- a/op-test
+++ b/op-test
@@ -37,7 +37,10 @@ try:
 except ImportError:
   pass
 
+
 import OpTestConfiguration
+OpTestConfiguration.conf = OpTestConfiguration.OpTestConfiguration()
+
 from testcases import HelloWorld
 from testcases import OpTestSwitchEndianSyscall
 from testcases import OpTestSensors

--- a/testcases/HelloWorld.py
+++ b/testcases/HelloWorld.py
@@ -18,17 +18,26 @@
 # permissions and limitations under the License.
 
 import unittest
+import logging
 
 import OpTestConfiguration
+import OpTestLogger
 from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
+
+module_logger = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger+'.{}'.format(__name__))
 
 class HelloWorld(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
+        self.my_logger = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger+'.{}'.format(__name__))
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
+        self.my_logger.info('setUp info call in HelloWorld class')
+        self.my_logger.debug('setUp debug call in HelloWorld class')
 
     def runTest(self):
+        module_logger.info('HelloWorld runTest info call')
+        module_logger.debug('HelloWorld runTest debug call')
         self.assertEqual("Hello World", "Hello World")

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -143,7 +143,7 @@ class InstallUbuntu(unittest.TestCase):
             rawc.send('\t\t\t\t') # FIXME :)
             rawc.send('\b\b\b\b') # remove ' ---'
             rawc.send('\b\b\b\b\b') #remove 'quiet'
-            rawc.send(kernelargs)
+            rawc.send(kernel_args)
             rawc.send('\t')
             rawc.sendline('')
             rawc.sendline('')

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -140,6 +140,14 @@ class OpTestFlashBase(unittest.TestCase):
 
 
 class BmcImageFlash(OpTestFlashBase):
+    '''
+    Flashes the BMC with BMC firmware.
+    This enables a single op-test incantation to test with a specific
+    BMC firmware build.
+
+    Currently supports SuperMicro (SMC) BMCs and OpenBMC.
+    FSP systems need to use a separate mechanism.
+    '''
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.bmc_image = conf.args.bmc_image
@@ -230,6 +238,20 @@ class BmcImageFlash(OpTestFlashBase):
 
 
 class PNORFLASH(OpTestFlashBase):
+    '''
+    Flash full PNOR image
+
+    For OpenBMC, uses REST image upload
+    For SMC, uses pUpdate
+    For AMI, relies on pflash
+
+    op-test needs to be provided locations of pUpdate and pflash
+    binaries to successfully flash machines that need them.
+
+    Supports SMC, AMI and OpenBMC based BMCs.
+
+    FSP systems use a different mechanism.
+    '''
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.pnor = conf.args.host_pnor
@@ -305,6 +327,24 @@ class PNORFLASH(OpTestFlashBase):
 
 
 class OpalLidsFLASH(OpTestFlashBase):
+    '''
+    Flash specific LIDs (partitions).
+    Can be combined with a full PNOR flash to test a base firmware image
+    plus new code. For example, if testing a new skiboot (before incorporating
+    it into upstream) you can test a base image plus new skiboot.
+
+    Compatible with AMI, SMC, OpenBMC and FSP.
+
+    This just flashes the raw file you provide, so you need to provide it
+    with the correct format for the system.
+
+    e.g. for skiboot:
+    FSP systems needs raw skiboot.lid
+    AMI,SMC,OpenBMC systems need skiboot.lid.xz
+    unless secure boot is enabled, and then they need skiboot.lid.xz.stb
+
+    TODO support arbitrary partition flashing.
+    '''
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.pflash = conf.args.pflash


### PR DESCRIPTION
Provide a common logger and handler infrastructure for op-test.

Provide a main log file for summary information.

Provide a debug log file for more verbose information to assist
during testcase development and testcase result analysis to
assess errors and failures and allow testcase instrumentation
to be non-obstructive to the main log file consumer.

Provide a mechanism to capture traces (adding debug loggers).

See HellowWorld.py for example module instrumentation.

Signed-off-by: Deb McLemore <debmc@linux.vnet.ibm.com>