### PR TITLE
Petitbooti18n: Check i18n strings are displayed

### DIFF
--- a/op-test
+++ b/op-test
@@ -49,6 +49,7 @@ from testcases import OpTestPCI
 from testcases import FWTS
 from testcases import BasicIPL
 from testcases import PetitbootDropbearServer
+from testcases import Petitbooti18n
 from testcases import OpTestRTCdriver
 from testcases import OpTestEM
 from testcases import AT24driver
@@ -137,6 +138,7 @@ class SkirootSuite():
         self.s.addTest(PciSlotLocCodes.SkirootDT())
         self.s.addTest(OpTestPCI.PcieLinkErrorsSkiroot())
         self.s.addTest(PetitbootDropbearServer.PetitbootDropbearServer())
+        self.s.addTest(Petitbooti18n.Petitbooti18n())
         self.s.addTest(OpTestFastReboot.OpTestFastReboot())
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())

--- a/testcases/Petitbooti18n.py
+++ b/testcases/Petitbooti18n.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# Do a basic sanity check of the Petitboot UI to see if unicode strings are
+# being displayed correctly. We do this by moving to the Language screen and
+# checking each example string is present. These representations match the
+# layout and encoding in ui/ncurses/nc-lang.c
+
+import time
+import unittest
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+
+class Petitbooti18n(unittest.TestCase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.cv_SYSTEM = conf.system()
+
+    def runTest(self):
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
+        print "Test i18n strings appear correctly in Petitboot"
+
+        # Wait a moment for pb-discover to connect
+        time.sleep(3)
+
+        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c.sol.send("l")
+        c.sol.expect('Deutsch')
+        c.sol.expect('English')
+        c.sol.expect(u'Espa\u00f1ol'.encode('utf-8'))
+        c.sol.expect(u'Fran\u00e7ais'.encode('utf-8'))
+        c.sol.expect('Italiano')
+        c.sol.expect(u'\u65e5\u672c\u8a9e'.encode('utf-8'))
+        c.sol.expect(u'\ud55c\uad6d\uc5b4'.encode('utf-8'))
+        c.sol.expect(u'Portugu\u00eas/Brasil'.encode('utf-8'))
+        c.sol.expect(u'\u0420\u0443\u0441\u0441\u043a\u0438\u0439'.encode('utf-8'))
+        c.sol.expect(u'\u7b80\u4f53\u4e2d\u6587'.encode('utf-8'))
+        c.sol.expect(u'\u7e41\u9ad4\u4e2d\u6587'.encode('utf-8'))
+
+        # Return to the Petitboot main menu
+        c.sol.send("x")
+        c.sol.expect('e=edit')
+
+        pass


### PR DESCRIPTION
Basic sanity check to ensure unicode strings are correctly displayed.

Starts to resolve https://github.com/open-power/op-test-framework/issues/164
From here we would switch the configured language and ensure the correct
unicode strings are present elsewhere in the UI.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>