### PR TITLE
OpTestPNOR: Clean up exception handling when flashing PAYLOAD

### DIFF
--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -120,9 +120,7 @@ class OpTestPNOR():
             self.pflashWrite("/tmp/payload", payloadInfo['offset'], payloadInfo['length'])
         except CommandFailed as cf:
             print repr(cf)
-            if 'R' in payloadInfo['flags'] and cf.exitcode in [8]:
-                pass
-            else:
+            if not ('R' in payloadInfo['flags'] and cf.exitcode in [8]):
                 raise cf
         # Check the same
         self.comparePartitionFile("/tmp/payload", "PAYLOAD")
@@ -130,9 +128,8 @@ class OpTestPNOR():
         try:
             self.pflashWritePartition("/tmp/payload", "PAYLOAD")
         except CommandFailed as cf:
-            if 'R' in payloadInfo['flags'] and cf.exitcode in [8]:
-                pass
-            raise cf
+            if not ('R' in payloadInfo['flags'] and cf.exitcode in [8]):
+                raise cf
         # Check the same
         self.comparePartitionFile("/tmp/payload", "PAYLOAD")
 


### PR DESCRIPTION
There was an inconsistency in the second try-catch block (w.r.t the
first) that caused the raised exception to be re-raised. Ensure that if
we expect the failure we don't fail the test.

Fixes: 0976e314fa63 ("OpTestPNOR: Check if PAYLOAD is marked READONLY")
Signed-off-by: Andrew Jeffery <andrew@aj.id.au>