### PR TITLE
Read secondary config after primary config

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -174,9 +174,9 @@ class OpTestConfiguration():
         args , remaining_args = conf_parser.parse_known_args(argv)
         defaults = {}
         config = ConfigParser.SafeConfigParser()
+        config.read([os.path.expanduser("~/.op-test-framework.conf")])
         if args.config_file:
             config.read([args.config_file])
-        config.read([os.path.expanduser("~/.op-test-framework.conf")])
         try:
             defaults = dict(config.items('op-test'))
         except ConfigParser.NoSectionError:


### PR DESCRIPTION
Currently the op-test primary-config (~/.op-test-framework.conf) is
read after reading the secondary-config mentioned on the command line
via '--config-file' arg. This prevents options set in secondary-config
to override the options set in the primary-config. For e.g:

 Primary-config:
 bmc_username=sysadmin

 Secondary-config:
 bmc_username=myuser

 Value used in code:
 bmc_username == 'sysadmin'

This patch updates the read order of the configurations so that
secondary-config is read after the primary-config. This makes it
possible for secondary-config to override values previously defined in
primary-config and enforce this more intuitive precedence order:

  cmd-line-options > secondary-config-options > primary-config-options

With this change the value for variable bmc_username == 'myuser' for
the example mentioned above.

Signed-off-by: Vaibhav Jain <vaibhav@linux.ibm.com>