### PR TITLE
Add python logger and handler infrastructure

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -15,10 +15,13 @@ from common.OpTestOpenBMC import HostManagement
 from common.OpTestWeb import OpTestWeb
 import argparse
 import time
+from datetime import datetime
 import subprocess
 import sys
 import ConfigParser
 import errno
+import OpTestLogger
+import logging
 
 # Look at the addons dir for any additional OpTest supported types
 # If new type was called Kona, the layout would be as follows
@@ -35,6 +38,7 @@ import errno
 import importlib
 import os
 import addons
+
 optAddons = dict() # Store all addons found.  We'll loop through it a couple time below
 # Look at the top level of the addons for any directories and load their Setup modules
 
@@ -64,6 +68,7 @@ def get_parser():
 
     # Options to set the output directory and suffix on the output
     parser.add_argument("-o", "--output", help="Output directory for test reports.  Can also be set via OP_TEST_OUTPUT env variable.")
+    parser.add_argument("-l", "--logdir", help="Output directory for log files.  Can also be set via OP_TEST_LOGDIR env variable.")
     parser.add_argument("--suffix", help="Suffix to add to all reports.  Default is current time.")
 
     bmcgroup = parser.add_argument_group('BMC',
@@ -232,27 +237,49 @@ class OpTestConfiguration():
         if (not os.path.exists(self.output)):
             os.makedirs(self.output)
 
+        if (self.args.logdir):
+            logdir = self.args.logdir
+        elif ("OP_TEST_LOGDIR" in os.environ):
+            logdir = os.environ["OP_TEST_LOGDIR"]
+        else:
+            logdir = self.output
+
+        self.logdir = os.path.abspath(logdir)
+        if (not os.path.exists(self.logdir)):
+            os.makedirs(self.logdir)
+
+        OpTestLogger.optest_logger_glob.logdir = self.logdir
+
         # Grab the suffix, if not given use current time
         self.outsuffix = self.get_suffix()
 
         # set up where all the logs go
-        logfile = os.path.join(self.output,"%s.log" % self.outsuffix)
-        print "Log file: %s" % logfile
+        logfile = os.path.join(self.output, "%s.log" % self.outsuffix)
+
         logcmd = "tee %s" % (logfile)
         # we use 'cat -v' to convert control characters
         # to something that won't affect the user's terminal
         if self.args.quiet:
             logcmd = logcmd + "> /dev/null"
+            # save sh_level for later refresh loggers
+            OpTestLogger.optest_logger_glob.sh_level = logging.ERROR
+            OpTestLogger.optest_logger_glob.sh.setLevel(logging.ERROR)
         else:
             logcmd = logcmd + "| sed -u -e 's/\\r$//g'|cat -v"
+            # save sh_level for later refresh loggers
+            OpTestLogger.optest_logger_glob.sh_level = logging.INFO
+            OpTestLogger.optest_logger_glob.sh.setLevel(logging.INFO)
 
-        print "logcmd: %s" % logcmd
+        OpTestLogger.optest_logger_glob.setUpLoggerFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.main.log')
+        OpTestLogger.optest_logger_glob.setUpLoggerDebugFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.debug.log')
+        OpTestLogger.optest_logger_glob.optest_logger.info('TestCase Log files: {}/*{}*'.format(self.output, self.outsuffix))
+        OpTestLogger.optest_logger_glob.optest_logger.info('StreamHandler setup {}'.format('quiet' if self.args.quiet else 'normal'))
+
         self.logfile_proc = subprocess.Popen(logcmd,
                                              stdin=subprocess.PIPE,
                                              stderr=sys.stderr,
                                              stdout=sys.stdout,
                                              shell=True)
-        print repr(self.logfile_proc)
         self.logfile = self.logfile_proc.stdin
 
         if self.args.machine_state == None:

--- a/OpTestLogger.py
+++ b/OpTestLogger.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+# This implements all the python logger setup for op-test
+
+import os
+import sys
+from datetime import datetime
+import logging
+from logging.handlers import RotatingFileHandler
+
+class OpTestLogger():
+    '''
+    This class is used as the main global logger and handler initialization module.
+
+    See testcases/HelloWorld.py as an example for the usage within an op-test module.
+    '''
+    def __init__(self, parent=None):
+        '''
+        Provide defaults and setup the minimal StreamHandlers
+        '''
+        self.parent_logger = 'op-test'
+        self.maxBytes_logger_file = 2000000
+        self.maxBytes_logger_debug_file = 2000000
+        self.backupCount_logger_files = 5
+        self.backupCount_debug_files = 5
+        self.logdir = os.getcwd()
+        self.logger_file = 'main.log'
+        self.logger_debug_file = 'debug.log'
+        self.optest_logger = logging.getLogger(self.parent_logger)
+        # clear the logger of any handlers in this shell
+        self.optest_logger.handlers = []
+        # need to set the logger to deepest level, handlers will filter
+        self.optest_logger.setLevel(logging.DEBUG)
+        if parent == 'parent':
+          # we need to init stream handler as special case to keep all happy
+          self.sh = logging.StreamHandler()
+          # save the sh level for later refreshes
+          self.sh_level = logging.ERROR
+          self.sh.setLevel(self.sh_level)
+          self.sh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+          self.optest_logger.addHandler(self.sh)
+        # set all child instances to use the parent stream handler
+        else:
+          self.sh = optest_logger_glob.sh
+          self.sh_level = optest_logger_glob.sh_level
+          self.sh.setLevel(self.sh_level)
+          self.sh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+          self.optest_logger.addHandler(self.sh)
+        self.fh = None
+        self.dh = None
+
+    def get_logger(self, myname):
+        '''
+         Provide a method that allows individual module helper capabilities
+        '''
+        return logging.getLogger(self.parent_logger+'.{}'.format(myname))
+
+    def setUpLoggerFile(self, logger_file):
+        '''
+        Provide a method that allows setting up of a file handler with customized file rotation and formatting.
+
+        :param logger_file: File name to use for logging the main log records.
+        '''
+        # need to log that location of logging may be changed
+        self.optest_logger.info('Preparing to set location of Log File to {}'.format(os.path.join(self.logdir, logger_file)))
+        self.logger_file = logger_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.fh = RotatingFileHandler(os.path.join(self.logdir, self.logger_file), maxBytes=self.maxBytes_logger_file, backupCount=self.backupCount_logger_files)
+        self.fh.setLevel(logging.INFO)
+        self.fh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.fh)
+        self.optest_logger.debug('FileHandler settings updated')
+        self.optest_logger.info('Log file: {}'.format(os.path.join(self.logdir, self.logger_file)))
+
+    def setUpLoggerDebugFile(self, logger_debug_file):
+        '''
+        Provide a method that allows setting up of a debug file handler with customized file rotation and formatting.
+
+        :param logger_debug_file: File name to use for logging the debug log records.
+        '''
+        self.optest_logger.info('Preparing to set location of Debug Log File to {}'.format(os.path.join(self.logdir, logger_debug_file)))
+        self.logger_debug_file = logger_debug_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.dh = RotatingFileHandler(os.path.join(self.logdir, self.logger_debug_file), maxBytes=self.maxBytes_logger_debug_file, backupCount=self.backupCount_debug_files)
+        self.dh.setLevel(logging.DEBUG)
+        self.dh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.dh)
+        self.optest_logger.debug('DebugHandler settings updated')
+        self.optest_logger.info('Debug Log file: {}'.format(os.path.join(self.logdir, self.logger_debug_file)))
+
+global optest_logger_glob
+optest_logger_glob = OpTestLogger('parent')

--- a/op-test
+++ b/op-test
@@ -29,6 +29,7 @@ op-test: run OpenPOWER test suite(s)
 import sys
 import os
 import unittest
+import re
 
 try:
   import faulthandler
@@ -37,7 +38,10 @@ try:
 except ImportError:
   pass
 
-
+import logging
+import OpTestLogger
+# op-test is the parent logger
+module_logger = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger)
 import OpTestConfiguration
 OpTestConfiguration.conf = OpTestConfiguration.OpTestConfiguration()
 
@@ -103,8 +107,6 @@ import testcases
 args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
 OpTestConfiguration.conf.objs()
 
-print args
-
 class SystemAccessSuite():
     '''
     Tests all system interfaces
@@ -119,6 +121,7 @@ class StandbySuite():
     '''Machine at standby. Focused on BMC'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of StandbySuite')
 #        self.s.addTest(OpTestEnergyScale.standby_suite())
     def suite(self):
         return self.s
@@ -127,6 +130,7 @@ class SkirootSuite():
     '''Tests in Petitboot environment'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of SkirootSuite')
         self.s.addTest(DeviceTreeWarnings.Skiroot())
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(IplParams.Skiroot))
         self.s.addTest(SecureBoot.VerifyOPALSecureboot())
@@ -162,6 +166,7 @@ class HostSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
         self.s.addTest(SystemLogin.OOBHostLogin())
+        module_logger.debug('addSuite of HostSuite')
         self.s.addTest(DeviceTreeWarnings.Host())
         self.s.addTest(OpTestOCC.basic_suite())
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(IplParams.Host))
@@ -199,6 +204,7 @@ class ExperimentalSuite():
     '''Tests that need further development'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of ExperimentalSuite')
         self.s.addTest(OpTestEEH.suite())
         # SwitchEndian is here as we need to resolve issue of running
         # kernel self-tests as part of op-test or not.
@@ -209,6 +215,7 @@ class ExperimentalSuite():
 class BasicIPLSuite():
     '''Basic boot/reboot power on/off'''
     def suite(self):
+        module_logger.debug('addSuite of BasicIPLSuite')
         return BasicIPL.suite()
 
 class SBSuite():
@@ -225,6 +232,7 @@ class DefaultSuite():
     '''Basic regression tests'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of DefaultSuite')
         self.s.addTest(SkirootSuite().suite())
         if OpTestConfiguration.conf.args.host_scratch_disk:
             self.s.addTest(InstallHost().suite())
@@ -246,6 +254,7 @@ class FullSuite():
     '''Every stable test'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of FullSuite')
         self.s.addTest(BasicIPLSuite().suite())
         self.s.addTest(DefaultSuite().suite())
         self.s.addTest(testRestAPI.basic_suite())
@@ -269,6 +278,7 @@ class OpTestEMSuite():
     '''Energy Management'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of OpTestEMSuite')
     def suite(self):
         self.s.addTest(OpTestEM.host_suite())
         self.s.addTest(OpTestEM.skiroot_suite())
@@ -277,29 +287,35 @@ class OpTestEMSuite():
 class BasicPCISuite():
     '''Basic PCI tests'''
     def suite(self):
+        module_logger.debug('addSuite of BasicPCISuite')
         return OpTestPCI.suite()
 
 class OpTestEEHSuite():
     '''PCI EEH error recovery'''
     def suite(self):
+        module_logger.debug('addSuite of OpTestEEHSuite')
         return OpTestEEH.suite()
 
 class HMISuite():
     '''HMI handling'''
     def suite(self):
+        module_logger.debug('addSuite of HMISuite')
         return OpTestHMIHandling.suite()
 
 class ExperimentalHMISuite():
     def suite(self):
+        module_logger.debug('addSuite of ExperimentalHMISuite')
         return OpTestHMIHandling.experimental_suite()
 
 class UnrecoverableHMISuite():
     def suite(self):
+        module_logger.debug('addSuite of UnrecoverableHMISuite')
         return OpTestHMIHandling.unrecoverable_suite()
 
 class OpTestEnergyScaleSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of OpTestEnergyScaleSuite')
         self.s.addTest(OpTestEnergyScale.standby_suite())
         self.s.addTest(OpTestEnergyScale.runtime_suite())
     def suite(self):
@@ -307,15 +323,18 @@ class OpTestEnergyScaleSuite():
 
 class BrokenReprovisionSuite():
     def suite(self):
+        module_logger.debug('addSuite of BrokenReprovisionSuite')
         return OpTestIPMIReprovision.broken_suite()
 
 class ExperimentalReprovisionSuite():
     def suite(self):
+        module_logger.debug('addSuite of ExperimentalReprovisionIPMISuite')
         return OpTestIPMIReprovision.experimental_suite()
 
 class InbandIPMISuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of InbandIPMISuite')
         self.s.addTest(OpTestInbandIPMI.basic_suite())
         self.s.addTest(OpTestInbandIPMI.full_suite())
         self.s.addTest(OpTestInbandUsbInterface.basic_suite())
@@ -331,6 +350,7 @@ class OutofbandIPMISuite():
     '''Out of band IPMI'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of OutofbandIPMISuite')
         self.s.addTest(OpTestOOBIPMI.basic_suite())
         self.s.addTest(OpTestOOBIPMI.standby_suite())
         self.s.addTest(OpTestOOBIPMI.runtime_suite())
@@ -351,6 +371,7 @@ class OCCSuite():
     '''OCC Test Suite'''
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of OCCSuite')
         self.s.addTest(OpTestOCC.OCC_RESET())
         self.s.addTest(OpTestOCC.basic_suite())
         self.s.addTest(OpTestOCC.full_suite())
@@ -366,16 +387,19 @@ class CAPISuite():
 class SystemIPLSuite():
     '''System IPL's'''
     def suite(self):
+        module_logger.debug('addSuite of SystemIPLSuite')
         return OpTestSystemBootSequence.suite()
 
 class CrashSuite():
     '''Crash Test Suite'''
     def suite(self):
+        module_logger.debug('addSuite of CrashSuite')
         return OpTestKernel.crash_suite()
 
 class FspOpalSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of FspOpalSuite')
         self.s.addTest(OpTestDumps.suite())
         self.s.addTest(OpalErrorLog.BasicTest())
         self.s.addTest(OpalErrorLog.FullTest())
@@ -390,12 +414,16 @@ class FspOpalSuite():
 class KnownBugs():
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of KnownBugs')
+        self.s.addTest(Console.Console32k())
+        self.s.addTest(Console.ControlC())
     def suite(self):
         return self.s
 
 class FlashFirmware():
     def __init__(self):
         self.s = unittest.TestSuite()
+        module_logger.debug('addSuite of FlashFirmware')
         self.s.addTest(testcases.OpTestFlash.FSPFWImageFLASH())
         self.s.addTest(testcases.OpTestFlash.BmcImageFlash())
         self.s.addTest(testcases.OpTestFlash.PNORFLASH())
@@ -464,6 +492,7 @@ suites = {
 # Loop through the addons and load in suites defined there
 for opt in OpTestConfiguration.optAddons:
     suites = OpTestConfiguration.optAddons[opt].addSuites(suites)
+    module_logger.debug('addSuites of {}'.format(opt))
 
 if OpTestConfiguration.conf.args.list_suites:
     print '{0:34}{1}'.format('Test Suite', 'Description')
@@ -479,45 +508,73 @@ t = unittest.TestSuite()
 
 if OpTestConfiguration.conf.args.run_suite:
     for suite in OpTestConfiguration.conf.args.run_suite:
+        module_logger.debug('conf args run_suite addSuites of {}'.format(suite))
         t.addTest(suites[suite].suite())
 
 if OpTestConfiguration.conf.args.run:
+    module_logger.debug('conf args run addTest of {}'.format(OpTestConfiguration.conf.args.run))
     t.addTest(unittest.TestLoader().loadTestsFromNames(OpTestConfiguration.conf.args.run))
 
 if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.args.run:
     if not OpTestConfiguration.conf.args.only_flash:
-        print "RUNNING DEFAULT SUITE"
+	module_logger.info('RUNNING DEFAULT SUITE')
         t.addTest(suites['default'].suite())
 
 xml_msg = ""
 def run_tests(t):
+    module_logger.debug('Start of run_tests')
     try:
-        print("Output to be written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
         import xmlrunner  # requires unittest-xml-reporting package
-        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
-        print("Output written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
-        return res
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            module_logger.debug('Calling XMLTestRunner')
+            res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, stream=main_logfile, verbosity=2).run(t)
+            module_logger.debug('Back from XMLTestRunner')
+            return res
     except ImportError, err:
-        sys.stderr.write("WARNING: xmlrunner module not available, falling back to using unittest...\n\n")
-        res = unittest.TextTestRunner(verbosity=2).run(t)
-        return res
+        module_logger.warning('xmlrunner module not available, falling back to using unittest...')
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            module_logger.debug('Calling TextTestRunner')
+            res = unittest.TextTestRunner(main_logfile, verbosity=2).run(t)
+            module_logger.debug('Back from TextTestRunner')
+            return res
 
+# OP-TEST marker used to clip summary of results from main.log
+module_logger.info('OP-TEST')
 res = None
-if not OpTestConfiguration.conf.args.noflash:
-    res = run_tests(FlashFirmware().suite())
 
-print repr(res)
+if not OpTestConfiguration.conf.args.noflash:
+    module_logger.debug('Calling run_tests FlashFirmware in noflash')
+    res = run_tests(FlashFirmware().suite())
+    module_logger.debug('Back from run_tests FlashFirmware in noflash')
+
+module_logger.debug('Print res {}'.format(repr(res)))
 
 if OpTestConfiguration.conf.args.only_flash:
     if res != None:
+        module_logger.error('Exit with Result errors="{}" and failures="{}" from only_flash'.format(len(res.errors), len(res.failures)))
+        module_logger.info('OP-TEST')
         exit(len(res.errors + res.failures))
     else:
+        module_logger.info('OP-TEST')
+        module_logger.debug('Exit normal')
         exit(0)
 
 if not res or (res and not (res.errors or res.failures)):
     res = run_tests(t)
 else:
-    print "Skipping main tests as flashing failed"
+    module_logger.error('Skipping main tests as flashing failed')
+    module_logger.info('OP-TEST')
     exit(-1)
+
+module_logger.info('Exit with Result errors="{}" and failures="{}"'.format(len(res.errors), len(res.failures)))
+module_logger.info('See Main Log File for Results')
+module_logger.info('OP-TEST')
+
+with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'r') as f:
+  summary_output = f.read()
+
+summary_text = re.search(r'OP-TEST.*?OP-TEST', summary_output, re.DOTALL)
+if summary_text:
+  print '{}'.format(re.sub('OP-TEST', '', summary_text.group()))
 
 exit(len(res.errors + res.failures))

--- a/testcases/HelloWorld.py
+++ b/testcases/HelloWorld.py
@@ -18,10 +18,14 @@
 # permissions and limitations under the License.
 
 import unittest
+import logging
 
 import OpTestConfiguration
+import OpTestLogger
 from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
+
+my_logger = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 class HelloWorld(unittest.TestCase):
     def setUp(self):
@@ -29,6 +33,10 @@ class HelloWorld(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
+        my_logger.info('HelloWorld setUp info call')
+        my_logger.debug('HelloWorld setUp debug call')
 
     def runTest(self):
+        my_logger.info('HelloWorld runTest info call')
+        my_logger.debug('HelloWorld runTest debug call')
         self.assertEqual("Hello World", "Hello World")


### PR DESCRIPTION
Provide a common logger and handler infrastructure for op-test.

Provide a main log file for summary information.

Provide a debug log file for more verbose information to assist
during testcase development and testcase result analysis to
assess errors and failures and allow testcase instrumentation
to be non-obstructive to the main log file consumer.

Provide a mechanism to capture traces (adding debug loggers).

See HellowWorld.py for example module instrumentation.

Signed-off-by: Deb McLemore <debmc@linux.vnet.ibm.com>