### PR TITLE
OpTestPNOR: Run this test on Host as well.

### DIFF
--- a/op-test
+++ b/op-test
@@ -135,7 +135,7 @@ class SkirootSuite():
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())
         self.s.addTest(Console.suite())
-        self.s.addTest(OpTestPNOR.OpTestPNOR())
+        self.s.addTest(OpTestPNOR.Skiroot())
         self.s.addTest(DeviceTreeValidation.DeviceTreeValidationSkiroot())
         self.s.addTest(OpalMsglog.Skiroot())
         self.s.addTest(KernelLog.Skiroot())
@@ -170,6 +170,7 @@ class HostSuite():
         self.s.addTest(OpTestPrdDaemon.OpTestPrdDaemon())
         self.s.addTest(SbePassThrough.SbePassThrough())
         self.s.addTest(DeviceTreeValidation.DeviceTreeValidationHost())
+        self.s.addTest(OpTestPNOR.Host())
         self.s.addTest(OpalMsglog.Host())
         self.s.addTest(KernelLog.Host())
     def suite(self):

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -46,7 +46,7 @@ from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 
-class OpTestPNOR(unittest.TestCase):
+class OpTestPNOR():
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.host = conf.host()
@@ -137,12 +137,9 @@ class OpTestPNOR(unittest.TestCase):
         self.pflashWrite("/tmp/toc", tocInfo['offset'], tocInfo['length'])
 
     def runTest(self):
+        self.setup_test()
         if not self.system.has_mtd_pnor_access():
             self.skipTest("Host doesn't have MTD PNOR access")
-
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.system.sys_get_ipmi_console()
-        self.system.host_console_unique_prompt()
 
         self.c.run_command("uname -a")
         self.c.run_command("cat /etc/os-release")
@@ -153,3 +150,14 @@ class OpTestPNOR(unittest.TestCase):
         self.runTestReadWritePAYLOAD()
         # Try write to the TOC
         self.runTestWriteTOC()
+
+class Skiroot(OpTestPNOR, unittest.TestCase):
+    def setup_test(self):
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.c = self.system.sys_get_ipmi_console()
+        self.system.host_console_unique_prompt()
+
+class Host(OpTestPNOR, unittest.TestCase):
+    def setup_test(self):
+        self.system.goto_state(OpSystemState.OS)
+        self.c = self.system.host().get_ssh_connection()


### PR DESCRIPTION
As we can easily upgrade the pflash tool using upstream skiboot on
host instead of petitboot, lets make it this test run on host as well.
So we can catch pflash bugs early, instead of waiting for petitboot
pflash to bump through op-build.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>