### PR TITLE
OpTestQemu improvements - host PNOR & logging

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -33,6 +33,10 @@ from common.Exceptions import CommandFailed
 from common import OPexpect
 from OpTestUtil import OpTestUtil
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 class ConsoleState():
     DISCONNECTED = 0
     CONNECTED = 1
@@ -112,7 +116,7 @@ class QemuConsole():
         except Exception as e:
             self.state = ConsoleState.DISCONNECTED
             pass
-        print "Qemu close -> TERMINATE"
+        log.debug("Qemu close -> TERMINATE")
 
     def connect(self):
         if self.state == ConsoleState.CONNECTED:
@@ -120,7 +124,7 @@ class QemuConsole():
         else:
             self.util.clear_state(self) # clear when coming in DISCONNECTED
 
-        print "#Qemu Console CONNECT"
+        log.debug("#Qemu Console CONNECT")
 
         cmd = ("%s" % (self.qemu_binary)
                + " -machine powernv -m 4G"
@@ -179,7 +183,7 @@ class QemuConsole():
 
         count = 0
         while (not self.sol.isalive()):
-            print '# Reconnecting'
+            log.info('# Reconnecting')
             if (count > 0):
                 time.sleep(20)
             self.connect()

--- a/op-test
+++ b/op-test
@@ -531,7 +531,10 @@ def run_tests(t):
 res = None
 
 if not OpTestConfiguration.conf.args.noflash:
-    res = run_tests(FlashFirmware().suite())
+    if any(s in OpTestConfiguration.conf.args.bmc_type for s in ("QEMU", "qemu")):
+        optestlog.info("Not adding FlashFirmware suite for QEMU machine")
+    else:
+        res = run_tests(FlashFirmware().suite())
 
 if OpTestConfiguration.conf.args.only_flash:
     if res != None:

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -281,7 +281,7 @@ class PNORFLASH(OpTestFlashBase):
     def runTest(self):
         if not self.pnor or not os.path.exists(self.pnor):
             self.skipTest("PNOR image %s not doesn't exist" % self.pnor)
-        if any(s in self.bmc_type for s in ("FSP", "QEMU")):
+        if any(s in self.bmc_type for s in ("FSP", "QEMU", "qemu")):
             self.skipTest("OP AMI/OpenBMC PNOR Flash test")
 
         if "AMI" in self.bmc_type and not self.pflash:
@@ -408,6 +408,8 @@ class OpalLidsFLASH(OpTestFlashBase):
         if not self.skiboot and not self.skiroot_kernel and not self.skiroot_initramfs \
             and not self.flash_part_list:
             self.skipTest("No custom skiboot/kernel to flash")
+        if any(s in self.bmc_type for s in ("QEMU", "qemu")):
+            self.skipTest("Skipping OpalLidsFLASH on QEMU machine")
 
         if self.bmc_type in ["AMI", "SMC"] and not self.pflash:
                 self.fail("pflash tool is needed for flashing OPAL lids")


### PR DESCRIPTION
Support attaching a PNOR image to the QEMU instance, and bring OpTestQemu in to line with the logging changes.