### PR TITLE
OpTestHost: Update test for existence of CAPI card

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -844,10 +844,10 @@ class OpTestHost():
     # @return True or False
     #
     def host_has_capi_fpga_card(self, console=0):
-        l_cmd = "lspci -d \"1014:0477\""
+        l_cmd = "lspci -d \"1014::1200\""
         l_res = self.host_run_command(l_cmd, console=console)
         l_res = " ".join(l_res)
-        if (l_res.__contains__('IBM Device 0477')):
+        if (l_res.__contains__('IBM Device')):
             l_msg = "Host has a CAPI FPGA card"
             log.debug(l_msg)
             return True


### PR DESCRIPTION
Current test for existence of a CAPI fpga card only includes a single
Nallatech card and ignores other CAPI cards in the system. So this
change updates OpTestHost.host_has_capi_fpga_card() to also include
other CAPI compatible cards by performing lspci for PCI devices with
IBM vendor id (0x1014) and device class as 'Processing
Aaccelerator' (0x1200).

Signed-off-by: Vaibhav Jain <vaibhav@linux.ibm.com>