### PR TITLE
OpTestSSH/IPMI: Fix printing command two times

### DIFF
--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -205,11 +205,12 @@ class IPMIConsole():
 
         cmd = self.ipmitool.binary_name() + self.ipmitool.arguments() + ' sol activate'
         print cmd
-        solChild = OPexpect.spawn(cmd,logfile=self.logfile,
+        solChild = OPexpect.spawn(cmd,
                                   failure_callback=set_system_to_UNKNOWN,
                                   failure_callback_data=self.system)
         self.state = IPMIConsoleState.CONNECTED
         self.sol = solChild
+        solChild.logfile_read = self.logfile
         if self.delaybeforesend:
 	    self.sol.delaybeforesend = self.delaybeforesend
         self.sol.expect_exact('[SOL Session operational.  Use ~? for help]')

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -101,13 +101,14 @@ class OpTestSSH():
             cmd = (cmd + " -o UserKnownHostsFile=" + self.known_hosts_file)
 
         print cmd
-        consoleChild = OPexpect.spawn(cmd,logfile=self.logfile,
+        consoleChild = OPexpect.spawn(cmd,
                 failure_callback=set_system_to_UNKNOWN,
                 failure_callback_data=self.system)
         self.state = ConsoleState.CONNECTED
         self.console = consoleChild
         # Users expecting "Host IPMI" will reference console.sol so make it available
         self.sol = self.console
+        consoleChild.logfile_read = self.logfile
         self.set_unique_prompt(consoleChild)
         return consoleChild
 


### PR DESCRIPTION
Currently we are printing any running commands two times.
This fix will make sure only the running command shows on
console any additional prints will be blocked.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>