### PR TITLE
Fix copy to destination function

### DIFF
--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -90,7 +90,7 @@ class OpTestFlashBase(unittest.TestCase):
 
     def scp_file(self, src_file_path, dst_file_path):
         self.util.copyFilesToDest(src_file_path, self.bmc_username, self.bmc_ip,
-                                  dst_file_path, self.bmc_password, "2", BMC_CONST.SCP_TO_REMOTE)
+                                  dst_file_path, self.bmc_password)
 
     def get_version_tar(self, file_path):
         tar = tarfile.open(file_path)

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -107,7 +107,7 @@ class OpTestMtdPnorDriver(unittest.TestCase):
 
         # Getting the /tmp/pnor file into local x86 machine
         l_path = "/tmp/"
-        self.util.copyFilesToDest(l_path, self.host_user, self.host_ip, l_file, self.host_Passwd, "2", BMC_CONST.SCP_TO_LOCAL)
+        self.util.copyFilesToDest(l_path, self.host_user, self.host_ip, l_file, self.host_Passwd)
         l_list =  commands.getstatusoutput("ls -l %s" % l_path)
         print l_list
 


### PR DESCRIPTION
Commit 53e7078c changes number of argument to copyFilesToDest().

Fixes: 53e7078c (EnergyScale_BaseLine: port to op-test)
Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>