### PR TITLE
Fixed timeout issue on ubuntu installation

### DIFF
--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -172,7 +172,7 @@ class InstallUbuntu(unittest.TestCase):
         rawc.expect('Loading additional components', timeout=300)
         rawc.expect('Setting up the clock', timeout=300)
         rawc.expect('Detecting hardware', timeout=300)
-        rawc.expect('Partitions formatting', timeout=300)
+        rawc.expect('Partitions formatting', timeout=600)
         rawc.expect('Installing the base system', timeout=300)
         r = None
         while r != 0:


### PR DESCRIPTION
In ubuntu installation failed so often on disk Partitions formatting
so increase timeout and tested most of the system

LOG:

Traceback (most recent call last):
File "/home/praveen/op-test-framework/testcases/InstallUbuntu.py", line 175, in runTest
rawc.expect('Partitions formatting', timeout=300)
File "/home/praveen/op-test-framework/common/OPexpect.py", line 71, in expect
searchwindowsize=searchwindowsize)
File "/usr/lib/python2.7/site-packages/pexpect/init.py", line 1418, in expect
timeout, searchwindowsize)
File "/usr/lib/python2.7/site-packages/pexpect/init.py", line 1433, in expect_list
timeout, searchwindowsize)
File "/usr/lib/python2.7/site-packages/pexpect/init.py", line 1535, in expect_loop
raise TIMEOUT(str(err) + '\n' + str(self))
TIMEOUT: Timeout exceeded.
<common.OPexpect.spawn object at 0x3fff78658d10>
version: 3.1
command: /usr/bin/ipmitool

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>