### PR TITLE
OpTestLogging: Add python logger infrastructure

### DIFF
--- a/OpTestLogger.py
+++ b/OpTestLogger.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+# This implements all the python logger setup for op-test
+
+import os
+import sys
+from datetime import datetime
+import logging
+from logging.handlers import RotatingFileHandler
+
+
+class FileLikeLogger():
+    def __init__(self, l):
+        self.log = l
+
+    def write(self, data):
+        self.log.debug(data)
+
+    def flush(self):
+        pass
+
+class OpTestLogger():
+    '''
+    This class is used as the main global logger and handler initialization module.
+
+    See testcases/HelloWorld.py as an example for the usage within an op-test module.
+    '''
+    def __init__(self):
+        '''
+        Provide defaults and setup the minimal StreamHandlers
+        '''
+        self.parent_logger = 'op-test'
+        self.maxBytes_logger_file = 2000000
+        self.maxBytes_logger_debug_file = 2000000
+        self.backupCount_logger_files = 10
+        self.backupCount_debug_files = 10
+        self.logdir = os.getcwd()
+        self.logger_file = 'main.log'
+        self.logger_debug_file = 'debug.log'
+        self.optest_logger = logging.getLogger(self.parent_logger)
+        # clear the logger of any handlers in this shell
+        self.optest_logger.handlers = []
+        # need to set the logger to deepest level, handlers will filter
+        self.optest_logger.setLevel(logging.DEBUG)
+
+        # we need to init stream handler as special case to keep all happy
+        self.sh = logging.StreamHandler()
+        # save the sh level for later refreshes
+        self.sh_level = logging.ERROR
+        self.sh.setLevel(self.sh_level)
+        self.sh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(funcName)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.sh)
+        self.fh = None
+        self.dh = None
+
+    def get_logger(self, myname):
+        '''
+         Provide a method that allows individual module helper capabilities
+        '''
+        return logging.getLogger(self.parent_logger+'.{}'.format(myname))
+
+    def setUpLoggerFile(self, logger_file):
+        '''
+        Provide a method that allows setting up of a file handler with customized file rotation and formatting.
+
+        :param logger_file: File name to use for logging the main log records.
+        '''
+        # need to log that location of logging may be changed
+        self.optest_logger.info('Preparing to set location of Log File to {}'.format(os.path.join(self.logdir, logger_file)))
+        self.logger_file = logger_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.fh = RotatingFileHandler(os.path.join(self.logdir, self.logger_file), maxBytes=self.maxBytes_logger_file, backupCount=self.backupCount_logger_files)
+        self.fh.setLevel(logging.INFO)
+        self.fh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.fh)
+        self.optest_logger.debug('FileHandler settings updated')
+        self.optest_logger.info('Log file: {}'.format(os.path.join(self.logdir, self.logger_file)))
+
+    def setUpLoggerDebugFile(self, logger_debug_file):
+        '''
+        Provide a method that allows setting up of a debug file handler with customized file rotation and formatting.
+
+        :param logger_debug_file: File name to use for logging the debug log records.
+        '''
+        self.optest_logger.info('Preparing to set location of Debug Log File to {}'.format(os.path.join(self.logdir, logger_debug_file)))
+        self.logger_debug_file = logger_debug_file
+        if (not os.path.exists(self.logdir)):
+          os.makedirs(self.logdir)
+        self.dh = RotatingFileHandler(os.path.join(self.logdir, self.logger_debug_file), maxBytes=self.maxBytes_logger_debug_file, backupCount=self.backupCount_debug_files)
+        self.dh.setLevel(logging.DEBUG)
+        self.dh.setFormatter(logging.Formatter('%(asctime)s:%(name)s:%(funcName)s:%(levelname)s:%(message)s'))
+        self.optest_logger.addHandler(self.dh)
+        self.optest_logger.debug('DebugHandler settings updated')
+        self.optest_logger.info('Debug Log file: {}'.format(os.path.join(self.logdir, self.logger_debug_file)))
+
+global optest_logger_glob
+optest_logger_glob = OpTestLogger()

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -23,6 +23,10 @@ import os
 import time
 import pexpect
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 from Exceptions import CommandFailed, SSHSessionDisconnected
 from OpTestUtil import OpTestUtil
 import OpTestSystem
@@ -140,7 +144,7 @@ class OpTestSSH():
         elif self.known_hosts_file:
             cmd = (cmd + " -o UserKnownHostsFile=" + self.known_hosts_file)
 
-        print cmd
+        log.debug(cmd)
 
         try:
           consoleChild = OPexpect.spawn(cmd,
@@ -158,7 +162,7 @@ class OpTestSSH():
           self.console.delaybeforesend = self.delaybeforesend
         # Users expecting "Host IPMI" will reference console.sol so make it available
         self.sol = self.console
-        consoleChild.logfile_read = self.logfile
+        consoleChild.logfile_read = OpTestLogger.FileLikeLogger(log)
         time.sleep(2) # delay here in case messages like afstokenpassing unsupported show up which mess up setup_term
         self.check_set_term()
         return consoleChild
@@ -181,7 +185,7 @@ class OpTestSSH():
 
         count = 0
         while (not self.console.isalive()):
-            print '# Reconnecting'
+            log.info('# Reconnecting')
             if (count > 0):
                 time.sleep(1)
             self.connect()

--- a/op-test
+++ b/op-test
@@ -29,6 +29,7 @@ op-test: run OpenPOWER test suite(s)
 import sys
 import os
 import unittest
+import re
 
 try:
   import faulthandler
@@ -37,11 +38,15 @@ try:
 except ImportError:
   pass
 
-
+import logging
+import OpTestLogger
+# op-test is the parent logger
+optestlog = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger)
 import OpTestConfiguration
 OpTestConfiguration.conf = OpTestConfiguration.OpTestConfiguration()
 
 from testcases import HelloWorld
+from testcases import OpTestExample
 from testcases import OpTestSwitchEndianSyscall
 from testcases import OpTestSensors
 from testcases import OpTestPrdDriver
@@ -103,8 +108,6 @@ import testcases
 
 args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
 OpTestConfiguration.conf.objs()
-
-print args
 
 class SystemAccessSuite():
     '''
@@ -403,6 +406,8 @@ class FspOpalSuite():
 class KnownBugs():
     def __init__(self):
         self.s = unittest.TestSuite()
+        self.s.addTest(Console.Console32k())
+        self.s.addTest(Console.ControlC())
     def suite(self):
         return self.s
 
@@ -424,23 +429,32 @@ class InstallHost():
         if conf.args.host_scratch_disk and target:
             if "ubuntu" in target.lower():
                 self.s.addTest(InstallUbuntu.InstallUbuntu())
-                print 'InstallUbuntu added to default suite'
+                optestlog.info('InstallUbuntu added to default suite')
             elif "rhel" in target.lower():
                 self.s.addTest(InstallRhel.InstallRhel())
-                print 'InstallRhel added to default suite'
+                optestlog.info('InstallRhel added to default suite')
             elif "hostos" in target.lower():
                 self.s.addTest(InstallHostOS.InstallHostOS())
-                print 'InstallHostOS added to default suite'
+                optestlog.info('InstallHostOS added to default suite')
             else:
-                print("Could not parse OS name from '{}'".format(target))
+                optestlog.info("Could not parse OS name from '{}'".format(target))
                 exit(-1)
         else:
-            print("Missing parameters for InstallHost suite")
+            optestlog.info("Missing parameters for InstallHost suite")
             exit(-1)
 
     def suite(self):
         return self.s
 
+class OpTestExampleSuite():
+    '''Tests in OpTestExample'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(OpTestExample.skiroot_full_suite())
+        self.s.addTest(OpTestExample.host_full_suite())
+
+    def suite(self):
+        return self.s
 
 suites = {
     'system-access' : SystemAccessSuite(),
@@ -473,6 +487,7 @@ suites = {
     'system-ipl' : SystemIPLSuite(),
     'fsp-opal-suite' :  FspOpalSuite(),
     'full' : FullSuite(),
+    'example' : OpTestExampleSuite(),
 }
 
 # Loop through the addons and load in suites defined there
@@ -500,38 +515,52 @@ if OpTestConfiguration.conf.args.run:
 
 if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.args.run:
     if not OpTestConfiguration.conf.args.only_flash:
-        print "RUNNING DEFAULT SUITE"
         t.addTest(suites['default'].suite())
 
 xml_msg = ""
 def run_tests(t):
     try:
-        print("Output to be written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
         import xmlrunner  # requires unittest-xml-reporting package
-        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
-        print("Output written to: %s/*%s*" % (OpTestConfiguration.conf.output, OpTestConfiguration.conf.outsuffix))
-        return res
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, stream=main_logfile, verbosity=2).run(t)
+            return res
     except ImportError, err:
-        sys.stderr.write("WARNING: xmlrunner module not available, falling back to using unittest...\n\n")
-        res = unittest.TextTestRunner(verbosity=2).run(t)
-        return res
+        with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'a') as main_logfile:
+            res = unittest.TextTestRunner(main_logfile, verbosity=2).run(t)
+            return res
 
+# OP-TEST marker used to clip summary of results from main.log
+optestlog.info('OP-TEST')
 res = None
+
 if not OpTestConfiguration.conf.args.noflash:
     res = run_tests(FlashFirmware().suite())
 
-print repr(res)
-
 if OpTestConfiguration.conf.args.only_flash:
     if res != None:
+        optestlog.error('Exit with Result errors="{}" and failures="{}" from only_flash'.format(len(res.errors), len(res.failures)))
+        optestlog.info('OP-TEST')
         exit(len(res.errors + res.failures))
     else:
+        optestlog.info('OP-TEST')
         exit(0)
 
 if not res or (res and not (res.errors or res.failures)):
     res = run_tests(t)
 else:
-    print "Skipping main tests as flashing failed"
+    optestlog.error('Skipping main tests as flashing failed')
+    optestlog.info('OP-TEST')
     exit(-1)
+
+optestlog.info('Exit with Result errors="{}" and failures="{}"'.format(len(res.errors), len(res.failures)))
+optestlog.info('See Main Log File for Results')
+optestlog.info('OP-TEST')
+
+with open(os.path.join(OpTestLogger.optest_logger_glob.logdir, OpTestLogger.optest_logger_glob.logger_file), 'r') as f:
+  summary_output = f.read()
+
+summary_text = re.search(r'OP-TEST.*?OP-TEST', summary_output, re.DOTALL)
+if summary_text:
+  print '{}'.format(re.sub('OP-TEST', '', summary_text.group()))
 
 exit(len(res.errors + res.failures))

--- a/testcases/OpTestExample.py
+++ b/testcases/OpTestExample.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2017
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import unittest
+import logging
+
+import OpTestConfiguration
+import OpTestLogger
+from common.OpTestSystem import OpSystemState
+from common.Exceptions import CommandFailed
+try:
+    import pxssh
+except ImportError:
+    from pexpect import pxssh
+
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+class OpTestExample(unittest.TestCase):
+    '''
+    This class is a demo to illustrate framework.
+    '''
+    @classmethod
+    def setUpClass(cls):
+      conf = OpTestConfiguration.conf
+      cls.cv_IPMI = conf.ipmi()
+      cls.cv_SYSTEM = conf.system()
+      cls.my_connect = None
+      cls.my_prompt = None
+
+    def setUp(self, my_connect='ipmi'):
+      self.cv_SYSTEM.goto_state(self.my_desired_state)
+      if self.my_connect == 'host':
+        self.my_console = self.cv_SYSTEM.host().get_ssh_connection()
+      else:
+        self.my_console = self.cv_SYSTEM.console
+
+    def OPComboTest(self):
+      '''Execute commands on target OS
+         Key Sort in OPDemoFunc for order of execution
+      '''
+      xcommand_table = {
+        'lsprop'         : 'lsprop /sys/firmware/devicetree/base/ibm,firmware-versions',
+        'os-release'     : 'cat /etc/os-release',
+        'uname'          : 'uname -a',
+      }
+
+      self.OPDemoFunc(xcommand_table)
+
+    def HostVersions(self):
+      '''Execute commands on target OS
+         Key Sort in OPDemoFunc for order of execution
+      '''
+      xcommand_table = {
+        'linux'          : 'lsprop /sys/firmware/devicetree/base/ibm,firmware-versions/linux',
+        'os-release'     : 'cat /etc/os-release',
+        'proc-cmdline'   : 'cat /proc/cmdline',
+        'version'        : 'cat /proc/version',
+      }
+
+      self.OPDemoFunc(xcommand_table)
+
+    def PetitbootVersions(self):
+      '''Execute commands on target OS
+         Key Sort in OPDemoFunc for order of execution
+      '''
+      xcommand_table = {
+        'cpu-present'        : 'cat /sys/devices/system/cpu/present',
+        'eeh'                : 'cat /proc/powerpc/eeh',
+        'linux'              : "dmesg -r|grep '<[4321]>'",
+        'loc-code'           : 'find /sys/firmware/devicetree/base -name ibm,loc-code',
+        'msglog'             : "grep ',[0-4]\]' /sys/firmware/opal/msglog",
+        'os-release'         : 'cat /etc/os-release',
+        'petitboot'          : 'lsprop /sys/firmware/devicetree/base/ibm,firmware-versions/petitboot',
+        'phb'                : "cat /sys/firmware/opal/msglog |  grep 'PHB#' | grep -i  ' C:'",
+        'proc-cmdline'       : 'cat /proc/cmdline',
+        'slot-label'         : 'find /sys/firmware/devicetree/base -name ibm,slot-label',
+      }
+
+      self.OPDemoFunc(xcommand_table)
+
+    def OPMisc(self):
+      '''Execute commands on target OS
+         Key Sort in OPDemoFunc for order of execution
+      '''
+      xcommand_table = {
+        'nvram-print'    : 'nvram --print-config',
+        'nvram-v'        : 'nvram -v',
+      }
+
+      self.OPDemoFunc(xcommand_table)
+
+    def OPDemoFunc(self, op_dictionary):
+      '''Process a command table
+      '''
+
+      xresults = {}
+
+      try:
+        for xkey, xcommand in sorted(op_dictionary.items()):
+          xresults[xkey] = list(filter(None, self.my_console.run_command(xcommand)))
+
+        for xkey, xvalue in sorted(xresults.items()):
+          log.debug('\nCommand Run: "{}"\n{}'.format(op_dictionary[xkey], '\n'.join(xresults[xkey])), extra=xresults)
+
+      except pxssh.ExceptionPxssh as op_pxssh:
+        self.fail(str(op_pxssh))
+      except CommandFailed as xe:
+        my_x = {x:xe.output[x] for x in range(len(xe.output))}
+        log.debug('\n******************************\nCommand Failed: \n{}\n******************************'.format('\n'.join(my_x[y] for y,z in my_x.items())), extra=my_x)
+        log.debug('\nExitcode {}'.format(xe))
+      except Exception as func_e:
+        self.fail('OPDemoFunc Exception handler {}'.format(func_e))
+
+class SkirootBasicCheck(OpTestExample, unittest.TestCase):
+    '''Class for Skiroot based tests
+       This class allows --run testcases.OpTestExample.SkirootBasicCheck
+    '''
+    def setUp(self):
+      self.my_desired_state = OpSystemState.PETITBOOT_SHELL
+      super(SkirootBasicCheck, self).setUp()
+
+    def runTest(self):
+      self.PetitbootVersions()
+      self.OPMisc()
+      self.OPComboTest()
+
+class HostBasicCheck(OpTestExample, unittest.TestCase):
+    '''Class for Host based tests
+       This class allows --run testcases.OpTestExample.HostBasicCheck
+    '''
+    def setUp(self):
+      self.my_connect = 'host'
+      self.my_desired_state = OpSystemState.OS
+      super(HostBasicCheck, self).setUp()
+
+    def runTest(self):
+      self.HostVersions()
+      self.OPComboTest()
+
+def skiroot_suite():
+    '''Function used to prepare a test suite (see op-test)
+       This allows --run-suite example
+       Tests run in order
+    '''
+    tests = ['PetitbootVersions']
+    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+
+def skiroot_full_suite():
+    '''Function used to prepare a test suite (see op-test)
+       This allows --run-suite example
+       Tests run in order
+    '''
+    tests = ['PetitbootVersions', 'OPMisc', 'OPComboTest']
+    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+
+def host_suite():
+    '''Function used to prepare a test suite (see op-test)
+       This allows --run-suite example
+       Tests run in order
+    '''
+    tests = ['HostVersions']
+    return unittest.TestSuite(map(HostBasicCheck, tests))
+
+def host_full_suite():
+    '''Function used to prepare a test suite (see op-test)
+       This allows --run-suite example
+       Tests run in order
+    '''
+    tests = ['HostVersions', 'PetitbootVersions', 'OPComboTest']
+    return unittest.TestSuite(map(HostBasicCheck, tests))

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -51,6 +51,10 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 class OpTestFlashBase(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
@@ -72,7 +76,7 @@ class OpTestFlashBase(unittest.TestCase):
         l_bmc_side, l_pnor_side = self.cv_IPMI.ipmi_get_side_activated()
         self.assertIn(BMC_CONST.PRIMARY_SIDE, l_bmc_side, "BMC: Primary side is not active")
         if (l_pnor_side == BMC_CONST.GOLDEN_SIDE):
-            print "PNOR: Primary side is not active"
+            log.info("PNOR: Primary side is not active")
             bios_sensor = self.cv_IPMI.ipmi_get_golden_side_sensor_id()
             self.assertNotEqual(bios_sensor, None, "Failed to get the BIOS Golden side sensor id")
             boot_count_sensor = self.cv_IPMI.ipmi_get_boot_count_sensor_id()
@@ -83,7 +87,7 @@ class OpTestFlashBase(unittest.TestCase):
 
     def get_pnor_level(self):
         rc = self.cv_IPMI.ipmi_get_PNOR_level()
-        print rc
+        log.info(rc)
 
     def bmc_down_check(self):
         self.assertTrue(self.util.ping_fail_check(self.cv_BMC.host_name), "FSP/BMC keeps on pinging up")
@@ -103,7 +107,7 @@ class OpTestFlashBase(unittest.TestCase):
                 version = content[0].split("=")[-1]
                 break
         tar.close()
-        print version
+        log.info(version)
         return version
 
     def get_image_version(self, path):
@@ -134,7 +138,7 @@ class OpTestFlashBase(unittest.TestCase):
     def get_image_id(self, version):
         img_path = self.get_image_path(version)
         img_id = img_path.split("/")[-2]
-        print "Image id for Host image is : %s" % img_id
+        log.info("Image id for Host image is : %s" % img_id)
         return img_id
 
     def wait_for_bmc_runtime(self):
@@ -183,7 +187,7 @@ class BmcImageFlash(OpTestFlashBase):
         elif "OpenBMC" in self.bmc_type:
             if self.cv_BMC.has_new_pnor_code_update():
                 # Assume all new systems has new BMC code update via REST
-                print "BMC has code for the new PNOR Code update via REST"
+                log.info("BMC has code for the new PNOR Code update via REST")
                 try:
                     # because openbmc
                     l_res = self.cv_BMC.run_command("rm -f /usr/local/share/pnor/* /media/pnor-prsv/GUARD")
@@ -199,9 +203,9 @@ class BmcImageFlash(OpTestFlashBase):
                 img_ids = self.cv_REST.bmc_image_ids()
 
                 if self.cv_REST.is_image_already_active(id):
-                    print "# The given BMC image %s is already active on the system" % id
+                    log.warning("# The given BMC image %s is already active on the system" % id)
                     if self.cv_REST.validate_functional_bootside(id):
-                        print "# And the given BMC image is already functional"
+                        log.warning("# And the given BMC image is already functional")
                         return True
                     # If non functional set the priority and reboot the BMC
                     self.cv_REST.set_image_priority(id, "0")
@@ -217,13 +221,13 @@ class BmcImageFlash(OpTestFlashBase):
                     for img_id in img_ids:
                         d = self.cv_REST.image_data(img_id)
                         if d['data']['Activation'] == "xyz.openbmc_project.Software.Activation.Activations.Ready":
-                            print "BMC image %s is ready to activate" % img_id
+                            log.debug("BMC image %s is ready to activate" % img_id)
                             break
                     else:
                         continue
                     break
                 self.assertTrue(retries > 0, "Uploaded image but it never is ready to activate it")
-                print "Going to activate image id: %s" % img_id
+                log.debug("Going to activate image id: %s" % img_id)
                 self.assertIsNotNone(img_id, "Could not find Image ID")
                 self.cv_REST.activate_image(img_id)
                 self.assertTrue(self.cv_REST.wait_for_image_active_complete(img_id), "Failed to activate image")
@@ -234,7 +238,7 @@ class BmcImageFlash(OpTestFlashBase):
                 # As BMC maintains two levels of code, so there may be possibilities/bugs which causes
                 # the boot from alternate side or other code.
                 self.assertTrue(self.cv_REST.validate_functional_bootside(img_id), "BMC failed to boot from the right code")
-                print "# BMC booting from the right code with image ID: %s" % img_id
+                log.info("# BMC booting from the right code with image ID: %s" % img_id)
         c = 0
         while True:
             time.sleep(5)
@@ -321,7 +325,7 @@ class PNORFLASH(OpTestFlashBase):
                 self.cv_BMC.pnor_img_flash_smc("/tmp/rsync_file", os.path.basename(self.pnor))
         elif "OpenBMC" in self.bmc_type:
             if self.cv_BMC.has_new_pnor_code_update():
-                print "BMC has code for the new PNOR Code update via REST"
+                log.info("BMC has code for the new PNOR Code update via REST")
                 try:
                     # because openbmc
                     l_res = self.cv_BMC.run_command("rm -f /usr/local/share/pnor/* /media/pnor-prsv/GUARD")
@@ -349,15 +353,15 @@ class PNORFLASH(OpTestFlashBase):
                     d = self.cv_REST.image_data(img_id)
                     if d['data']['Activation'] == "xyz.openbmc_project.Software.Activation.Activations.Ready":
                         break
-                print "Going to activate image id: %s" % img_id
+                log.info("Going to activate image id: %s" % img_id)
                 self.assertIsNotNone(img_id, "Could not find Image ID")
                 self.cv_REST.activate_image(img_id)
                 self.assertTrue(self.cv_REST.wait_for_image_active_complete(img_id), "Failed to activate image")
                 # We need to have below check after power on of the host.
                 #self.assertTrue(self.cv_REST.validate_functional_bootside(img_id), "PNOR failed to boot from the right code")
-                print "# PNOR boots from the right code with image ID: %s" % img_id
+                log.debug("# PNOR boots from the right code with image ID: %s" % img_id)
             else:
-                print "Fallback to old code update method using pflash tool"
+                log.debug("Fallback to old code update method using pflash tool")
                 self.cv_BMC.image_transfer(self.pnor)
                 self.cv_BMC.pnor_img_flash_openbmc(os.path.basename(self.pnor))
 
@@ -438,22 +442,22 @@ class OpalLidsFLASH(OpTestFlashBase):
             self.cv_BMC.fsp_run_command(cmd)
             if self.skiboot:
                 self.cv_BMC.fsp_run_command("cp -f /opt/extucode/80f00100.lid %s/80f00100_bkp.lid" % self.ext_lid_test_path)
-                print "Backup of skiboot lid is in %s/80f00100_bkp.lid" % self.ext_lid_test_path
+                log.debug("Backup of skiboot lid is in %s/80f00100_bkp.lid" % self.ext_lid_test_path)
                 self.cv_BMC.fsp_run_command("rm -f /opt/extucode/80f00100.lid")
                 self.scp_file(self.skiboot, "/opt/extucode/80f00100.lid")
 
             if not self.skiroot_kernel and not self.skiroot_initramfs:
-                print "No skiroot lids provided, Flashing only skiboot"
+                log.debug("No skiroot lids provided, Flashing only skiboot")
             else:
                 self.cv_BMC.fsp_run_command("cp -f /opt/extucode/80f00101.lid %s/80f00101_bkp.lid" % self.ext_lid_test_path)
-                print "Backup of skiroot kernel lid is in %s/80f00101_bkp.lid" % self.ext_lid_test_path
+                log.debug("Backup of skiroot kernel lid is in %s/80f00101_bkp.lid" % self.ext_lid_test_path)
                 self.cv_BMC.fsp_run_command("cp -f /opt/extucode/80f00102.lid %s/80f00102_bkp.lid" % self.ext_lid_test_path)
-                print "Backup of skiroot initrd lid is in %s/80f00102_bkp.lid" % self.ext_lid_test_path
+                log.debug("Backup of skiroot initrd lid is in %s/80f00102_bkp.lid" % self.ext_lid_test_path)
                 self.cv_BMC.fsp_run_command("rm -f /opt/extucode/80f00101.lid")
                 self.cv_BMC.fsp_run_command("rm -f /opt/extucode/80f00102.lid")
                 self.scp_file(self.skiroot_kernel, "/opt/extucode/80f00101.lid")
                 self.scp_file(self.skiroot_initramfs, "/opt/extucode/80f00102.lid")
-            print "Regenerating the hashes by running command cupdmfg -opt"
+            log.info("Regenerating the hashes by running command cupdmfg -opt")
             self.cv_BMC.fsp_run_command("cupdmfg -opt")
 
         if "AMI" in self.bmc_type:
@@ -575,7 +579,7 @@ class FSPFWImageFLASH(OpTestFlashBase):
         # Fetch the FSP side of flash active to verify after the update
         preup_boot = self.cv_BMC.fsp_run_command("cupdcmd -f | grep \"Current Boot Side\"")
         preup_build = self.cv_BMC.fsp_run_command("cupdcmd -f | grep \"Current Side Driver\"")
-        print "System boot side %s, build: %s" % (preup_boot, preup_build)
+        log.info("System boot side %s, build: %s" % (preup_boot, preup_build))
         preup_boot = re.search('.*([T|P])', preup_boot)
         preup_boot = preup_boot.group(1)
 
@@ -584,13 +588,13 @@ class FSPFWImageFLASH(OpTestFlashBase):
 
         # Wait until we have a route (i.e. network is up)
         tries = 12
-        print '#Waiting for network (by waiting for a route)'
+        log.debug('#Waiting for network (by waiting for a route)')
         while tries:
             r = con.run_command("route -n")
             if len(r) > 2:
                 break
             tries = tries - 1
-            print '#No route yet, sleeping 5s and retrying'
+            log.debug('#No route yet, sleeping 5s and retrying')
             time.sleep(5)
 
         con.run_command("wget %s -O /tmp/firm.img" % self.image)
@@ -613,5 +617,5 @@ class FSPFWImageFLASH(OpTestFlashBase):
         postup_boot = re.search('.*([T|P])', postup_boot)
         postup_boot = postup_boot.group(1)
         postup_build = self.cv_BMC.fsp_run_command("cupdcmd -f | grep \"Current Side Driver\"")
-        print "System Boot side: %s, build: %s" % (postup_boot, postup_build)
+        log.info("System Boot side: %s, build: %s" % (postup_boot, postup_build))
         self.assertEqual(preup_boot, postup_boot, "System booted from different bootside")


### PR DESCRIPTION
Provide a common logger (with file like methods) for op-test.

Provide a main log file for summary information.

Provide a debug log file for more verbose information to assist
during testcase development and testcase result analysis to
assess errors and failures and allow testcase instrumentation
to be non-obstructive to the main log file consumer.

Provide a mechanism to capture traces (adding debug loggers).

See OpTestExample.py for sample module instrumentation.

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>
Signed-off-by: Deb McLemore <debmc@linux.ibm.com>