### PR TITLE
OpTestPNOR: Fix failure of parsing partitions when flags are optional

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -905,11 +905,19 @@ class OpTestHost():
         for line in d:
             s = re.search(partition, line)
             if s:
-                m = re.match(r'ID=\d+\s+\S+\s+((0[xX])?[0-9a-fA-F]+)..(0[xX])?[0-9a-fA-F]+\s+\(actual=((0[xX])?[0-9a-fA-F]+)\).*', line)
+                m = re.match(r'ID=\d+\s+\S+\s+((0[xX])?[0-9a-fA-F]+)..(0[xX])?[0-9a-fA-F]+\s+\(actual=((0[xX])?[0-9a-fA-F]+)\)\s(\[)?([A-Za-z-]+)?(\])?.*', line)
+                if not m:
+                    continue
                 offset = int(m.group(1), 16)
                 length = int(m.group(4), 16)
-                ret = {'offset': offset, 'length': length}
-        return ret
+                ret = {'offset': offset,
+                       'length': length
+                       }
+                flags = m.group(7)
+                if flags:
+                    ret['flags'] = [x for x in list(flags) if x != '-']
+                return ret
+
 
     ##
     # @brief Check that host has a CAPI FPGA card

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -77,14 +77,17 @@ class OpTestPNOR():
         for line in d:
             s = re.search(partition, line)
             if s:
-                m = re.match(r'ID=\d+\s+\S+\s+((0[xX])?[0-9a-fA-F]+)..(0[xX])?[0-9a-fA-F]+\s+\(actual=((0[xX])?[0-9a-fA-F]+)\).*\[([A-Za-z-]+)\].*', line)
+                m = re.match(r'ID=\d+\s+\S+\s+((0[xX])?[0-9a-fA-F]+)..(0[xX])?[0-9a-fA-F]+\s+\(actual=((0[xX])?[0-9a-fA-F]+)\)\s(\[)?([A-Za-z-]+)?(\])?.*', line)
+                if not m:
+                    continue
                 offset = int(m.group(1), 16)
                 length = int(m.group(4), 16)
-                flags = m.group(6)
                 ret = {'offset': offset,
-                       'length': length,
-                       'flags': [x for x in list(flags) if x != '-'],
+                       'length': length
                        }
+                flags = m.group(7)
+                if flags:
+                    ret['flags'] = [x for x in list(flags) if x != '-']
                 return ret
 
     def comparePartitionFile(self, filename, partition):


### PR DESCRIPTION
On P8 platform:
===============
ID=18           NVRAM 01de2000..01e72000 (actual=00090000)

On P9 plaform:
===============
ID=03           NVRAM 0x00031000..0x000c1000 (actual=0x00090000) [-P--F--]

Not all partitions on P8 platforms having flags, hence make it optional
in regex. So this patch fixes the issue in P8 AMI platforms.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>