### PR TITLE
OpTestInstallUtil: Set proxy variable in script files

### DIFF
--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -58,6 +58,7 @@ class InstallUtil():
         global PASSWORD
         global BOOTPATH
         global REPO
+        global PROXY
         self.conf = conf
         self.host = conf.host()
         self.system = conf.system()
@@ -73,6 +74,7 @@ class InstallUtil():
         BASE_PATH = base_path
         INITRD = initrd
         VMLINUX = vmlinux
+        PROXY = self.host.get_proxy()
         KS = ks
 
     def wait_for_network(self):
@@ -327,9 +329,9 @@ class ThreadedHTTPHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 f = open("%s/%s" % (BASE_PATH, KS), "r")
                 d = f.read()
                 if "hostos" in BASE_PATH:
-                    ps = d.format(REPO, PASSWORD, DISK, DISK, DISK)
+                    ps = d.format(REPO, PROXY, PASSWORD, DISK, DISK, DISK)
                 elif "rhel" in BASE_PATH:
-                    ps = d.format(REPO, PASSWORD, DISK, DISK, DISK)
+                    ps = d.format(REPO, PROXY, PASSWORD, DISK, DISK, DISK)
                 elif "ubuntu" in BASE_PATH:
                     user = USERNAME
                     if user == 'root':
@@ -345,9 +347,8 @@ class ThreadedHTTPHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                     packages+= "ipmitool i2c-tools pciutils opal-prd opal-utils "
                     packages+= "device-tree-compiler fwts"
 
-
                     ps = d.format("openpower", "example.com",
-                                  PASSWORD, PASSWORD, user, PASSWORD, PASSWORD, DISK, packages)
+                                  PROXY, PASSWORD, PASSWORD, user, PASSWORD, PASSWORD, DISK, packages)
                 else:
                     print "unknown distro"
                 self.wfile.write(ps)

--- a/osimages/hostos/hostos.ks
+++ b/osimages/hostos/hostos.ks
@@ -1,7 +1,7 @@
 #HostOS Preseed for op-test
 %pre
 %end
-url --url={}
+url --url={} --proxy={}
 text
 keyboard --vckeymap=us --xlayouts='us'
 services --enabled=NetworkManager,sshd

--- a/osimages/rhel/rhel.ks
+++ b/osimages/rhel/rhel.ks
@@ -1,7 +1,7 @@
 # RHEL Preseed for op-test
 %pre
 %end
-url --url={}
+url --url={} --proxy={}
 text
 keyboard --vckeymap=us --xlayouts='us'
 lang en_US.UTF-8

--- a/osimages/ubuntu/preseed.cfg
+++ b/osimages/ubuntu/preseed.cfg
@@ -16,7 +16,7 @@ d-i keyboard-configuration/xkb-keymap select us
 d-i mirror/country string manual
 d-i mirror/http/hostname string ports.ubuntu.com
 d-i mirror/http/directory string /
-d-i mirror/http/proxy string
+d-i mirror/http/proxy string {}
 
 # Alternatively: by default, the installer uses CC.archive.ubuntu.com where
 # CC is the ISO-3166-2 code for the selected country. You can preseed this


### PR DESCRIPTION
The --proxy option is not populated to the kickstart/preseed files when
installing an OS; update the relevant files to recognise the variable.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>