### PR TITLE
OpenBMC: Fix BMC reboot path and login failures.

### DIFF
--- a/common/Exceptions.py
+++ b/common/Exceptions.py
@@ -37,6 +37,24 @@ class CommandFailed(Exception):
     def __str__(self):
         return "Command '%s' exited with %d.\nOutput:\n%s" % (self.command, self.exitcode, self.output)
 
+class SSHSessionDisconnected(Exception):
+    '''
+    SSH session/console was disconnected unexpectedly. e.g. it may have crashed
+    '''
+    def __init__(self, notice):
+        self.notice = notice
+    def __str__(self):
+        return "SSH session/console disconnected due to '%s'" % self.notice
+
+class LoginFailure(Exception):
+    '''
+    SSH/IPMI Login failure - username/password may be wrong
+    '''
+    def __init__(self, notice):
+        self.notice = notice
+    def __str__(self):
+        return "Login failure due to '%s'" % self.notice
+
 class BMCDisconnected(Exception):
     '''
     BMC Cosnole was disconnected unexpectedly. e.g. it may have crashed

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -22,7 +22,7 @@ import sys
 import time
 import pexpect
 
-from Exceptions import CommandFailed
+from Exceptions import CommandFailed, SSHSessionDisconnected
 import OpTestSystem
 try:
     from common import OPexpect
@@ -131,9 +131,9 @@ class OpTestSSH():
         except pexpect.EOF as cf:
             print cf
             if self.check_ssh_keys:
-                raise Exception("SSH session exited early - bad host key?")
+                raise SSHSessionDisconnected("SSH session exited early - bad host key?")
             else:
-                raise Exception("SSH session exited early!")
+                raise SSHSessionDisconnected("SSH session exited early!")
 
     def build_prompt(self):
         if self.prompt:
@@ -212,7 +212,7 @@ class OpTestSSH():
             raise CommandFailed(command, 'Retry Password TIMEOUT ' + ''.join(retry_list_output), -1)
           elif (rc == 3):
             self.state = ConsoleState.DISCONNECTED
-            raise Exception("SSH session exited early!")
+            raise SSHSessionDisconnected("SSH session exited early!")
 
         return retry_list_output, echo_rc
 
@@ -249,7 +249,7 @@ class OpTestSSH():
           failure_list_output += handle_list_output
           if (rc == 3):
             self.state = ConsoleState.DISCONNECTED
-            raise Exception("SSH session exited early!")
+            raise SSHSessionDisconnected("SSH session exited early!")
           else:
             raise CommandFailed(command, ''.join(failure_list_output), -1)
         return list_output, echo_rc
@@ -292,7 +292,7 @@ class OpTestSSH():
           output_list, echo_rc = self.try_sendcontrol(console, command)
         else:
           self.state = ConsoleState.DISCONNECTED
-          raise Exception("SSH session exited early!")
+          raise SSHSessionDisconnected("SSH session exited early!")
         res = output_list
         if echo_rc != 0:
           raise CommandFailed(command, res, echo_rc)


### PR DESCRIPTION
We have couple of failures in BMC re-boot code path, and also
i see there are intermediate loggin session expire failures.
So this patch fixes the following things.
   1. Fix the order of BMC reboot path in BMCcode update test.
      Do the code update --> Do BMC reboot --> Wait for BMC go down
      --> Wait for BMC UP --> Wait for BMC ready/standby
   2. If existing login session/cookies expires in b/w tests re-login
      again to continue tests.
   3. Also handle login failure due to incorrect username or password.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>