### PR TITLE
Enable OpTestSSH for sudo

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -21,18 +21,16 @@ import re
 import sys
 import time
 import pexpect
-import subprocess
-import json
 
-from OpTestUtil import OpTestUtil
 from Exceptions import CommandFailed
-from common.OpTestError import OpTestError
-from OpTestConstants import OpTestConstants as BMC_CONST
 import OpTestSystem
 try:
     from common import OPexpect
 except ImportError:
     import OPexpect
+
+sudo_responses = ["not in the sudoers",
+                  "incorrect password"]
 
 class ConsoleState():
     DISCONNECTED = 0
@@ -105,10 +103,13 @@ class OpTestSSH():
                 failure_callback=set_system_to_UNKNOWN,
                 failure_callback_data=self.system)
         self.state = ConsoleState.CONNECTED
+        # set for bash, otherwise it takes the 24x80 default
+        consoleChild.setwinsize(1000,1000)
         self.console = consoleChild
         # Users expecting "Host IPMI" will reference console.sol so make it available
         self.sol = self.console
         self.set_unique_prompt(consoleChild)
+
         return consoleChild
 
     def set_unique_prompt(self, console):
@@ -117,14 +118,9 @@ class OpTestSSH():
         if self.use_default_bash:
             console.sendline("exec bash --norc --noprofile")
 
-        if self.prompt:
-            prompt = self.prompt
-        else:
-            prompt = "\[console-pexpect\]#"
-        expect_prompt = prompt + "$"
+        expect_prompt = self.build_prompt() + "$"
 
-        console.sendline('PS1=' + prompt)
-        console.expect("\n") # from us, because echo
+        console.sendline('PS1=' + self.build_prompt())
 
         # Check for an early EOF - this can happen if we had a bad ssh host key
         # console.isalive() can still return True in this case if called
@@ -138,6 +134,14 @@ class OpTestSSH():
                 raise Exception("SSH session exited early - bad host key?")
             else:
                 raise Exception("SSH session exited early!")
+
+    def build_prompt(self):
+        if self.prompt:
+          built_prompt = self.prompt
+        else:
+          built_prompt = "\[console-pexpect\]#"
+
+        return built_prompt
 
     def get_console(self):
         if self.state == ConsoleState.DISCONNECTED:
@@ -155,52 +159,144 @@ class OpTestSSH():
 
         return self.console
 
-    def run_command(self, command, timeout=60):
-        console = self.get_console()
-        if self.prompt:
-            prompt = self.prompt
+    def set_env(self, console):
+        set_env_list = []
+        if self.use_default_bash:
+          console.sendline("exec bash --norc --noprofile")
+        expect_prompt = self.build_prompt() + "$"
+        console.sendline('PS1=' + self.build_prompt())
+        console.expect(expect_prompt)
+        combo_io = (console.before + console.after).lstrip()
+        set_env_list += combo_io.splitlines()
+        # remove the expect prompt since matched generic #
+        del set_env_list[-1]
+        return set_env_list
+
+    def try_sendcontrol(self, console, command):
+        res = console.before
+        expect_prompt = self.build_prompt() + "$"
+        console.sendcontrol('c')
+        try_list = []
+        rc = console.expect([expect_prompt, pexpect.TIMEOUT, pexpect.EOF], 10)
+        if rc != 0:
+          self.terminate()
+          self.state = ConsoleState.DISCONNECTED
+          raise CommandFailed(command, 'run_command TIMEOUT', -1)
         else:
-            prompt = "\[console-pexpect\]#"
-        expect_prompt = prompt + "$"
+          try_list = res.splitlines()
+          echo_rc = 1
+        return try_list, echo_rc
 
-        console.sendline(command)
-        console.expect("\n") # from us
-        rc = None
-        output = None
-        exitcode = None
-        try:
-            rc = console.expect([expect_prompt], timeout=timeout)
-            output = console.before
-            console.sendline("echo $?")
-            console.expect("\n") # from us
-            rc = console.expect([expect_prompt], timeout=timeout)
-            exitcode = int(console.before)
-        except pexpect.TIMEOUT as e:
-            print e
-            print "# TIMEOUT waiting for command to finish."
-            print "# Attempting to control-c"
-            try:
-                console.sendcontrol('c')
-                rc = console.expect(["\[console-pexpect\]#$"], 10)
-                if rc == 0:
-                    raise CommandFailed(command, "TIMEOUT", -1)
-            except pexpect.TIMEOUT:
-                print "# Timeout trying to kill timed-out command."
-                print "# Failing current command and attempting to continue"
-                self.terminate()
-                raise CommandFailed("ssh -p %u" % self.port, "timeout", -1)
-            raise e
+    def retry_password(self, console, command):
+        retry_list_output = []
+        a = 0
+        while a < 3:
+          a += 1
+          console.sendline(self.password)
+          rc = console.expect([".*#", "try again.", pexpect.TIMEOUT, pexpect.EOF])
+          if (rc == 0) or (rc == 1):
+            combo_io = console.before + console.after
+            retry_list_output += combo_io.splitlines()
+            matching = [xs for xs in sudo_responses if any(xs in xa for xa in console.after.splitlines())]
+            if len(matching):
+              echo_rc = 1
+              rc = -1 # use to flag the failure next
+          if rc == 0:
+            retry_list_output += self.set_env(console)
+            echo_rc = 0
+            break
+          elif a == 2:
+            echo_rc = 1
+            break
+          elif (rc == 2):
+            raise CommandFailed(command, 'Retry Password TIMEOUT ' + ''.join(retry_list_output), -1)
+          elif (rc == 3):
+            self.state = ConsoleState.DISCONNECTED
+            raise Exception("SSH session exited early!")
 
+        return retry_list_output, echo_rc
+
+    def handle_password(self, console, command):
+        # this is for run_command 'sudo -s' or the like
+        handle_list_output = []
+        failure_list_output = []
+        pre_combo_io = console.before + console.after
+        console.sendline(self.password)
+        rc = console.expect([".*#", "try again.", pexpect.TIMEOUT, pexpect.EOF])
+        if (rc == 0) or (rc == 1):
+          combo_io = pre_combo_io + console.before + console.after
+          handle_list_output += combo_io.splitlines()
+          matching = [xs for xs in sudo_responses if any(xs in xa for xa in console.after.splitlines())]
+          if len(matching):
+            # remove the expect prompt since matched generic #
+            del handle_list_output[-1]
+            echo_rc = 1
+            rc = -1 # use this to flag the failure next
         if rc == 0:
-            res = output
-            res = res.splitlines()
-            if exitcode != 0:
-                raise CommandFailed(command, res, exitcode)
-            return res
+          # with unknown prompts and unknown environment unable to capture echo $?
+          echo_rc = 0
+          self.set_env(console)
+          list_output = handle_list_output
+        elif rc == 1:
+          retry_list_output, echo_rc = self.retry_password(console, command)
+          list_output = (handle_list_output + retry_list_output)
         else:
-            res = console.before
-            res = res.split(command)
-            return res[-1].splitlines()
+          if (rc == 2) or (rc == 3):
+            failure_list_output += ['Password Problem/TIMEOUT ']
+            failure_list_output += pre_combo_io.splitlines()
+          # timeout path needs access to output
+          # handle_list_output empty if timeout or EOF
+          failure_list_output += handle_list_output
+          if (rc == 3):
+            self.state = ConsoleState.DISCONNECTED
+            raise Exception("SSH session exited early!")
+          else:
+            raise CommandFailed(command, ''.join(failure_list_output), -1)
+        return list_output, echo_rc
+
+    def run_command(self, command, timeout=60):
+        running_sudo_s = False
+        extra_sudo_output = False
+        console = self.get_console()
+        expect_prompt = self.build_prompt() + "$"
+        console.sendline(command)
+        console.expect("\n") # removes the echo of command from output
+        if command == 'sudo -s':
+          running_sudo_s = True
+          # special case to catch loss of env
+          rc = console.expect([".*#", r"[Pp]assword", pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+        else:
+          rc = console.expect([expect_prompt, r"[Pp]assword", pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+        output_list = []
+        output_list += console.before.splitlines()
+        # if we are running 'sudo -s' as root then catch on generic # prompt, restore env
+        if running_sudo_s and (rc == 0):
+          extra_sudo_output = True
+          set_env_list = self.set_env(console)
+        if rc == 0:
+          if extra_sudo_output:
+            output_list += set_env_list
+          console.sendline("echo $?")
+          rc2 = console.expect([expect_prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+          if rc2 == 0:
+            echo_output = console.before
+            echo_rc = int(echo_output.splitlines()[-1])
+          else:
+            raise CommandFailed(command, 'echo TIMEOUT', -1)
+        elif rc == 1:
+          handle_output_list, echo_rc = self.handle_password(console, command)
+          # remove the expect prompt since matched generic #
+          del handle_output_list[-1]
+          output_list = handle_output_list
+        elif rc == 2:
+          output_list, echo_rc = self.try_sendcontrol(console, command)
+        else:
+          self.state = ConsoleState.DISCONNECTED
+          raise Exception("SSH session exited early!")
+        res = output_list
+        if echo_rc != 0:
+          raise CommandFailed(command, res, echo_rc)
+        return res
 
     # This command just runs and returns the ouput & ignores the failure
     # A straight copy of what's in OpTestIPMI

--- a/testcases/SystemLogin.py
+++ b/testcases/SystemLogin.py
@@ -33,7 +33,7 @@ from common.Exceptions import CommandFailed
 
 class OOBHostLogin(unittest.TestCase):
     '''
-    Log into the host via out of band console and run differenc commands
+    Log into the host via out of band console and run different commands
     '''
     def setUp(self):
         conf = OpTestConfiguration.conf
@@ -52,6 +52,12 @@ class OOBHostLogin(unittest.TestCase):
             self.assertEqual(r.exitcode, 1)
         for i in range(2):
             l_con.run_command("dmesg", timeout=60)
+        l_con.run_command("lscpu")
+        try:
+            r = l_con.run_command("sleep 20", timeout=10)
+        except CommandFailed as r:
+            print str(r)
+        l_con.run_command("lscpu")
 
 class BMCLogin(unittest.TestCase):
     '''
@@ -91,6 +97,15 @@ class SSHHostLogin(unittest.TestCase):
             self.assertEqual(r.exitcode, 1)
         for i in range(2):
             self.host.host_run_command("dmesg")
+        self.host.host_run_command("whoami")
+        self.host.host_run_command("sudo -s")
+        self.host.host_run_command("lscpu")
+        try:
+            r = self.host.host_run_command("echo \'hai\';sleep 20", timeout=10)
+        except CommandFailed as r:
+            print str(r)
+        self.host.host_run_command("whoami")
+        self.host.host_run_command("lscpu")
 
 class ExampleRestAPI(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Enable run_command to perform sudo commands on the target OS.

Allow commands like 'sudo -s' and other sudo prefixed commands
to automatically pass credentials.

Enables applications and tests to instrument code and test
fixtures for various exploits.

Signed-off-by: Deb McLemore <debmc@linux.vnet.ibm.com>