### PR TITLE
OpTestSystem: Cleanup and consistency for ssh

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -344,7 +344,6 @@ class OpTestConfiguration():
                 host=host,
             )
             ipmi.set_system(self.op_system)
-            bmc.set_system(self.op_system) # this needs testing
         elif self.args.bmc_type in ['OpenBMC']:
             ipmi = OpTestIPMI(self.args.bmc_ip,
                               self.args.bmc_usernameipmi,

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -97,6 +97,7 @@ class OpTestBMC():
             pass
         except CommandFailed as e:
             pass
+        self.ssh.close()
         print 'Sent reboot command now waiting for reboot to complete...'
         # Wait for BMC to go down.
         self.util.ping_fail_check(self.cv_bmcIP)

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -225,7 +225,8 @@ class OpTestHost():
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def host_check_command(self, console=0, *i_cmd):
+    def host_check_command(self, *i_cmd):
+        console = 0 # TODO: Fix this with right function arguments
         l_cmd = 'which ' + ' '.join(i_cmd)
         print l_cmd
         try:

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1802,9 +1802,11 @@ class OpTestOpenBMCSystem(OpTestSystem):
         self.rest.set_bootdev_to_none()
 
     def sys_warm_reset(self):
+        self.console.close()
         self.rest.bmc_reset()
 
     def sys_cold_reset_bmc(self):
+        self.console.close()
         self.rest.bmc_reset()
 
     def sys_enable_tpm(self):

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -367,7 +367,9 @@ class OpTestUtil():
         my_user = host.username()
         my_pwd = host.password()
         my_term.sendline("which sudo && sudo -s")
-        rc = my_term.expect([r"[Pp]assword for", "#", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        rc = my_term.expect([r"[Pp]assword for", pexpect.TIMEOUT, pexpect.EOF], timeout=5)
+        # we must not add # prompt to the expect, we get false hit when complicated user login prompt and control chars,
+        # we need to cleanly ignore everything but password and then we blindly next do PS1 setup, ignoring who knows what
         if rc == 0:
           my_term.sendline(my_pwd)
           time.sleep(0.5) # delays for next call
@@ -375,7 +377,7 @@ class OpTestUtil():
           self.check_root(my_term, prompt)
           my_SUDO_set = 1
           return my_PS1_set, my_SUDO_set # caller needs to save state
-        elif rc in [1,2]: # we must have been root, we first filter out password prompt above
+        elif rc == 1: # we must have been root, we first filter out password prompt above
           my_PS1_set = self.set_PS1(term_obj, my_term, prompt)
           self.check_root(my_term, prompt)
           my_SUDO_set = 1

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -30,44 +30,41 @@ from common.OpTestError import OpTestError
 class BasicIPL(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.host = conf.host()
-        self.ipmi = conf.ipmi()
-        self.system = conf.system()
-        self.bmc = conf.bmc()
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+        self.cv_BMC = conf.bmc()
         self.util = OpTestUtil()
         self.pci_good_data_file = conf.lspci_file()
 
 class BootToPetitboot(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
 
 class BootToPetitbootShell(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
 class SoftPowerOff(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT)
-        self.system.sys_power_soft()
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.sys_power_soft()
         print "soft powered off"
-        self.system.set_state(OpSystemState.POWERING_OFF)
+        self.cv_SYSTEM.set_state(OpSystemState.POWERING_OFF)
         print "set state, going to off"
-        self.system.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
 
 class BMCReset(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.OFF)
-        self.bmc.reboot()
-
-        # BMC reset disconnects the old console
-        self.system.console.close()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_BMC.reboot()
 
         c = 0
         while True:
             try:
-                self.system.sys_wait_for_standby_state()
+                self.cv_SYSTEM.sys_wait_for_standby_state()
             except OpTestError as e:
                 c+=1
                 if c == 10:
@@ -75,43 +72,40 @@ class BMCReset(BasicIPL):
             else:
                 break
 
-        self.system.set_state(OpSystemState.POWERING_OFF)
-        self.system.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.set_state(OpSystemState.POWERING_OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
 
 class BootToOS(BasicIPL):
     def runTest(self):
         print "Currently powered off!"
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.OS)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
         # We booted, SHIP IT!
 
 class OutOfBandWarmReset(BasicIPL):
     def runTest(self):
         # FIXME currently we have to go via OFF to ensure we go to petitboot
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
         # TODO skip if no IPMI
         # TODO use abstracted out-of-band warm reset
-        self.system.sys_warm_reset()
-        # BMC reset disconnects the old console
-        self.system.console.close()
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.sys_warm_reset()
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
 
 class HardPowerCycle(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT)
-        self.system.sys_power_reset()
-        self.system.console.close()
-        self.system.set_state(OpSystemState.IPLing)
-        self.system.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.sys_power_reset()
+        self.cv_SYSTEM.set_state(OpSystemState.IPLing)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
 
 class PowerOff(BasicIPL):
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT)
-        self.system.sys_power_off()
-        self.system.set_state(OpSystemState.POWERING_OFF)
-        self.system.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.sys_power_off()
+        self.cv_SYSTEM.set_state(OpSystemState.POWERING_OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
 
 def suite():
     suite = unittest.TestSuite()

--- a/testcases/BootTorture.py
+++ b/testcases/BootTorture.py
@@ -34,16 +34,16 @@ class BootTorture(unittest.TestCase, TestPCI):
     BOOT_ITERATIONS = 1024
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
+        self.cv_SYSTEM = conf.system()
         self.pci_good_data_file = conf.lspci_file()
 
     def runTest(self):
-        self.c = self.system.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
         for i in range(1,self.BOOT_ITERATIONS):
             print "Boot iteration %d..." % i
-            self.system.goto_state(OpSystemState.OFF)
+            self.cv_SYSTEM.goto_state(OpSystemState.OFF)
             try:
-                self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+                self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
             except pexpect.EOF:
                 continue
             self.c.run_command_ignore_fail("head /sys/firmware/opal/msglog")
@@ -61,12 +61,12 @@ class ReBootTorture(unittest.TestCase, TestPCI):
     BOOT_ITERATIONS = 1024
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
+        self.cv_SYSTEM = conf.system()
         self.pci_good_data_file = conf.lspci_file()
 
     def runTest(self):
-        console = self.system.sys_get_ipmi_console()
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        console = self.cv_SYSTEM.console
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         # Disable the fast-reset
         console.run_command("nvram -p ibm,skiboot --update-config fast-reset=0")
         for i in range(1,self.BOOT_ITERATIONS):
@@ -79,12 +79,12 @@ class ReBootTorture(unittest.TestCase, TestPCI):
             console.run_command_ignore_fail("grep ',[0-4]\]' /sys/firmware/opal/msglog")
             console.sol.sendline("echo 10  > /proc/sys/kernel/printk")
             console.sol.sendline("reboot")
-            self.system.set_state(OpSystemState.IPLing)
+            self.cv_SYSTEM.set_state(OpSystemState.IPLing)
             try:
-                self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+                self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
             except pexpect.EOF:
-                self.system.goto_state(OpSystemState.OFF)
-                self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+                self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+                self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
 class ReBootTorture10(ReBootTorture):
     BOOT_ITERATIONS = 10

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -32,13 +32,13 @@ class Console():
     count = 8
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.bmc = conf.bmc()
-        self.system = conf.system()
+        self.cv_BMC = conf.bmc()
+        self.cv_SYSTEM = conf.system()
         self.util = OpTestUtil()
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        console = self.bmc.get_host_console()
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        console = self.cv_BMC.get_host_console()
         bs = self.bs
         count = self.count
         self.assertTrue( (bs*count)%16 == 0, "Bug in test writer. Must be multiple of 16 bytes: bs %u count %u / 16 = %u" % (bs, count, (bs*count)%16))
@@ -68,8 +68,8 @@ class ControlC(unittest.TestCase):
     CONTROL = 'c'
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.bmc = conf.bmc()
-        self.system = conf.system()
+        self.cv_BMC = conf.bmc()
+        self.cv_SYSTEM = conf.system()
         self.util = OpTestUtil()
         self.prompt = self.util.build_prompt()
 
@@ -77,8 +77,8 @@ class ControlC(unittest.TestCase):
         pass
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        console = self.bmc.get_host_console()
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        console = self.cv_BMC.get_host_console()
         # I should really make this API less nasty...
         raw_console = console.get_console()
         #raw_console.sendline("hexdump -C -v /dev/zero")
@@ -96,14 +96,14 @@ class ControlC(unittest.TestCase):
             print e
             print "# TIMEOUT waiting for command to finish with ctrl-c."
             print "# Everything is terrible. Fail the world, power cycle (if lucky)"
-            self.system.set_state(OpSystemState.UNKNOWN_BAD)
+            self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
             self.fail("Could not ctrl-c running command in reasonable time")
         self.cleanup()
 
 class ControlZ(ControlC):
     CONTROL='z'
     def cleanup(self):
-        console = self.bmc.get_host_console()
+        console = self.cv_BMC.get_host_console()
         console.run_command_ignore_fail("kill %1")
         console.run_command_ignore_fail("fg")
 

--- a/testcases/CpuHotPlug.py
+++ b/testcases/CpuHotPlug.py
@@ -40,8 +40,7 @@ class CpuHotPlug(unittest.TestCase):
 
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_HOST.get_ssh_connection()
-        self.c.run_command("stty cols 300;stty rows 30")
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         self.c.run_command("uname -a")
         self.c.run_command("cat /etc/os-release")
         self.num_avail_cores = self.cv_HOST.host_get_core_count()

--- a/testcases/DeviceTreeValidation.py
+++ b/testcases/DeviceTreeValidation.py
@@ -213,7 +213,7 @@ class DeviceTreeValidationSkiroot(DeviceTreeValidation):
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         system_state = self.cv_SYSTEM.get_state()
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
         if isinstance(self.c, OpTestQemu.QemuConsole):
           raise self.skipTest("OpTestSystem running QEMU so comparing Skiroot to Host is not applicable")
         self.get_proc_gen()
@@ -231,7 +231,7 @@ class DeviceTreeValidationSkiroot(DeviceTreeValidation):
 class DeviceTreeValidationHost(DeviceTreeValidation):
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         self.get_proc_gen()
         self.validate_idle_state_properties()
         self.validate_pstate_properties()

--- a/testcases/DeviceTreeWarnings.py
+++ b/testcases/DeviceTreeWarnings.py
@@ -56,10 +56,10 @@ class DeviceTreeWarnings():
 class Skiroot(DeviceTreeWarnings, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(DeviceTreeWarnings, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         self.cv_HOST.host_check_command("dtc")

--- a/testcases/EPOW.py
+++ b/testcases/EPOW.py
@@ -157,7 +157,7 @@ class EPOW3Random(EPOWBase):
     def runTest(self):
         if "FSP" not in self.bmc_type:
             self.skipTest("FSP specific OPAL EPOW Test.")
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
         console.run_command("uname -a")
         # Range of EPOW temperatures from EPOW3 to CRITICAL
         temp_list = self.get_epow_list_temps()
@@ -214,7 +214,7 @@ class EPOW3LOW(EPOWBase):
     def runTest(self):
         if "FSP" not in self.bmc_type:
             self.skipTest("FSP specific OPAL EPOW Test.")
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
         # Range of EPOW temperatures from EPOW3 to CRITICAL
         temp_list = self.get_epow_list_temps()
         print temp_list

--- a/testcases/FWTS.py
+++ b/testcases/FWTS.py
@@ -114,7 +114,7 @@ class FWTSTest(unittest.TestCase):
 
 class FWTS(unittest.TestSuite):
     def add_fwts_results(self, major_version, minor_version):
-        host = self.host
+        host = self.cv_HOST
         try:
             fwtsjson = host.host_run_command('fwts -q -r stdout --log-type=json')
         except CommandFailed as cf:
@@ -158,12 +158,12 @@ class FWTS(unittest.TestSuite):
 
     def run(self, result):
         conf = OpTestConfiguration.conf
-        self.host = conf.host()
-        self.system = conf.system()
+        self.cv_HOST = conf.host()
+        self.cv_SYSTEM = conf.system()
         self.bmc_type = conf.args.bmc_type
         self.real_fwts_suite = unittest.TestSuite()
         try:
-            self.system.goto_state(OpSystemState.OS)
+            self.cv_SYSTEM.goto_state(OpSystemState.OS)
         except Exception as e:
             # In the event of something going wrong during IPL,
             # We need to catch that here as we're abusing UnitTest
@@ -174,8 +174,8 @@ class FWTS(unittest.TestSuite):
             self.real_fwts_suite.addTest(f)
             self.real_fwts_suite.run(result)
             return
-        self.centaurs_present = self.system.has_centaurs_in_dt()
-        host = self.host
+        self.centaurs_present = self.cv_SYSTEM.has_centaurs_in_dt()
+        host = self.cv_HOST
 
 	fwts_version = None
         try:

--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -58,12 +58,12 @@ class I2C():
     def set_up(self):
         if self.test == "skiroot":
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
         elif self.test == "host":
             self.cv_SYSTEM.goto_state(OpSystemState.OS)
             self.c = self.cv_HOST.get_ssh_connection()
         else:
-            raise Exception("Unknow test type")
+            raise Exception("Unknown test type")
         return self.c
 
     def i2c_init(self):

--- a/testcases/InstallHostOS.py
+++ b/testcases/InstallHostOS.py
@@ -31,10 +31,10 @@ from common import OpTestInstallUtil
 class InstallHostOS(unittest.TestCase):
     def setUp(self):
         self.conf = OpTestConfiguration.conf
-        self.host = self.conf.host()
-        self.ipmi = self.conf.ipmi()
-        self.system = self.conf.system()
-        self.bmc = self.conf.bmc()
+        self.cv_HOST = self.conf.host()
+        self.cv_IPMI = self.conf.ipmi()
+        self.cv_SYSTEM = self.conf.system()
+        self.cv_BMC = self.conf.bmc()
         self.util = OpTestUtil()
         self.bmc_type = self.conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
@@ -50,7 +50,7 @@ class InstallHostOS(unittest.TestCase):
             self.fail("Provide hostname to be set during installation")
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
         # Local path to keep install files
         base_path = os.path.join(self.conf.basedir, "osimages", "hostos")
@@ -85,13 +85,13 @@ class InstallHostOS(unittest.TestCase):
         if "qemu" not in self.bmc_type:
             ks_url = 'http://%s:%s/%s' % (my_ip, port, ks)
             kernel_args = "ifname=net0:%s ip=%s::%s:%s:%s:net0:none nameserver=%s inst.ks=%s" % (self.conf.args.host_mac,
-                                                                                                 self.host.ip,
+                                                                                                 self.cv_HOST.ip,
                                                                                                  self.conf.args.host_gateway,
                                                                                                  self.conf.args.host_submask,
                                                                                                  self.conf.args.host_name,
                                                                                                  self.conf.args.host_dns,
                                                                                                  ks_url)
-            self.c = self.system.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
             cmd = "[ -f %s ]&& rm -f %s;[ -f %s ] && rm -f %s;true" % (vmlinux,
                                                                        vmlinux,
                                                                        initrd,
@@ -118,14 +118,14 @@ class InstallHostOS(unittest.TestCase):
                              'Performing post-installation setup tasks',
                              'Configuring installed system'], timeout=1500)
         rawc.expect('reboot: Restarting system', timeout=300)
-        self.system.set_state(OpSystemState.IPLing)
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.cv_SYSTEM.set_state(OpSystemState.IPLing)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         OpIU.stop_server()
-        OpIU.set_bootable_disk(self.host.get_scratch_disk())
-        self.system.goto_state(OpSystemState.OFF)
-        self.system.goto_state(OpSystemState.OS)
-        con = self.system.sys_get_ipmi_console()
+        OpIU.set_bootable_disk(self.cv_HOST.get_scratch_disk())
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        con = self.cv_SYSTEM.console
         con.run_command("uname -a")
         con.run_command("cat /etc/os-release")
-        self.host.host_gather_opal_msg_log()
-        self.host.host_gather_kernel_log()
+        self.cv_HOST.host_gather_opal_msg_log()
+        self.cv_HOST.host_gather_kernel_log()

--- a/testcases/IplParams.py
+++ b/testcases/IplParams.py
@@ -148,9 +148,9 @@ class IplParams():
 class Skiroot(IplParams, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(IplParams, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_HOST.get_ssh_connection()

--- a/testcases/IpmiTorture.py
+++ b/testcases/IpmiTorture.py
@@ -63,7 +63,8 @@ class InbandIpmiThread(threading.Thread):
         self.cmd = cmd
         self.execution_time = execution_time
         conf = OpTestConfiguration.conf
-        self.host = conf.host()
+        self.cv_HOST = conf.host()
+        self.cv_SYSTEM = conf.system()
 
     def run(self):
         print "Starting " + self.name
@@ -72,7 +73,7 @@ class InbandIpmiThread(threading.Thread):
 
     def inband_ipmi_thread(self, threadName, cmd, t):
         execution_time = time.time() + 60*t
-        self.c = self.host.get_ssh_connection()
+        self.c = self.cv_HOST.get_ssh_connection()
         print "Starting %s for inband-ipmi %s" % (threadName, cmd)
         while True:
             try:
@@ -99,7 +100,7 @@ class SolConsoleThread(threading.Thread):
         print "Exiting " + self.name
 
     def sol_console_thread(self, threadName, t):
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
         # Enable kernel logging(printk) to console
         self.c.run_command("echo 10 > /proc/sys/kernel/printk")
         execution_time = time.time() + 60*self.execution_time
@@ -231,35 +232,35 @@ class SkirootConsoleTorture(ConsoleIpmiTorture):
     def setup_test(self):
         self.test = "skiroot_runtime"
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 
 class SkirootIpmiTorture(IpmiInterfaceTorture):
     def setup_test(self):
         self.test = "skiroot_runtime"
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class RuntimeConsoleTorture(ConsoleIpmiTorture):
     def setup_test(self):
 	self.test = "runtime"
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class StandbyConsoleTorture(ConsoleIpmiTorture):
     def setup_test(self):
 	self.test = "standby"
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class RuntimeIpmiInterfaceTorture(IpmiInterfaceTorture):
     def setup_test(self):
         self.test = "runtime"
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class StandbyIpmiInterfaceTorture(IpmiInterfaceTorture):
     def setup_test(self):
         self.test = "standby"
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console

--- a/testcases/KernelLog.py
+++ b/testcases/KernelLog.py
@@ -91,10 +91,10 @@ class Skiroot(KernelLog, unittest.TestCase):
     def setup_test(self):
         self.test = "skiroot"
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(KernelLog, unittest.TestCase):
     def setup_test(self):
         self.test = "host"
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_HOST.get_ssh_connection()

--- a/testcases/OpTestCAPI.py
+++ b/testcases/OpTestCAPI.py
@@ -51,29 +51,29 @@ from common.Exceptions import CommandFailed
 class OpTestCAPI(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.ipmi = conf.ipmi()
-        self.system = conf.system()
-        self.host = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+        self.cv_HOST = conf.host()
 
     def set_up(self):
-        self.system.goto_state(OpSystemState.OS)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
         # Check that host has a CAPI FPGA card
-        if (self.host.host_has_capi_fpga_card() != True):
+        if (self.cv_HOST.host_has_capi_fpga_card() != True):
             raise unittest.SkipTest("No CAPI card available on host \
                                      Skipping the CAPI tests")
 
-        self.host.host_check_command("git", "gcc")
+        self.cv_HOST.host_check_command("git", "gcc")
 
         # Get OS level
-        l_oslevel = self.host.host_get_OS_Level()
+        l_oslevel = self.cv_HOST.host_get_OS_Level()
 
         # Get kernel version
-        l_kernel = self.host.host_get_kernel_version()
+        l_kernel = self.cv_HOST.host_get_kernel_version()
 
         # Load module cxl based on config option
         l_config = "CONFIG_CXL"
         l_module = "cxl"
-        self.host.host_load_module_based_on_config(l_kernel, l_config, \
+        self.cv_HOST.host_load_module_based_on_config(l_kernel, l_config, \
                                                    l_module)
 
 class CxlDeviceFileTest(OpTestCAPI, unittest.TestCase):
@@ -89,7 +89,7 @@ class CxlDeviceFileTest(OpTestCAPI, unittest.TestCase):
         # Check device files /dev/cxl/afu0.0{m,s} existence
         l_cmd = "ls -l /dev/cxl/afu0.0{m,s}; echo $?"
         try:
-            self.host.host_run_command(l_cmd)
+            self.cv_HOST.host_run_command(l_cmd)
         except CommandFailed:
             self.assertTrue(False, "cxl device file tests fail")
 
@@ -107,17 +107,17 @@ class SysfsABITest(OpTestCAPI, unittest.TestCase):
         # Check that cxl-tests binary and library are available
         # If not, clone and build cxl-tests (along with libcxl)
         l_dir = "/tmp/cxl-tests"
-        if (self.host.host_check_binary(l_dir, "libcxl_tests") != True or
-            self.host.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
-            self.host.host_clone_cxl_tests(l_dir)
-            self.host.host_build_cxl_tests(l_dir)
+        if (self.cv_HOST.host_check_binary(l_dir, "libcxl_tests") != True or
+            self.cv_HOST.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
+            self.cv_HOST.host_clone_cxl_tests(l_dir)
+            self.cv_HOST.host_build_cxl_tests(l_dir)
 
         # Run sysfs abi tests
         l_exec = "libcxl_tests >/tmp/libcxl_tests.log"
         cmd = "cd %s && LD_LIBRARY_PATH=libcxl ./%s;" % (l_dir, l_exec)
         print cmd
         try:
-            self.host.host_run_command(cmd)
+            self.cv_HOST.host_run_command(cmd)
             l_msg = "sysfs abi libcxl_tests pass"
             print l_msg
         except CommandFailed:
@@ -138,17 +138,17 @@ class MemCpyAFUTest(OpTestCAPI, unittest.TestCase):
         # Check that cxl-tests binary and library are available
         # If not, clone and build cxl-tests (along with libcxl)
         l_dir = "/tmp/cxl-tests"
-        if (self.host.host_check_binary(l_dir, "memcpy_afu_ctx") != True or
-            self.host.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
-            self.host.host_clone_cxl_tests(l_dir)
-            self.host.host_build_cxl_tests(l_dir)
+        if (self.cv_HOST.host_check_binary(l_dir, "memcpy_afu_ctx") != True or
+            self.cv_HOST.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
+            self.cv_HOST.host_clone_cxl_tests(l_dir)
+            self.cv_HOST.host_build_cxl_tests(l_dir)
 
         # Run memcpy afu tests
         l_exec = "memcpy_afu_ctx -p1 -l1 >/tmp/memcpy_afu_ctx.log"
         cmd = "cd %s && LD_LIBRARY_PATH=libcxl ./%s; echo $?" % (l_dir, l_exec)
         print cmd
         try:
-            self.host.host_run_command(cmd)
+            self.cv_HOST.host_run_command(cmd)
             l_msg = "memcpy_afu_ctx tests pass"
             print l_msg
         except CommandFailed:
@@ -169,7 +169,7 @@ class TimeBaseSyncTest(OpTestCAPI, unittest.TestCase):
         # Check PSL timebase sync support
         l_cmd = "grep -q -w 1 /sys/class/cxl/card0/psl_timebase_synced;"
         try:
-            self.host.host_run_command(l_cmd)
+            self.cv_HOST.host_run_command(l_cmd)
         except CommandFailed:
             l_msg = "PSL does not support timebase sync; skipping test"
             raise unittest.SkipTest(l_msg)
@@ -177,17 +177,17 @@ class TimeBaseSyncTest(OpTestCAPI, unittest.TestCase):
         # Check that cxl-tests binary and library are available
         # If not, clone and build cxl-tests (along with libcxl)
         l_dir = "/tmp/cxl-tests"
-        if (self.host.host_check_binary(l_dir, "memcpy_afu_ctx") != True or
-            self.host.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
-            self.host.host_clone_cxl_tests(l_dir)
-            self.host.host_build_cxl_tests(l_dir)
+        if (self.cv_HOST.host_check_binary(l_dir, "memcpy_afu_ctx") != True or
+            self.cv_HOST.host_check_binary(l_dir, "libcxl/libcxl.so") != True):
+            self.cv_HOST.host_clone_cxl_tests(l_dir)
+            self.cv_HOST.host_build_cxl_tests(l_dir)
 
         # Run timebase sync tests
         l_exec = "memcpy_afu_ctx -t -p1 -l1 >/tmp/memcpy_afu_ctx-t.log"
         cmd = "cd %s && LD_LIBRARY_PATH=libcxl ./%s; echo $?" % (l_dir, l_exec)
         print cmd
         try:
-            self.host.host_run_command(cmd)
+            self.cv_HOST.host_run_command(cmd)
             print "memcpy_afu_ctx -t tests pass"
         except CommandFailed:
             self.assertTrue(False, "memcpy_afu_ctx -t tests failed")

--- a/testcases/OpTestDumps.py
+++ b/testcases/OpTestDumps.py
@@ -160,7 +160,7 @@ class SYSTEM_DUMP(OpTestDumps, unittest.TestCase):
         self.trigger_dump()
         self.cv_FSP.wait_for_systemdump_to_finish()
         self.cv_FSP.wait_for_runtime()
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         console.sendline()
         console.expect("login:", timeout=600)
         console.close()

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -61,7 +61,7 @@ class OpTestEM():
         self.c = None # clear this, we may not get back from goto and tearDown relies on
         if self.test == "skiroot":
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
         elif self.test == "host":
             self.cv_SYSTEM.goto_state(OpSystemState.OS)
             self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/OpTestFastReboot.py
+++ b/testcases/OpTestFastReboot.py
@@ -85,7 +85,7 @@ class OpTestFastReboot(unittest.TestCase):
         else:
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         cpu = ''.join(c.run_command("grep '^cpu' /proc/cpuinfo|uniq|sed -e 's/^.*: //;s/[,]* .*//;'"))
         print repr(cpu)
         if cpu not in ["POWER9", "POWER8", "POWER8E"]:
@@ -108,7 +108,7 @@ class OpTestFastReboot(unittest.TestCase):
             # We do some funny things with the raw console here, as
             # 'reboot' isn't meant to return, so we want the raw
             # pexpect 'console'.
-            self.con = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+            self.con = self.cv_SYSTEM.console.get_console()
             self.con.sendline("reboot")
             self.cv_SYSTEM.set_state(OpSystemState.IPLing)
             # We're looking for a skiboot log message, that it's doing fast

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -580,7 +580,7 @@ class FSPFWImageFLASH(OpTestFlashBase):
         preup_boot = preup_boot.group(1)
 
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        con = self.cv_SYSTEM.sys_get_ipmi_console()
+        con = self.cv_SYSTEM.console
 
         # Wait until we have a route (i.e. network is up)
         tries = 12
@@ -605,7 +605,7 @@ class FSPFWImageFLASH(OpTestFlashBase):
         self.util.PingFunc(self.cv_BMC.host_name, BMC_CONST.PING_RETRY_POWERCYCLE)
         time.sleep(10)
         self.cv_BMC.fsp_get_console()
-        con = self.cv_SYSTEM.sys_get_ipmi_console()
+        con = self.cv_SYSTEM.console
         self.cv_SYSTEM.set_state(OpSystemState.IPLing)
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         con.run_command("update_flash -d")

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -43,7 +43,7 @@ class HeartbeatSkiroot(unittest.TestCase):
 
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
     def runTest(self):
         self.setup_test()
@@ -53,4 +53,4 @@ class HeartbeatSkiroot(unittest.TestCase):
 class HeartbeatHost(HeartbeatSkiroot):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -111,7 +111,7 @@ class OpTestIPMILockMode(unittest.TestCase):
     # @brief This function will execute whitelisted in-band ipmi commands
     #        and test the functionality in locked mode.
     def run_inband_ipmi_whitelisted_cmds(self):
-        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        l_con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         l_con.run_command("uname -a")
 
         # Test IPMI white listed commands those should be allowed through un-authenticated

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -57,21 +57,21 @@ class UnexpectedBootDevice(Exception):
 class OpTestInbandIPMIBase(object):
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.host = conf.host()
-        self.ipmi = conf.ipmi()
-        self.system = conf.system()
-        self.bmc = conf.bmc()
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
+        self.cv_BMC = conf.bmc()
         self.util = OpTestUtil()
         pass
 
     def set_up(self):
         if self.test == "skiroot":
-            self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c = self.system.sys_get_ipmi_console()
+            self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+            self.c = self.cv_SYSTEM.console
         elif self.test == "host":
-            self.system.goto_state(OpSystemState.OS)
-            self.system.load_ipmi_drivers()
-            self.c = self.host.get_ssh_connection()
+            self.cv_SYSTEM.goto_state(OpSystemState.OS)
+            self.cv_SYSTEM.load_ipmi_drivers()
+            self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         else:
             raise Exception("Unknown test type")
         return self.c
@@ -172,7 +172,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
                 except CommandFailed as cf:
                     if 'Error loading interface usb' in cf.output:
                         self.skipTest("No USB IPMI interface")
-                    if not self.bmc.has_inband_bootdev():
+                    if not self.cv_BMC.has_inband_bootdev():
                         self.skipTest("Does not support inband bootdev")
                     self.fail("Could not set boot device %s. Errored with %s" % (bootdev,str(cf)))
                 self.verify_bootdev(bootdev, ipmiresponse)
@@ -642,7 +642,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
         try:
             self.sensor_byid(BMC_CONST.SENSOR_HOST_STATUS)
         except CommandFailed as cf:
-            if not self.bmc.has_host_status_sensor():
+            if not self.cv_BMC.has_host_status_sensor():
                 if 'not found' in ''.join(cf.output):
                     self.skipTest("Platform doesn't Sensor")
                 if 'Error loading interface usb' in cf.output:
@@ -658,7 +658,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
         try:
             self.sensor_byid(BMC_CONST.SENSOR_OS_BOOT)
         except CommandFailed as cf:
-            if not self.bmc.has_os_boot_sensor():
+            if not self.cv_BMC.has_os_boot_sensor():
                 if 'not found' in ''.join(cf.output):
                     self.skipTest("Platform doesn't Sensor")
                 if 'Error loading interface usb' in cf.output:
@@ -673,7 +673,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
         try:
             self.sensor_byid(BMC_CONST.SENSOR_OCC_ACTIVE)
         except CommandFailed as cf:
-            if not self.bmc.has_occ_active_sensor():
+            if not self.cv_BMC.has_occ_active_sensor():
                 if 'not found' in ''.join(cf.output):
                     self.skipTest("Platform doesn't Sensor")
                 if 'Error loading interface usb' in cf.output:

--- a/testcases/OpTestKernel.py
+++ b/testcases/OpTestKernel.py
@@ -64,7 +64,7 @@ class OpTestKernelBase(unittest.TestCase):
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def kernel_crash(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
         console.run_command("uname -a")
         console.run_command("cat /etc/os-release")
         console.run_command("nvram -p ibm,skiboot --update-config fast-reset=0")
@@ -101,7 +101,7 @@ class KernelCrash_KdumpEnable(OpTestKernelBase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
         self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
 
     ##
     # @brief This function will test the kernel crash followed by crash kernel dump
@@ -124,7 +124,7 @@ class KernelCrash_KdumpDisable(OpTestKernelBase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
         self.util.PingFunc(self.cv_HOST.ip, BMC_CONST.PING_RETRY_POWERCYCLE)
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
 
     ##
     # @brief This function will test the kernel crash followed by system IPL
@@ -144,7 +144,7 @@ class KernelCrash_KdumpDisable(OpTestKernelBase):
 class SkirootKernelCrash(OpTestKernelBase, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
         output = self.c.run_command("cat /proc/cmdline")
         res = ""
         found = False

--- a/testcases/OpTestNVRAM.py
+++ b/testcases/OpTestNVRAM.py
@@ -166,7 +166,7 @@ class HostNVRAM(OpTestNVRAM):
     #
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.doNVRAMTest(self.cv_HOST.get_ssh_connection())
+        self.doNVRAMTest(self.cv_SYSTEM.cv_HOST.get_ssh_connection())
 
 class SkirootNVRAM(OpTestNVRAM):
     def runTest(self):
@@ -174,4 +174,4 @@ class SkirootNVRAM(OpTestNVRAM):
         # Execute these tests in petitboot
         if not self.cv_SYSTEM.has_mtd_pnor_access():
             self.skipTest("OpTestSystem Skiroot does not have MTD PNOR access, probably running QEMU")
-        self.doNVRAMTest(self.cv_SYSTEM.sys_get_ipmi_console())
+        self.doNVRAMTest(self.cv_SYSTEM.console)

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -162,12 +162,12 @@ class TestPCI():
 class TestPCISkiroot(TestPCI, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class TestPCIHost(TestPCI, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
 
 class PcieLinkErrorsHost(TestPCIHost, unittest.TestCase):
 
@@ -188,7 +188,7 @@ class TestPciSkirootReboot(TestPCI, unittest.TestCase):
 
     def runTest(self):
         self.set_up()
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
         if "skiroot_reboot" in self.test:
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
@@ -219,7 +219,7 @@ class TestPciOSReboot(TestPciSkirootReboot, unittest.TestCase):
 class TestPciSkirootvsOS(TestPCI, unittest.TestCase):
 
     def runTest(self):
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         l_res = c.run_command("lspci -mm -n")
         self.pci_data_skiroot = '\n'.join(l_res) + '\n'
@@ -246,11 +246,11 @@ class TestPciDriverBindHost(TestPCIHost, unittest.TestCase):
         self.set_up()
         if "skiroot" in self.test:
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
             root_pe = "xxxx"
         else:
             self.cv_SYSTEM.goto_state(OpSystemState.OS)
-            self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
             root_pe = self.get_root_pe_address()
             self.c.run_command("dmesg -D")
         list = self.get_list_of_pci_devices()
@@ -315,7 +315,7 @@ class TestPciHotplugHost(TestPCI, unittest.TestCase):
         if "FSP" not in self.bmc_type:
             self.skipTest("FSP Platform OPAL specific PCI Hotplug tests")
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        c = self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.c = self.cv_SYSTEM.console
         res = self.c.run_command("uname -r")[-1].split("-")[0]
         if LooseVersion(res) < LooseVersion("4.10.0"):
             self.skipTest("This kernel does not support hotplug %s" % res)

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -49,9 +49,9 @@ from common.Exceptions import CommandFailed
 class OpTestPNOR():
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.host = conf.host()
-        self.ipmi = conf.ipmi()
-        self.system = conf.system()
+        self.cv_HOST = conf.host()
+        self.cv_IPMI = conf.ipmi()
+        self.cv_SYSTEM = conf.system()
         self.util = OpTestUtil()
 
     def pflashErase(self, offset, length):
@@ -155,7 +155,7 @@ class OpTestPNOR():
 
     def runTest(self):
         self.setup_test()
-        if not self.system.has_mtd_pnor_access():
+        if not self.cv_SYSTEM.has_mtd_pnor_access():
             self.skipTest("Host doesn't have MTD PNOR access")
 
         self.c.run_command("uname -a")
@@ -170,10 +170,10 @@ class OpTestPNOR():
 
 class Skiroot(OpTestPNOR, unittest.TestCase):
     def setup_test(self):
-        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.system.sys_get_ipmi_console()
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.c = self.cv_SYSTEM.console
 
 class Host(OpTestPNOR, unittest.TestCase):
     def setup_test(self):
-        self.system.goto_state(OpSystemState.OS)
-        self.c = self.system.host().get_ssh_connection()
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -87,10 +87,10 @@ class OpTestPrdDriver(unittest.TestCase):
     #
     def prd_init(self):
         # Get OS level
-        self.cv_HOST.host_get_OS_Level()
+        self.cv_HOST.host_get_OS_Level(console=1)
 
         # Getting list of processor chip Id's(executing getscom -l to get chip id's)
-        l_res = self.cv_HOST.host_run_command("PATH=/usr/local/sbin:$PATH getscom -l")
+        l_res = self.cv_HOST.host_run_command("PATH=/usr/local/sbin:$PATH getscom -l", console=1)
         l_chips = []
         for line in l_res:
             matchObj = re.search("(\d{8}).*processor", line)
@@ -113,7 +113,7 @@ class OpTestPrdDriver(unittest.TestCase):
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
     def prd_test_core_fir(self, FIR, FIMR, ERROR):
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         chip_id = "0x" + self.random_chip
         print chip_id
         print "OPAL-PRD: Injecting error 0x%x on FIR: %s" % (ERROR, FIR)
@@ -172,7 +172,7 @@ class OpTestPrdDriver(unittest.TestCase):
 
     ##
     # @brief This function performs below steps
-    #        1. Initially connecting to host and ipmi consoles for execution.
+    #        1. Initially connecting to host for execution.
     #        2. check for IPOLL mask register value to see whether opal-prd is running or not
     #           if it is 0-->opal-prd is running-->continue
     #           else start opal-prd service again
@@ -186,9 +186,10 @@ class OpTestPrdDriver(unittest.TestCase):
             self.skipTest("OpenPower specific")
         # In P9 FSP systems we need to enable this test
         self.prd_init()
-        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        # need console in case of crash or lockups
+        l_con = self.cv_SYSTEM.console
 
-        cpu = self.cv_HOST.host_get_proc_gen()
+        cpu = self.cv_HOST.host_get_proc_gen(console=1)
         faults_to_inject = []
 
         if cpu not in ["POWER8", "POWER8E", "POWER9"]:

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -42,14 +42,16 @@ from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 
 class FullRTC(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         conf = OpTestConfiguration.conf
-        self.cv_HOST = conf.host()
-        self.cv_IPMI = conf.ipmi()
-        self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
+        cls.cv_HOST = conf.host()
+        cls.cv_IPMI = conf.ipmi()
+        cls.cv_SYSTEM = conf.system()
+        cls.util = OpTestUtil()
+        cls.test = None
 
-    def rtc_init(self):
+    def setUp(self):
         if self.test == "host":
             self.cv_SYSTEM.goto_state(OpSystemState.OS)
 
@@ -65,7 +67,7 @@ class FullRTC(unittest.TestCase):
 
         elif self.test == "skiroot":
             self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-            self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+            self.c = self.cv_SYSTEM.console
 
     # We have a busy box version hwclock with limited options
     # to access the HW RTC
@@ -108,8 +110,7 @@ class FullRTC(unittest.TestCase):
     #
     # @return BMC_CONST.FW_SUCCESS or raise OpTestError
     #
-    def runTest(self):
-        self.rtc_init()
+    def RunFullRTC(self):
 
         # Get the device files for rtc driver
         l_files = self.cv_HOST.host_run_command("ls --color=never /dev/ | grep -i --color=never rtc")
@@ -299,7 +300,6 @@ class BasicRTC(FullRTC):
         super(BasicRTC, self).setUp()
 
     def runTest(self):
-        self.rtc_init()
         self.cv_HOST.host_read_hwclock()
         self.cv_HOST.host_read_systime()
 
@@ -308,13 +308,15 @@ class HostRTC(FullRTC):
         self.test = "host"
         super(HostRTC, self).setUp()
 
+    def runTest(self):
+        self.RunFullRTC()
+
 class SkirootRTC(FullRTC):
     def setUp(self):
         self.test = "skiroot"
         super(SkirootRTC, self).setUp()
 
     def runTest(self):
-        self.rtc_init()
         self.skiroot_read_hwclock()
         self.skiroot_assume_hwclock_utc()
         self.skiroot_assume_hwclock_localtime()

--- a/testcases/OpTestRebootTimeout.py
+++ b/testcases/OpTestRebootTimeout.py
@@ -52,9 +52,9 @@ class RebootTime():
 class Skiroot(RebootTime, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(RebootTime, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -69,7 +69,7 @@ class OpTestSensors(unittest.TestCase):
     #
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
 
         # Get OS level
         l_oslevel = self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -63,7 +63,7 @@ class OpTestSwitchEndianSyscall(unittest.TestCase):
     #
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
 
         # Get OS level
         self.cv_HOST.host_get_OS_Level()

--- a/testcases/OpalGard.py
+++ b/testcases/OpalGard.py
@@ -79,7 +79,7 @@ class OpalGard(unittest.TestCase):
         if "FSP" in self.bmc_type:
             self.skipTest("OpenPOWER BMC specific")
 
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         self.cv_HOST.host_check_command("pflash")
         self.cv_HOST.host_copy_fake_gard()
         self.c.run_command("dmesg -D")

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -59,9 +59,9 @@ class OpalMsglog():
 class Skiroot(OpalMsglog, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(OpalMsglog, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/OpalSysfsTests.py
+++ b/testcases/OpalSysfsTests.py
@@ -146,10 +146,10 @@ class Skiroot(OpalSysfsTests, unittest.TestCase):
     def setup_test(self):
         self.test = 'skiroot'
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(OpalSysfsTests, unittest.TestCase):
     def setup_test(self):
         self.test = 'host'
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/OpalUtils.py
+++ b/testcases/OpalUtils.py
@@ -186,7 +186,7 @@ class OpalUtils(unittest.TestCase):
     def runTest(self):
         self.l_dic = []
         self.utils_init()
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
         self.c.run_command("dmesg -D")
         self.cpu = self.cv_HOST.host_get_proc_gen()

--- a/testcases/PciSlotLocCodes.py
+++ b/testcases/PciSlotLocCodes.py
@@ -223,19 +223,19 @@ class PciSlotLocCodesDeviceTree():
 class Skiroot(PciSlotLocCodesOPAL, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(PciSlotLocCodesOPAL, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
 
 class SkirootDT(PciSlotLocCodesDeviceTree, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class HostDT(PciSlotLocCodesDeviceTree, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.host().get_ssh_connection()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/PetitbootDropbearServer.py
+++ b/testcases/PetitbootDropbearServer.py
@@ -50,7 +50,7 @@ class PetitbootDropbearServer(unittest.TestCase):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         print "Test Dropbear server not running in Petitboot"
 
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         c.run_command("uname -a")
         # we don't grep for 'dropbear' so that our naive line.count
         # below doesn't hit a false positive.

--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -29,7 +29,7 @@ from common.OpTestSystem import OpSystemState
 class RunHostTest(unittest.TestCase):
     def setUp(self):
         self.conf = OpTestConfiguration.conf
-        self.system = self.conf.system()
+        self.cv_SYSTEM = self.conf.system()
         self.host_cmd = self.conf.args.host_cmd
         self.host_cmd_file = self.conf.args.host_cmd_file
         self.host_cmd_timeout = self.conf.args.host_cmd_timeout
@@ -37,8 +37,8 @@ class RunHostTest(unittest.TestCase):
             self.fail("Provide either --host-cmd and --host-cmd-file option")
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.OS)
-        con = self.system.sys_get_ipmi_console()
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         if self.host_cmd:
             con.run_command(self.host_cmd, timeout=self.host_cmd_timeout)
         if self.host_cmd_file:
@@ -48,8 +48,8 @@ class RunHostTest(unittest.TestCase):
             for line in fd.readlines():
                 line = line.strip()
                 if "reboot" in line:
-                    self.system.goto_state(OpSystemState.OFF)
-                    self.system.goto_state(OpSystemState.OS)
-                    con = self.system.sys_get_ipmi_console()
+                    self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+                    self.cv_SYSTEM.goto_state(OpSystemState.OS)
+                    con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
                     continue
                 con.run_command(line, timeout=self.host_cmd_timeout)

--- a/testcases/SbePassThrough.py
+++ b/testcases/SbePassThrough.py
@@ -80,7 +80,7 @@ class SbePassThrough(unittest.TestCase):
 
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
         # Clear any pre-existing SEL or eSEL's
         self.cv_SYSTEM.sys_sdr_clear()
         self.c.run_command("dmesg -D")

--- a/testcases/SecureBoot.py
+++ b/testcases/SecureBoot.py
@@ -47,7 +47,7 @@ class SecureBoot(unittest.TestCase):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
     def verify_boot_fail(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         self.cv_SYSTEM.sys_power_on()
         count = 4
         boot = False
@@ -62,22 +62,22 @@ class SecureBoot(unittest.TestCase):
         return True
 
     def wait_for_secureboot_enforce(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         self.cv_SYSTEM.sys_power_on()
         console.expect("STB: secure mode enforced, aborting.", timeout=300)
         console.expect("secondary_wait", timeout=20)
         console.expect("host_voltage_config", timeout=100)
 
     def wait_for_sb_kt_start(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         console.expect("sbe|Performing Secure Boot key transition", timeout=300)
 
     def wait_for_shutdown(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         console.expect("shutdown complete", timeout=100)
 
     def verify_opal_sb(self):
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
 
         self.cpu = ''.join(c.run_command("grep '^cpu' /proc/cpuinfo |uniq|sed -e 's/^.*: //;s/[,]* .*//;'"))
         print self.cpu
@@ -98,7 +98,7 @@ class SecureBoot(unittest.TestCase):
                 self.assertTrue(False, "OPAL-SB: %s verification failed or not happened" % part)
 
     def verify_dt_sb(self):
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
 
         # Check for STB support - /ibm,secureboot DT node should exist
         try:
@@ -227,7 +227,7 @@ class KeyTransitionPNOR(SecureBoot, PNORFLASH):
     def runTest(self):
         if not self.kt_pnor:
             self.skipTest("No key transition PNOR image is provided")
-        console = self.cv_SYSTEM.sys_get_ipmi_console()
+        console = self.cv_SYSTEM.console
         PNORFLASH.pnor = self.kt_pnor
         super(KeyTransitionPNOR, self).runTest()
         self.cv_SYSTEM.sys_power_on()

--- a/testcases/SystemLogin.py
+++ b/testcases/SystemLogin.py
@@ -37,11 +37,11 @@ class OOBHostLogin(unittest.TestCase):
     '''
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
+        self.cv_SYSTEM = conf.system()
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.OS)
-        l_con = self.system.sys_get_ipmi_console()
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        l_con = self.cv_SYSTEM.console
         r = l_con.run_command("echo 'Hello World'")
         self.assertIn("Hello World", r)
         try:
@@ -63,18 +63,18 @@ class BMCLogin(unittest.TestCase):
     '''
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
-        self.bmc = conf.bmc()
+        self.cv_SYSTEM = conf.system()
+        self.cv_BMC = conf.bmc()
 
     def runTest(self):
-        r = self.bmc.run_command("echo 'Hello World'")
+        r = self.cv_BMC.run_command("echo 'Hello World'")
         self.assertIn("Hello World", r)
         try:
-            r = self.bmc.run_command("false")
+            r = self.cv_BMC.run_command("false")
         except CommandFailed as r:
             self.assertEqual(r.exitcode, 1)
         for i in range(2):
-            self.bmc.run_command("dmesg")
+            self.cv_BMC.run_command("dmesg")
 
 class SSHHostLogin(unittest.TestCase):
     '''
@@ -82,41 +82,41 @@ class SSHHostLogin(unittest.TestCase):
     '''
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
-        self.host = conf.host()
+        self.cv_SYSTEM = conf.system()
+        self.cv_HOST = conf.host()
 
     def runTest(self):
-        self.system.goto_state(OpSystemState.OS)
-        r = self.host.host_run_command("echo 'Hello World'")
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        r = self.cv_HOST.host_run_command("echo 'Hello World'")
         self.assertIn("Hello World", r)
         try:
-            r = self.host.host_run_command("false")
+            r = self.cv_HOST.host_run_command("false")
         except CommandFailed as r:
             self.assertEqual(r.exitcode, 1)
         for i in range(2):
-            self.host.host_run_command("dmesg")
-        self.host.host_run_command("whoami")
-        self.host.host_run_command("sudo -s")
-        self.host.host_run_command("lscpu")
+            self.cv_HOST.host_run_command("dmesg")
+        self.cv_HOST.host_run_command("whoami")
+        self.cv_HOST.host_run_command("sudo -s")
+        self.cv_HOST.host_run_command("lscpu")
         try:
-            r = self.host.host_run_command("echo \'hai\';sleep 20", timeout=10)
+            r = self.cv_HOST.host_run_command("echo \'hai\';sleep 20", timeout=10)
         except CommandFailed as r:
             print str(r)
-        self.host.host_run_command("whoami")
-        self.host.host_run_command("lscpu")
+        self.cv_HOST.host_run_command("whoami")
+        self.cv_HOST.host_run_command("lscpu")
 
 class ExampleRestAPI(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
+        self.cv_SYSTEM = conf.system()
         self.bmc_type = conf.args.bmc_type
 
     def runTest(self):
         if "OpenBMC" not in self.bmc_type:
             self.skipTest("OpenBMC specific Rest API Tests")
-        self.system.sys_inventory()
-        self.system.sys_sensors()
-        self.system.sys_bmc_state()
+        self.cv_SYSTEM.sys_inventory()
+        self.cv_SYSTEM.sys_sensors()
+        self.cv_SYSTEM.sys_bmc_state()
 
 def system_access_suite():
     s = unittest.TestSuite()

--- a/testcases/TrustedBoot.py
+++ b/testcases/TrustedBoot.py
@@ -54,13 +54,13 @@ class TrustedBoot(unittest.TestCase):
         self.securemode = conf.args.secure_mode
 
     def wait_for_system_shutdown(self):
-        console = self.cv_SYSTEM.sys_get_ipmi_console().get_console()
+        console = self.cv_SYSTEM.console.get_console()
         console.expect("System shutting down with error status", timeout=100)
         console.expect("RC_TPM_NOFUNCTIONALTPM_FAIL", timeout=50)
         console.expect("================================================", timeout=20)
 
     def verify_opal_tb(self):
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         self.cpu = ''.join(c.run_command("grep '^cpu' /proc/cpuinfo |uniq|sed -e 's/^.*: //;s/[,]* .*//;'"))
         print self.cpu
         if self.cpu in ["POWER9"]:
@@ -92,7 +92,7 @@ class TrustedBoot(unittest.TestCase):
             self.assertTrue(False, "OPAL: EV_SEPARATOR measured on TPM PCR registers")
 
     def verify_dt_tb(self):
-        c = self.cv_SYSTEM.sys_get_ipmi_console()
+        c = self.cv_SYSTEM.console
         c.run_command("lsprop /proc/device-tree/ibm,secureboot")
 
         if not self.trustedmode:

--- a/testcases/fspresetReload.py
+++ b/testcases/fspresetReload.py
@@ -138,7 +138,7 @@ class fspresetReload(unittest.TestCase):
 
     # check for sol console, whether we are able to use or not
     def check_for_sol_console(self):
-        l_con = self.cv_SYSTEM.sys_get_ipmi_console()
+        l_con = self.cv_SYSTEM.console
         r = l_con.run_command("echo 'Hello World'")
         self.assertIn("Hello World", r)
         try:

--- a/testcases/gcov.py
+++ b/testcases/gcov.py
@@ -41,7 +41,7 @@ class gcov():
         self.setup_test()
         exports = self.c.run_command("ls -1 --color=never /sys/firmware/opal/exports/")
         if 'gcov' not in exports:
-            self.skip("Not a GCOV build")
+            self.skipTest("Not a GCOV build")
 
         l = self.c.run_command("wc -c /sys/firmware/opal/exports/gcov")
         iutil = OpTestInstallUtil.InstallUtil()
@@ -73,9 +73,9 @@ class gcov():
 class Skiroot(gcov, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.console
 
 class Host(gcov, unittest.TestCase):
     def setup_test(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        self.c = self.cv_SYSTEM.sys_get_ipmi_console()
+        self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()

--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -35,8 +35,8 @@ from common.Exceptions import CommandFailed
 class RestAPI(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
-        self.system = conf.system()
-        self.bmc = conf.bmc()
+        self.cv_SYSTEM = conf.system()
+        self.cv_BMC = conf.bmc()
         self.bmc_password = conf.args.bmc_password
         self.rest = conf.system().rest
         self.bmc_type = conf.args.bmc_type
@@ -68,11 +68,11 @@ class RestAPI(unittest.TestCase):
         ids = self.rest.get_occ_ids()
         for id in ids:
             # If system is in runtime OCC should be Active
-            if self.system.get_state() in [OpSystemState.PETITBOOT, OpSystemState.PETITBOOT_SHELL,
+            if self.cv_SYSTEM.get_state() in [OpSystemState.PETITBOOT, OpSystemState.PETITBOOT_SHELL,
                                            OpSystemState.BOOTING, OpSystemState.OS]:
                 self.assertTrue(self.rest.is_occ_active(id), "OCC%s is not in active state" % id)
             # if system is in standby state OCC should be inactive
-            elif self.system.get_state() == OpSystemState.OFF:
+            elif self.cv_SYSTEM.get_state() == OpSystemState.OFF:
                 self.assertFalse(self.rest.is_occ_active(id), "OCC%s is still in active state" % id)
 
     def test_software_enumerate(self):
@@ -91,7 +91,7 @@ class RestAPI(unittest.TestCase):
         self.rest.set_field_mode("1")
         self.assertTrue(self.rest.has_field_mode_set(), "Field mode enable failed")
         self.rest.set_field_mode("0")
-        self.bmc.clear_field_mode()
+        self.cv_BMC.clear_field_mode()
         self.assertFalse(self.rest.has_field_mode_set(), "Field mode disable failed")
 
     def test_upload_image(self):


### PR DESCRIPTION
Use ssh connections for OS tests where applicable.

Consistency for console and ssh usage,
i.e. use common syntax across testcases.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>