### PR TITLE
Fixed issue in installation when user miss host user name

### DIFF
--- a/testcases/InstallHostOS.py
+++ b/testcases/InstallHostOS.py
@@ -38,8 +38,11 @@ class InstallHostOS(unittest.TestCase):
         self.bmc_type = self.conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation, --os-repo is missing")
-        if not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
-            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if not (self.conf.args.host_ip and self.conf.args.host_gateway and self.conf.args.host_dns
+                and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{ip,gateway,dns,submask,mac}")
+        if not (self.conf.args.host_user and self.conf.args.host_password):
+            self.fail("Provide host user details refer, --host-{user,password}")
         if not self.conf.args.host_scratch_disk:
             self.fail("Provide proper host disk to install refer, --host-scratch-disk")
 

--- a/testcases/InstallRhel.py
+++ b/testcases/InstallRhel.py
@@ -38,8 +38,11 @@ class InstallRhel(unittest.TestCase):
         self.bmc_type = self.conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation, --os-repo is missing")
-        if not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
-            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if not (self.conf.args.host_ip and self.conf.args.host_gateway and self.conf.args.host_dns
+                and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{ip,gateway,dns,submask,mac}")
+        if not (self.conf.args.host_user and self.conf.args.host_password):
+            self.fail("Provide host user details refer, --host-{user,password}")
         if not self.conf.args.host_scratch_disk:
             self.fail("Provide proper host disk to install refer, --host-scratch-disk")
 

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -59,8 +59,10 @@ class InstallUbuntu(unittest.TestCase):
         self.bmc_type = conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation with --os-repo or --os-cdrom")
-        if "qemu" not in self.bmc_type and not (self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
-            self.fail("Provide host network details refer, --host-{gateway,dns,submask,mac}")
+        if "qemu" not in self.bmc_type and not (self.conf.args.host_ip and self.conf.args.host_gateway and self.conf.args.host_dns and self.conf.args.host_submask and self.conf.args.host_mac):
+            self.fail("Provide host network details refer, --host-{ip,gateway,dns,submask,mac}")
+        if not (self.conf.args.host_user and self.conf.args.host_password):
+            self.fail("Provide host user details refer, --host-{user,password}")
         if not self.host.get_scratch_disk():
             self.fail("Provide proper host disk to install refer, --host-scratch-disk")
 


### PR DESCRIPTION
installation script error out , so this patch made some param
as required

failed LOG:

======================================================================
ERROR [1174.995s]: runTest (testcases.InstallRhel.InstallRhel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/praveen/op-test-framework/testcases/InstallRhel.py", line 120, in runTest
    self.system.host_console_login()
  File "/home/praveen/op-test-framework/common/OpTestSystem.py", line 294, in host_console_login
    l_con.sendline(l_user)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 1036, in sendline
    n = self.send(s)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 1024, in send
    s = self._coerce_send_string(s)
  File "/usr/lib/python2.7/site-packages/pexpect/__init__.py", line 496, in _coerce_send_string
    return s.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'

----------------------------------------------------------------------
Ran 1 test in 1174.995s

FAILED (errors=1)

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>