### PR TITLE
Fix run_command API in OpTestSSH

### DIFF
--- a/common/OPexpect.py
+++ b/common/OPexpect.py
@@ -40,7 +40,7 @@ import OpTestSystem
 
 
 class spawn(pexpect.spawn):
-    def __init__(self, command, args=[], timeout=30, maxread=2000,
+    def __init__(self, command, args=[], timeout=60, maxread=8000,
                  searchwindowsize=None, logfile=None, cwd=None, env=None,
                  ignore_sighup=False, echo=True, preexec_fn=None,
                  encoding=None, codec_errors='strict', dimensions=None,

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -73,7 +73,7 @@ class OpTestHost():
         self.logfile = logfile
         self.ssh = OpTestSSH(i_hostip, i_hostuser, i_hostpasswd,
                 logfile=self.logfile, check_ssh_keys=check_ssh_keys,
-                known_hosts_file=known_hosts_file)
+                known_hosts_file=known_hosts_file, use_default_bash=True)
         self.scratch_disk = scratch_disk
         self.proxy = proxy
         self.scratch_disk_size = None

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -260,7 +260,7 @@ class IPMIConsole():
         try:
             console.sendline(command)
             console.expect("\n") # from us
-            rc = console.expect([BMC_DISCONNECT, "\[console-pexpect\]#$"], timeout)
+            rc = console.expect([BMC_DISCONNECT, "\[console-pexpect\]#$"], timeout=timeout)
             if rc == 0:
                 raise BMCDisconnected(BMC_DISCONNECT)
             output = console.before
@@ -268,7 +268,7 @@ class IPMIConsole():
             rc = console.expect([BMC_DISCONNECT, "\n"]) # from us
             if rc == 0:
                 raise BMCDisconnected(BMC_DISCONNECT)
-            rc = console.expect([BMC_DISCONNECT, "\[console-pexpect\]#$"], timeout)
+            rc = console.expect([BMC_DISCONNECT, "\[console-pexpect\]#$"], timeout=timeout)
             if rc == 0:
                 raise BMCDisconnected(BMC_DISCONNECT)
             exitcode = int(console.before)

--- a/op-test
+++ b/op-test
@@ -216,7 +216,7 @@ class FullSuite():
         self.s = unittest.TestSuite()
         self.s.addTest(BasicIPLSuite().suite())
         self.s.addTest(DefaultSuite().suite())
-        self.s.addTest(testRestAPI.RestAPI())
+        self.s.addTest(testRestAPI.basic_suite())
         self.s.addTest(OpalGard.OpalGard())
         self.s.addTest(OpalUtils.OpalUtils())
         self.s.addTest(OpTestRTCdriver.HostRTC())
@@ -305,6 +305,16 @@ class OutofbandIPMISuite():
     def suite(self):
         return self.s
 
+class RestAPISuite():
+    '''REST API(OpenBMC Specific Out of band management)'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(testRestAPI.basic_suite())
+        self.s.addTest(testRestAPI.standby_suite())
+        self.s.addTest(testRestAPI.runtime_suite())
+    def suite(self):
+        return self.s
+
 class OCCSuite():
     '''OCC Test Suite'''
     def __init__(self):
@@ -385,6 +395,7 @@ suites = {
     'broken-reprovision' : BrokenReprovisionSuite(),
     'full-inbandipmi' : InbandIPMISuite(),
     'full-outofbandipmi' : OutofbandIPMISuite(),
+    'rest-api' : RestAPISuite(),
     'full-occ' : OCCSuite(),
     'capi' : CAPISuite(),
     'crash-suite' : CrashSuite(),

--- a/op-test
+++ b/op-test
@@ -67,7 +67,7 @@ from testcases import OpTestOOBIPMI
 from testcases import OpTestOCC
 from testcases import OpTestSystemBootSequence
 from testcases import OpTestDumps
-from testcases import HostLogin
+from testcases import SystemLogin
 from testcases import OpalMsglog
 from testcases import KernelLog
 from testcases import OpTestFlash
@@ -96,6 +96,16 @@ args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
 OpTestConfiguration.conf.objs()
 
 print args
+
+class SystemAccessSuite():
+    '''
+    Tests all system interfaces
+    '''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(SystemLogin.system_access_suite())
+    def suite(self):
+        return self.s
 
 class StandbySuite():
     '''Machine at standby. Focused on BMC'''
@@ -138,7 +148,7 @@ class HostSuite():
     '''Tests run in booted OS'''
     def __init__(self):
         self.s = unittest.TestSuite()
-        self.s.addTest(HostLogin.OOBHostLogin())
+        self.s.addTest(SystemLogin.OOBHostLogin())
         self.s.addTest(DeviceTreeWarnings.Host())
         self.s.addTest(OpTestPrdDriver.OpTestPrdDriver())
         self.s.addTest(PciSlotLocCodes.Host())
@@ -355,6 +365,7 @@ class FlashFirmware():
 
 
 suites = {
+    'system-access' : SystemAccessSuite(),
     'skiroot' : SkirootSuite(),
     'host'    : HostSuite(),
     'default' : DefaultSuite(),

--- a/testcases/SystemLogin.py
+++ b/testcases/SystemLogin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python2
 # OpenPOWER Automated Test Project
 #
-# Contributors Listed Below - COPYRIGHT 2017
+# Contributors Listed Below - COPYRIGHT 2017, 2018
 # [+] International Business Machines Corp.
 #
 #
@@ -32,7 +32,9 @@ from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 
 class OOBHostLogin(unittest.TestCase):
-    '''Log into the host via out of band console'''
+    '''
+    Log into the host via out of band console and run differenc commands
+    '''
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.system = conf.system()
@@ -48,9 +50,32 @@ class OOBHostLogin(unittest.TestCase):
             r = l_con.run_command("false")
         except CommandFailed as r:
             self.assertEqual(r.exitcode, 1)
+        for i in range(2):
+            l_con.run_command("dmesg", timeout=60)
+
+class BMCLogin(unittest.TestCase):
+    '''
+    Log into the BMC via SSH and run different commands
+    '''
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.system = conf.system()
+        self.bmc = conf.bmc()
+
+    def runTest(self):
+        r = self.bmc.run_command("echo 'Hello World'")
+        self.assertIn("Hello World", r)
+        try:
+            r = self.bmc.run_command("false")
+        except CommandFailed as r:
+            self.assertEqual(r.exitcode, 1)
+        for i in range(2):
+            self.bmc.run_command("dmesg")
 
 class SSHHostLogin(unittest.TestCase):
-    '''Log into the host via SSH'''
+    '''
+    Log into the host via SSH and run different commands
+    '''
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.system = conf.system()
@@ -64,13 +89,26 @@ class SSHHostLogin(unittest.TestCase):
             r = self.host.host_run_command("false")
         except CommandFailed as r:
             self.assertEqual(r.exitcode, 1)
+        for i in range(2):
+            self.host.host_run_command("dmesg")
 
 class ExampleRestAPI(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.system = conf.system()
+        self.bmc_type = conf.args.bmc_type
 
     def runTest(self):
+        if "OpenBMC" not in self.bmc_type:
+            self.skipTest("OpenBMC specific Rest API Tests")
         self.system.sys_inventory()
         self.system.sys_sensors()
         self.system.sys_bmc_state()
+
+def system_access_suite():
+    s = unittest.TestSuite()
+    s.addTest(OOBHostLogin())
+    s.addTest(BMCLogin())
+    s.addTest(SSHHostLogin())
+    s.addTest(ExampleRestAPI())
+    return s

--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -37,15 +37,24 @@ class RestAPI(unittest.TestCase):
         conf = OpTestConfiguration.conf
         self.system = conf.system()
         self.bmc = conf.bmc()
+        self.bmc_password = conf.args.bmc_password
         self.rest = conf.system().rest
         self.bmc_type = conf.args.bmc_type
         if "OpenBMC" in self.bmc_type:
             self.curltool = conf.system().rest.curl
-
-    def runTest(self):
         if "OpenBMC" not in self.bmc_type:
             self.skipTest("OpenBMC specific Rest API Tests")
         self.curltool.log_result()
+
+    def test_bmc_reset(self):
+        self.rest.bmc_reset()
+
+    def test_login(self):
+        self.rest.login()
+        self.rest.logout()
+        self.rest.login()
+
+    def test_system_power_cap(self):
         # System power cap enable/disable tests
         self.rest.power_cap_enable()
         PowerCapEnable, PowerCap =self.rest.get_power_cap_settings()
@@ -53,34 +62,65 @@ class RestAPI(unittest.TestCase):
         self.rest.power_cap_disable()
         PowerCapEnable, PowerCap =self.rest.get_power_cap_settings()
         self.assertEqual(int(PowerCapEnable), 0, "system power cap disable failed")
+
+    def test_occ_active(self):
         # OCC Active state tests using RestAPI
         ids = self.rest.get_occ_ids()
         for id in ids:
-            self.assertTrue(self.rest.is_occ_active(id), "OCC%s is not in active state" % id)
-        # Field mode tests
+            # If system is in runtime OCC should be Active
+            if self.system.get_state() in [OpSystemState.PETITBOOT, OpSystemState.PETITBOOT_SHELL,
+                                           OpSystemState.BOOTING, OpSystemState.OS]:
+                self.assertTrue(self.rest.is_occ_active(id), "OCC%s is not in active state" % id)
+            # if system is in standby state OCC should be inactive
+            elif self.system.get_state() == OpSystemState.OFF:
+                self.assertFalse(self.rest.is_occ_active(id), "OCC%s is still in active state" % id)
+
+    def test_software_enumerate(self):
         self.rest.software_enumerate()
+        ids = self.rest.get_list_of_image_ids()
+        for id in ids:
+            cur_prty = self.rest.get_image_priority(id)
+            self.rest.set_image_priority(id, cur_prty)
+            next_prty = self.rest.get_image_priority(id)
+            self.assertEqual(cur_prty, next_prty, "priority changed after setting")
+
+
+    def test_field_mode_enable_disable(self):
+        # Field mode tests
         self.rest.has_field_mode_set()
         self.rest.set_field_mode("1")
         self.assertTrue(self.rest.has_field_mode_set(), "Field mode enable failed")
         self.rest.set_field_mode("0")
         self.bmc.clear_field_mode()
         self.assertFalse(self.rest.has_field_mode_set(), "Field mode disable failed")
+
+    def test_upload_image(self):
         # Upload image
         self.rest.upload_image(os.path.basename("README.md"))
+
+    def test_inventory(self):
         # FRU Inventory
         self.rest.get_inventory()
+
+    def test_sensors(self):
         # Sensors
         self.rest.sensors()
+
+    def test_obmc_states(self):
         # get BMC State
         self.rest.get_bmc_state()
         # Get Chassis Power State
         self.rest.get_power_state()
         # Get Host State
         self.rest.get_host_state()
+
+    def test_list_sel(self):
         # List SEL records
         self.rest.list_sel()
         # get list of SEL event ID's if any exist
         self.rest.get_sel_ids()
+
+    def test_clear_sel(self):
         # Clear SEL entry by ID- Clear individual SEL Entry
         self.rest.clear_sel_by_id()
         self.rest.get_sel_ids()
@@ -88,9 +128,10 @@ class RestAPI(unittest.TestCase):
         self.rest.clear_sel()
         # Check if SEL has really zero entries or not
         self.assertTrue(self.rest.verify_clear_sel(), "openBMC failed to clear SEL repository")
+
+    def test_obmc_dump(self):
         # List available dumps
         self.rest.list_available_dumps()
-
         # OpenBMC Dump capture procedure
         # Initiate a dump nd get the dump id
         id = self.rest.create_new_dump()
@@ -98,13 +139,76 @@ class RestAPI(unittest.TestCase):
         self.assertTrue(self.rest.wait_for_dump_finish(id), "OpenBMC Dump capture timeout")
         # Download the dump which is ready to offload
         self.rest.download_dump(id)
+
+    def test_set_bootdevs(self):
         # Set bootdev to setup
         self.rest.set_bootdev_to_setup()
         # Get current bootdev
-        self.rest.get_current_bootdev()
+        bootdev = self.rest.get_current_bootdev()
+        self.assertEqual(bootdev, "Setup", "Failed to set Setup boot device")
         # Set bootdev to Default
         self.rest.set_bootdev_to_none()
         # Get current bootdev
-        self.rest.get_current_bootdev()
+        bootdev = self.rest.get_current_bootdev()
+        self.assertEqual(bootdev, "Regular", "Failed to set Regular boot device")
+
+    def test_get_boot_progress(self):
         # Get boot progress info
         self.rest.get_boot_progress()
+
+    def test_clear_gard_record(self):
+        self.rest.clear_gard_records()
+
+    def test_factory_reset_software(self):
+        #self.rest.factory_reset_software()
+        # Not sure what is the effect of it, enable it caution
+        pass
+
+    def test_factory_reset_network(self):
+        #self.rest.factory_reset_network()
+        # It may clear static N/W, enable it with caution
+        pass
+
+    def test_update_root_password(self):
+        self.rest.login()
+        self.rest.update_root_password(str(self.bmc_password))
+        self.rest.login()
+
+
+class RestAPIStandby(RestAPI):
+    @classmethod
+    def setUpClass(self):
+        conf = OpTestConfiguration.conf
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        super(RestAPIStandby, self).setUpClass()
+
+    @classmethod
+    def tearDownClass(self):
+        OpTestConfiguration.conf.system().goto_state(OpSystemState.OFF)
+        OpTestConfiguration.conf.system().goto_state(OpSystemState.OS)
+
+
+class RestAPIRuntime(RestAPI):
+    @classmethod
+    def setUpClass(self):
+        conf = OpTestConfiguration.conf
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        super(RestAPIRuntime, self).setUpClass()
+
+    @classmethod
+    def tearDownClass(self):
+        OpTestConfiguration.conf.system().goto_state(OpSystemState.OFF)
+        OpTestConfiguration.conf.system().goto_state(OpSystemState.OS)
+
+def basic_suite():
+    return unittest.defaultTestLoader.loadTestsFromTestCase(RestAPI)
+
+def standby_suite():
+    return unittest.defaultTestLoader.loadTestsFromTestCase(RestAPIStandby)
+
+def runtime_suite():
+    return unittest.defaultTestLoader.loadTestsFromTestCase(RestAPIRuntime)


### PR DESCRIPTION
commit 1a17c1d ("OpTestSSH: Make an SSH helper common to all platforms")
breaks run_command in some corner cases and also it sets the unique prompt
for each run_command call.

This fix makes sure for all Host and BMC SSH connections, we will set
unique prompt once during get_console, and run_command just executes
the commands without again re-setting prompt.

Only for SSH Console(port 2200), we are still having login and set
prompt functions outside of the OpTestSSH similar to IPMI SOL console.

And also it fixes bash profile related issues for Host SSH on linux OS's.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>