### PR TITLE
Fixed issue in installation when user miss host user name

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -75,9 +75,9 @@ def get_parser():
     bmcgroup.add_argument("--bmc-type",
                           choices=bmcChoices,
                           help="Type of service processor")
-    bmcgroup.add_argument("--bmc-ip", help="BMC address")
-    bmcgroup.add_argument("--bmc-username", help="SSH username for BMC")
-    bmcgroup.add_argument("--bmc-password", help="SSH password for BMC")
+    bmcgroup.add_argument("--bmc-ip", help="BMC address", required=True)
+    bmcgroup.add_argument("--bmc-username", help="SSH username for BMC", required=True)
+    bmcgroup.add_argument("--bmc-password", help="SSH password for BMC", required=True)
     bmcgroup.add_argument("--bmc-usernameipmi", help="IPMI username for BMC")
     bmcgroup.add_argument("--bmc-passwordipmi", help="IPMI password for BMC")
     bmcgroup.add_argument("--bmc-prompt", default="#",
@@ -87,9 +87,9 @@ def get_parser():
                           help="[QEMU Only] qemu simulator binary")
 
     hostgroup = parser.add_argument_group('Host', 'Installed OS information')
-    hostgroup.add_argument("--host-ip", help="Host address")
-    hostgroup.add_argument("--host-user", help="SSH username for Host")
-    hostgroup.add_argument("--host-password", help="SSH password for Host")
+    hostgroup.add_argument("--host-ip", help="Host address", required=True)
+    hostgroup.add_argument("--host-user", help="SSH username for Host", required=True)
+    hostgroup.add_argument("--host-password", help="SSH password for Host", required=True)
     hostgroup.add_argument("--host-lspci", help="Known 'lspci -n -m' for host")
     hostgroup.add_argument("--host-scratch-disk", help="A block device we can erase", default="")
     hostgroup.add_argument("--host-prompt", default="#",


### PR DESCRIPTION
installation script error out , so this patch made some param
as required

failed LOG:

======================================================================
ERROR [1174.995s]: runTest (testcases.InstallRhel.InstallRhel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/praveen/op-test-framework/testcases/InstallRhel.py", line 120, in runTest
    self.system.host_console_login()
  File "/home/praveen/op-test-framework/common/OpTestSystem.py", line 294, in host_console_login
    l_con.sendline(l_user)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 1036, in sendline
    n = self.send(s)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 1024, in send
    s = self._coerce_send_string(s)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 496, in _coerce_send_string
    return s.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'

----------------------------------------------------------------------
Ran 1 test in 1174.995s

FAILED (errors=1)

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>