### PR TITLE
OpTestSystem: Detect machine state

### DIFF
--- a/common/OPexpect.py
+++ b/common/OPexpect.py
@@ -92,7 +92,7 @@ class spawn(pexpect.spawn):
         state = None
 
         if r in [1,2,3,4,5,6,7,8,9,10]:
-            # We set the system state to UNKNOWN as we want to have a path
+            # We set the system state to UNKNOWN_BAD as we want to have a path
             # to recover and run the next test, which is going to be to IPL
             # the box again.
             # We do this via a callback rather than any other method as that's

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -154,9 +154,9 @@ class IPMIConsoleState():
     DISCONNECTED = 0
     CONNECTED = 1
 
-def set_system_to_UNKNOWN(system):
+def set_system_to_UNKNOWN_BAD(system):
     s = system.get_state()
-    system.set_state(OpSystemState.UNKNOWN)
+    system.set_state(OpSystemState.UNKNOWN_BAD)
     return s
 
 class IPMIConsole():
@@ -206,7 +206,7 @@ class IPMIConsole():
         cmd = self.ipmitool.binary_name() + self.ipmitool.arguments() + ' sol activate'
         print cmd
         solChild = OPexpect.spawn(cmd,logfile=self.logfile,
-                                  failure_callback=set_system_to_UNKNOWN,
+                                  failure_callback=set_system_to_UNKNOWN_BAD,
                                   failure_callback_data=self.system)
         self.state = IPMIConsoleState.CONNECTED
         self.sol = solChild

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -36,9 +36,9 @@ class ConsoleState():
     DISCONNECTED = 0
     CONNECTED = 1
 
-def set_system_to_UNKNOWN(system):
+def set_system_to_UNKNOWN_BAD(system):
     s = system.get_state()
-    system.set_state(OpTestSystem.OpSystemState.UNKNOWN)
+    system.set_state(OpTestSystem.OpSystemState.UNKNOWN_BAD)
     return s
 
 class OpTestSSH():
@@ -100,7 +100,7 @@ class OpTestSSH():
 
         print cmd
         consoleChild = OPexpect.spawn(cmd,logfile=self.logfile,
-                failure_callback=set_system_to_UNKNOWN,
+                failure_callback=set_system_to_UNKNOWN_BAD,
                 failure_callback_data=self.system)
         self.state = ConsoleState.CONNECTED
         # set for bash, otherwise it takes the 24x80 default

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -91,7 +91,7 @@ class ControlC(unittest.TestCase):
             print e
             print "# TIMEOUT waiting for command to finish with ctrl-c."
             print "# Everything is terrible. Fail the world, power cycle (if lucky)"
-            self.system.set_state(OpSystemState.UNKNOWN)
+            self.system.set_state(OpSystemState.UNKNOWN_BAD)
             self.fail("Could not ctrl-c running command in reasonable time")
         self.cleanup()
 

--- a/testcases/SecureBoot.py
+++ b/testcases/SecureBoot.py
@@ -162,7 +162,7 @@ class UnSignedPNOR(SecureBoot, PNORFLASH):
             self.verify_opal_sb()
         else:
             self.assertTrue(self.verify_boot_fail(), "Unexpected system boot")
-            self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN)
+            self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
             self.cv_SYSTEM.goto_state(OpSystemState.OFF)
 
 class SignedPNOR(SecureBoot, PNORFLASH):
@@ -279,7 +279,7 @@ class OPALContainerTest(SecureBoot, OpalLidsFLASH):
             super(OPALContainerTest, self).runTest()
             if self.securemode:
                 self.wait_for_secureboot_enforce()
-                self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN)
+                self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
                 self.cv_SYSTEM.goto_state(OpSystemState.OFF)
             else:
                 self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)

--- a/testcases/TrustedBoot.py
+++ b/testcases/TrustedBoot.py
@@ -215,7 +215,7 @@ class NoFunctionalTPM_PolicyON(TrustedBoot):
         if self.securemode:
             self.cv_SYSTEM.sys_power_on()
             self.wait_for_system_shutdown()
-            self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN)
+            self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
             self.cv_SYSTEM.goto_state(OpSystemState.OFF)
             self.cv_SYSTEM.sys_disable_tpm() 
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)


### PR DESCRIPTION
Auto detect the current state of the machine.

When performing tests the current state of the machine
will be checked to transition to the desired state
requested by the test fixture.

This relates to the --machine-state command line option,
instead of having to manually identify the --machine-state
the detection will query the current machine to
see if it can be determined if at Host OS or Petitboot.

If not able to determine the current state then proceed
as usual by entering UNKNOWN machine state.

Signed-off-by: Deb McLemore <debmc@linux.vnet.ibm.com>