### PR TITLE
Fail early if secondary config doesn't exists

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -18,6 +18,7 @@ import time
 import subprocess
 import sys
 import ConfigParser
+import errno
 
 # Look at the addons dir for any additional OpTest supported types
 # If new type was called Kona, the layout would be as follows
@@ -176,7 +177,10 @@ class OpTestConfiguration():
         config = ConfigParser.SafeConfigParser()
         config.read([os.path.expanduser("~/.op-test-framework.conf")])
         if args.config_file:
-            config.read([args.config_file])
+            if os.access(args.config_file, os.R_OK):
+                config.read([args.config_file])
+            else:
+                raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), args.config_file)
         try:
             defaults = dict(config.items('op-test'))
         except ConfigParser.NoSectionError:


### PR DESCRIPTION
Presently if the secondary config (specified via --config arg) doesn't
exist a very misleading and confusing error message is shown:

ERROR: runTest (testcases.OpTestFlash.OpalLidsFLASH)
----------------------------------------------------------------------
Traceback (most recent call last):
<snip>
    raise SSHSessionDisconnected("SSH session exited early!")
SSHSessionDisconnected: SSH session/console disconnected due to 'SSH session exited early!'

This is due to SafeConfigParser.read() function that doesn't report an
error in case the input file-path doesn't exists. This patch fixes this
by adding a existence check for secondary config so that a more
relevant error is reported to the user.

Signed-off-by: Vaibhav Jain <vaibhav@linux.ibm.com>