### PR TITLE
OpTestSSH: Fix SSH connection failure on afs LCB setup.

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -86,7 +86,7 @@ class OpTestSSH():
                + " ssh"
                + " -p %s" % str(self.port)
                + " -l %s %s" % (self.username, self.host)
-               + " -o PubkeyAuthentication=no"
+               + " -o PubkeyAuthentication=no -o afstokenpassing=no"
                )
 
         if not self.check_ssh_keys:


### PR DESCRIPTION
On afs LCB setup SSH is a patched version of ssh which blocks the
ssh connection due to afs token passing. Below is the failure signature
Received disconnect from x.xx.xxx.xx: 2: Invalid ssh2 packet type: 192

To fix this issue pass afstokenpassing=no to ssh command. But this will
throw a below warning message on other non afs machines.
command-line line 0: Unsupported option "afstokenpassing"

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>