### PR TITLE
OpTestBMC: like SSH don't use public key authentication for rsync

### DIFF
--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -123,7 +123,7 @@ class OpTestBMC():
     def image_transfer(self,i_imageName, copy_as=None):
 
         img_path = i_imageName
-        ssh_opts = ' -k'
+        ssh_opts = ' -k -o PubkeyAuthentication=no '
         if not self.check_ssh_keys:
             ssh_opts = ssh_opts + ' -o StrictHostKeyChecking=no'
         elif self.known_hosts_file:


### PR DESCRIPTION
Fixes: https://github.com/open-power/op-test-framework/issues/250

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>