### PR TITLE
SecureBoot: Fix DT properties check for P8 vs P9

### DIFF
--- a/testcases/SecureBoot.py
+++ b/testcases/SecureBoot.py
@@ -97,7 +97,7 @@ class SecureBoot(unittest.TestCase):
         for part in part_list:
             msg = "STB: %s verified" % part
             if not msg in data:
-                self.assertTrue(False, "OPAL-SB: %s is not verified" % part)
+                self.assertTrue(False, "OPAL-SB: %s verification failed or not happened" % part)
 
     def verify_dt_sb(self):
         c = self.cv_SYSTEM.sys_get_ipmi_console()
@@ -106,14 +106,16 @@ class SecureBoot(unittest.TestCase):
         if self.securemode:
             c.run_command("ls /proc/device-tree/ibm,secureboot/secure-enabled")
         c.run_command("ls /proc/device-tree/ibm,secureboot/compatible")
-        c.run_command("ls /proc/device-tree/ibm,secureboot/hw-key-hash-size")
         c.run_command("ls /proc/device-tree/ibm,secureboot/hw-key-hash")
         c.run_command("ls /proc/device-tree/ibm,secureboot/name")
         value = c.run_command("cat /proc/device-tree/ibm,secureboot/compatible")[-1]
         if "ibm,secureboot-v2" in value:
+            c.run_command("ls /proc/device-tree/ibm,secureboot/hw-key-hash-size")
             c.run_command("ls /proc/device-tree/ibm,secureboot/ibm,cvc")
             c.run_command("ls /proc/device-tree/ibm,secureboot/ibm,cvc/compatible")
             c.run_command("ls /proc/device-tree/ibm,secureboot/ibm,cvc/memory-region")
+        elif "ibm,secureboot-v1" in value:
+            c.run_command("ls /proc/device-tree/ibm,secureboot/hash-algo")
 
 class VerifyOPALSecureboot(SecureBoot):
 


### PR DESCRIPTION
In P8 platforms ibm,secureboot-v1 uses hash-algo and in P9
platforms ibm,secureboot-v2 uses hw-key-hash-size. So this
patch fixes this accordingly.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>