### PR TITLE
I2C: Fix failure of i2c adapter detection in petit kernel

### DIFF
--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -338,7 +338,10 @@ class FullI2C(I2C, unittest.TestCase):
                 l_val = self.i2c_get(l_chips[1], l_addr)
                 # self.i2c_set(l_list2[1], l_addr, "0x50")
 
-        # list i2c adapter conetents
+        if self.test == "skiroot":
+            return
+
+        # list i2c adapter contents
         try:
             l_res = self.c.run_command("ls -l /sys/class/i2c-adapter")
         except CommandFailed as cf:


### PR DESCRIPTION
All kernel features may not available in petit kernel, hence don't
check for i2c_adapter class.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>