### PR TITLE
Minor UI improvements

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -59,6 +59,8 @@ def get_parser():
                         help="Run a test suite(s)")
     tgroup.add_argument("--run", action='append',
                         help="Run individual tests")
+    tgroup.add_argument("-f", "--failfast", action='store_true',
+                        help="Stop on first failure")
     tgroup.add_argument("--quiet", action='store_true', default=False,
                         help="Don't splat lots of things to the console")
 

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -161,7 +161,8 @@ class QemuConsole():
           solChild = OPexpect.spawn(cmd,logfile=self.logfile)
         except Exception as e:
           self.state = ConsoleState.DISCONNECTED
-          raise CommandFailed('OPexpect.spawn', 'OPexpect.spawn encountered a problem', -1)
+          raise CommandFailed('OPexpect.spawn',
+                  'OPexpect.spawn encountered a problem: ' + str(e), -1)
 
         self.state = ConsoleState.CONNECTED
         solChild.setwinsize(1000,1000)

--- a/op-test
+++ b/op-test
@@ -523,13 +523,21 @@ if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.
 
 xml_msg = ""
 def run_tests(t):
+    runner = unittest.TextTestRunner
+    kwargs = {
+        'verbosity': 2,
+    }
     try:
         import xmlrunner  # requires unittest-xml-reporting package
-        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
-        return res
-    except ImportError, err:
-        res = unittest.TextTestRunner(verbosity=2).run(t)
-        return res
+        runner = xmlrunner.XMLTestRunner
+        kwargs.update({
+                'output': OpTestConfiguration.conf.output,
+                'outsuffix': OpTestConfiguration.conf.outsuffix,
+            })
+    except ImportError:
+        pass
+
+    return runner(**kwargs).run(t)
 
 res = None
 

--- a/op-test
+++ b/op-test
@@ -32,11 +32,11 @@ import unittest
 import re
 
 try:
-  import faulthandler
-  import signal
-  faulthandler.register(signal.SIGUSR1)
+    import faulthandler
+    import signal
+    faulthandler.register(signal.SIGUSR1)
 except ImportError:
-  pass
+    pass
 
 import logging
 import OpTestLogger
@@ -524,12 +524,12 @@ if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.
 xml_msg = ""
 def run_tests(t):
     try:
-      import xmlrunner  # requires unittest-xml-reporting package
-      res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
-      return res
+        import xmlrunner  # requires unittest-xml-reporting package
+        res = xmlrunner.XMLTestRunner(output=OpTestConfiguration.conf.output, outsuffix=OpTestConfiguration.conf.outsuffix, verbosity=2).run(t)
+        return res
     except ImportError, err:
-      res = unittest.TextTestRunner(verbosity=2).run(t)
-      return res
+        res = unittest.TextTestRunner(verbosity=2).run(t)
+        return res
 
 res = None
 

--- a/op-test
+++ b/op-test
@@ -522,10 +522,11 @@ if not OpTestConfiguration.conf.args.run_suite and not OpTestConfiguration.conf.
         t.addTest(suites['default'].suite())
 
 xml_msg = ""
-def run_tests(t):
+def run_tests(t, failfast):
     runner = unittest.TextTestRunner
     kwargs = {
         'verbosity': 2,
+        'failfast': failfast,
     }
     try:
         import xmlrunner  # requires unittest-xml-reporting package
@@ -534,6 +535,14 @@ def run_tests(t):
                 'output': OpTestConfiguration.conf.output,
                 'outsuffix': OpTestConfiguration.conf.outsuffix,
             })
+
+        # xmlrunner pre v1.13 doesn't support failfast
+        try:
+            runner(failfast=True)
+        except TypeError:
+            if failfast:
+                optestlog.info("Ignoring failfast: not supported by runner")
+            del kwargs['failfast']
     except ImportError:
         pass
 
@@ -545,7 +554,8 @@ if not OpTestConfiguration.conf.args.noflash:
     if any(s in OpTestConfiguration.conf.args.bmc_type for s in ("QEMU", "qemu")):
         optestlog.info("Not adding FlashFirmware suite for QEMU machine")
     else:
-        res = run_tests(FlashFirmware().suite())
+        res = run_tests(FlashFirmware().suite(),
+                failfast=OpTestConfiguration.conf.args.failfast)
 
 if OpTestConfiguration.conf.args.only_flash:
     if res != None:
@@ -555,7 +565,7 @@ if OpTestConfiguration.conf.args.only_flash:
         exit(0)
 
 if not res or (res and not (res.errors or res.failures)):
-    res = run_tests(t)
+    res = run_tests(t, failfast=OpTestConfiguration.conf.args.failfast)
 else:
     optestlog.error('Skipping main tests as flashing failed')
     exit(-1)


### PR DESCRIPTION
This series contains a few minor fixes for issues with initial op-test deployment with qemu;
the ability to stop on the first failure (with `--failfast`), and slightly better error reporting when
pexpect can't start the qemu process. 