### PR TITLE
OpTestQemu: Fix disk/cdrom attach

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -130,9 +130,17 @@ class QemuConsole():
         if self.initramfs is not None:
             cmd = cmd + " -initrd %s" % (self.initramfs)
         if self.hda is not None:
-            cmd = cmd + " -hda %s" % (self.hda)
+            # Put the disk on the first PHB
+            cmd = (cmd
+                    + " -drive file={},id=disk01,if=none".format(self.hda)
+                    + " -device virtio-blk-pci,drive=disk01,id=virtio01,bus=pcie.0,addr=0"
+                )
         if self.cdrom is not None:
-            cmd = cmd + " -cdrom %s" % (self.cdrom)
+            # Put the CDROM on the second PHB
+            cmd = (cmd
+                    + " -drive file={},id=cdrom01,if=none,media=cdrom".format(self.cdrom)
+                    + " -device virtio-blk-pci,drive=cdrom01,id=virtio02,bus=pcie.1,addr=0"
+                )
         # typical host ip=10.0.2.2 and typical skiroot 10.0.2.15
         # use skiroot as the source, no sshd in skiroot
         cmd = cmd + " -nic user,model=virtio-net-pci"


### PR DESCRIPTION
Recent updates to Cedric's powernv Qemu model (which is what we're
realistically running) change how devices must be attached.
Three PHBs are initialised by default but no default PCI layout is
provided[0]. This leaves us with one free slot on each PHB to use.
This can be expanded by adding bridges but for our current uses we
only need two slots, one for the scratch disk and one for the CDROM.

[0]: https://github.com/legoater/qemu/wiki/PowerNV#branch-powernv-30

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>