### PR TITLE
hmi: ignore PROC_RECV_ERROR_MASKED hmi test for p9

### DIFF
--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -281,9 +281,7 @@ class OpTestHMIHandling(unittest.TestCase):
     #        Processor went through recovery for an error which is actually masked for reporting
     #        this function also injecting the error on all the cpu's one-by-one.
     def _test_proc_recv_error_masked(self):
-        if self.proc_gen in ["POWER9"]:
-            scom_addr = "20010A40"
-        elif self.proc_gen in ["POWER8", "POWER8E"]:
+        if self.proc_gen in ["POWER8", "POWER8E"]:
             scom_addr = "10013100"
         else:
             return


### PR DESCRIPTION
In p8 bit 44 of CORE FIR was used to inject Processor recovery masked hmi.
But in p9 bit 44 is no more valid and do not generate Processor recovery
masked hmi. Hence ignore this test for p9.

Signed-off-by: Mahesh Salgaonkar <mahesh@linux.vnet.ibm.com>