### PR TITLE
OpTestEM : Monitor time as well as usage to test cpuidle driver

### DIFF
--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -434,13 +434,18 @@ class cpu_idle_states_host(OpTestEM, unittest.TestCase):
             self.disable_idle_state(i)
             self.verify_disable_idle_state(i)
 
-        # With all idle disabled, gather current usage (as a baseline)
+        # With all idle disabled, gather current usage and total time spent in idle 
+        # state (as a baseline)
         before_usage = {}
+        before_time = {}
         for i in idle_states:
             before_usage[i] = self.c.run_command("cat /sys/devices/system/cpu/cpu*/cpuidle/state%s/usage" % (i))
             before_usage[i] = [int(a) for a in before_usage[i]]
+            before_time[i] = self.c.run_command("cat /sys/devices/system/cpu/cpu*/cpuidle/state%s/time" % (i))
+            before_time[i] = [int(a) for a in before_time[i]]
 
         after_usage = {}
+        after_time = {}
         for i in idle_states:
             self.enable_idle_state(i)
             self.verify_enable_idle_state(i)
@@ -448,11 +453,17 @@ class cpu_idle_states_host(OpTestEM, unittest.TestCase):
                 self.c.run_command("taskset 0x%x find / |head -n 200000 > /dev/null" % (1 << c))
             after_usage[i] = self.c.run_command("cat /sys/devices/system/cpu/cpu*/cpuidle/state%s/usage" % i)
             after_usage[i] = [int(a) for a in after_usage[i]]
+            after_time[i] = self.c.run_command("cat /sys/devices/system/cpu/cpu*/cpuidle/state%s/time" % i)
+            after_time[i] = [int(a) for a in after_time[i]]
             print repr(before_usage[i])
             print repr(after_usage[i])
+            print repr(before_time[i])
+            print repr(after_time[i])
             for c in range(nrcpus):
                 print "# CPU %d entered idle state %s %u times" % (c, idle_state_names[i], after_usage[i][c] - before_usage[i][c])
+                print "# CPU %d entered idle state %s for %u microseconds" % (c, idle_state_names[i], after_time[i][c] - before_time[i][c])
                 self.assertGreater(after_usage[i][c], before_usage[i][c], "CPU %d did not enter expected idle state %s (%s)" % (c,i,idle_state_names[i]))
+                self.assertGreater(after_time[i][c], before_time[i][c], "CPU %d did not enter expected idle state %s (%s)" % (c,i,idle_state_names[i]))
             self.disable_idle_state(i)
 
         # and reset back to enabling idle.


### PR DESCRIPTION
After entering into idle state, a cpu will wakeup in case of a interrupt.
Usage gives number of times a particular state was entered. Thus a cpu
which has more usage may not necessarily have spent more time in idle
state. So time should also be used for monitoring of entering and exiting out
of idle state.

Signed-off-by: Abhishek Goel <huntbag@linux.vnet.ibm.com>
Reported-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>