### PR TITLE
flash: configure host n/w before downloading firmware image

### DIFF
--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -124,11 +124,7 @@ class InstallUtil():
         cmd = "echo 'nameserver %s' > /etc/resolv.conf" % self.conf.args.host_dns
         self.cv_SYSTEM.console.run_command(cmd)
 
-    def get_server_ip(self):
-        """
-        Get IP of server where test runs
-        """
-        my_ip = ""
+    def configure_host_ip(self):
         self.wait_for_network()
         # Check if ip is assigned in petitboot
         try:
@@ -136,6 +132,13 @@ class InstallUtil():
         except CommandFailed as cf:
             self.assign_ip_petitboot()
             self.ping_network()
+
+    def get_server_ip(self):
+        """
+        Get IP of server where test runs
+        """
+        my_ip = ""
+        self.configure_host_ip()
         retry = 30
         while retry > 0:
             try:

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -50,6 +50,7 @@ from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
+from common import OpTestInstallUtil
 
 import logging
 import OpTestLogger
@@ -65,6 +66,7 @@ class OpTestFlashBase(unittest.TestCase):
         self.cv_IPMI = conf.ipmi()
         self.platform = conf.platform()
         self.util = OpTestUtil()
+        self.OpIU = OpTestInstallUtil.InstallUtil()
         self.bmc_type = conf.args.bmc_type
         self.bmc_ip = conf.args.bmc_ip
         self.bmc_username = conf.args.bmc_username
@@ -589,16 +591,8 @@ class FSPFWImageFLASH(OpTestFlashBase):
         con = self.cv_SYSTEM.console
 
         # Wait until we have a route (i.e. network is up)
-        tries = 12
         log.debug('#Waiting for network (by waiting for a route)')
-        while tries:
-            r = con.run_command("route -n")
-            if len(r) > 2:
-                break
-            tries = tries - 1
-            log.debug('#No route yet, sleeping 5s and retrying')
-            time.sleep(5)
-
+        self.OpIU.configure_host_ip()
         con.run_command("wget %s -O /tmp/firm.img" % self.image)
         con.run_command("update_flash -d")
         con.sol.sendline("update_flash -f /tmp/firm.img")


### PR DESCRIPTION
Currently for fsp platforms we have pre-assumed the host n/w is
configured in petitboot. To remove this pre-requiste re-use
configure_host_ip function from OpTestInstallUtil to configure
the host n/w during runtime before downloading firmware image.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>