### PR TITLE
conf: Enable test reports store in a new directory per test run.

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -219,16 +219,16 @@ class OpTestConfiguration():
         else:
             outdir = os.path.join(self.basedir, "test-reports")
 
+        self.outsuffix = "test-run-%s" % self.get_suffix()
+        outdir = os.path.join(outdir, self.outsuffix)
+
         # Normalize the path to fully qualified and create if not there
         self.output = os.path.abspath(outdir)
         if (not os.path.exists(self.output)):
             os.makedirs(self.output)
 
         # Grab the suffix, if not given use current time
-        if (self.args.suffix):
-            self.outsuffix = self.args.suffix
-        else:
-            self.outsuffix = time.strftime("%Y%m%d%H%M%S")
+        self.outsuffix = self.get_suffix()
 
         # set up where all the logs go
         logfile = os.path.join(self.output,"%s.log" % self.outsuffix)
@@ -255,6 +255,14 @@ class OpTestConfiguration():
         else:
             self.startState = stateMap[self.args.machine_state]
         return self.args, self.remaining_args
+
+    def get_suffix(self):
+        # Grab the suffix, if not given use current time
+        if (self.args.suffix):
+            outsuffix = self.args.suffix
+        else:
+            outsuffix = time.strftime("%Y%m%d%H%M%S")
+        return outsuffix
 
     def objs(self):
         if self.args.list_suites:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ ready.
 
 This framework runs on most Linux based systems.
 
-You need python 2.7 or greater.
+You need python 2.7 or greater and also needs below modules to be installed
 
-You will also need (recent) ipmiutil - 1.8.15 or above should be adequate.
+	pexpect, importlib, ptyprocess
+
+You will also need below packages need to be installed
+
+	sshpass and (recent) ipmitool - 1.8.15 or above should be adequate.
 
 You will need to run the test suite on a machine that has access to both
 the BMC and the host of the machine(s) you're testing.


### PR DESCRIPTION
Example output:
===============
ls test-reports/test-run-20180608101142/
20180608101142.log
TEST-testcases.OpTestFlash.FSPFWImageFLASH-20180608101142.xml
Kernel_dmesg_log_Fri_Jun__8_10:12:10_2018.log
TEST-testcases.OpTestFlash.OpalLidsFLASH-20180608101142.xml
Opal_msglog_Fri_Jun__8_10:12:09_2018.log
TEST-testcases.OpTestFlash.PNORFLASH-20180608101142.xml
TEST-testcases.OpTestFlash.BmcImageFlash-20180608101142.xml
TEST-testcases.OpTestSensors.OpTestSensors-20180608101142.xml

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>