### PR TITLE
TestReboot: Test time to complete reboot call

### DIFF
--- a/testcases/OpTestRebootTimeout.py
+++ b/testcases/OpTestRebootTimeout.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+import unittest
+import re
+import time
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+
+class RebootTime():
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+
+    def runTest(self):
+        self.setup_test()
+
+        # Don't use run_command() in case we actually reboot quickly
+        self.c.sol.sendline("reboot")
+
+        start = time.time()
+        self.c.sol.expect("OPAL: Reboot request", timeout=120)
+        print("Time to OPAL reboot handler: {} seconds".format(time.time() - start))
+
+class Skiroot(RebootTime, unittest.TestCase):
+    def setup_test(self):
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_SYSTEM.host_console_unique_prompt()
+
+class Host(RebootTime, unittest.TestCase):
+    def setup_test(self):
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.cv_SYSTEM.host_console_login()
+        self.cv_SYSTEM.host_console_unique_prompt()


### PR DESCRIPTION
Useful for tracking the time we're losing between calling reboot and
actually rebooting.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>