### PR TITLE
OpTestConfiguration: Allow FSP IPMI commands

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -523,7 +523,7 @@ class OpTestConfiguration():
             bmc.set_system(self.op_system)
         elif self.args.bmc_type in ['FSP']:
             ipmi = OpTestIPMI(self.args.bmc_ip,
-                              self.args.bmc_usernameipmi,
+                              None, # FSP does not use UID
                               self.args.bmc_passwordipmi,
                               host=host,
                               logfile=self.logfile)

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -18,6 +18,7 @@ from common.Exceptions import HostLocker, AES, ParameterCheck
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 import argparse
 import time
+import traceback
 from datetime import datetime
 import subprocess
 import sys
@@ -468,7 +469,8 @@ class OpTestConfiguration():
                       "ping '{}', check your configuration and setup, see "
                       "Exception details: {}".format(self.args.bmc_ip, e))
 
-        host = common.OpTestHost.OpTestHost(self.args.host_ip,
+        try:
+            host = common.OpTestHost.OpTestHost(self.args.host_ip,
                           self.args.host_user,
                           self.args.host_password,
                           self.args.bmc_ip,
@@ -477,20 +479,20 @@ class OpTestConfiguration():
                           proxy=self.args.proxy,
                           check_ssh_keys=self.args.check_ssh_keys,
                           known_hosts_file=self.args.known_hosts_file)
-        if self.args.bmc_type in ['AMI', 'SMC']:
-            web = OpTestWeb(self.args.bmc_ip,
+            if self.args.bmc_type in ['AMI', 'SMC']:
+                web = OpTestWeb(self.args.bmc_ip,
                             self.args.bmc_usernameipmi,
                             self.args.bmc_passwordipmi)
-            bmc = None
-            if self.args.bmc_type in ['AMI']:
-                ipmi = OpTestIPMI(self.args.bmc_ip,
+                bmc = None
+                if self.args.bmc_type in ['AMI']:
+                    ipmi = OpTestIPMI(self.args.bmc_ip,
                                   self.args.bmc_usernameipmi,
                                   self.args.bmc_passwordipmi,
                                   host=host,
                                   logfile=self.logfile,
-                )
+                    )
 
-                bmc = OpTestBMC(ip=self.args.bmc_ip,
+                    bmc = OpTestBMC(ip=self.args.bmc_ip,
                                 username=self.args.bmc_username,
                                 password=self.args.bmc_password,
                                 logfile=self.logfile,
@@ -498,71 +500,71 @@ class OpTestConfiguration():
                                 web=web,
                                 check_ssh_keys=self.args.check_ssh_keys,
                                 known_hosts_file=self.args.known_hosts_file
-                )
-            elif self.args.bmc_type in ['SMC']:
-                ipmi = OpTestSMCIPMI(self.args.bmc_ip,
+                    )
+                elif self.args.bmc_type in ['SMC']:
+                    ipmi = OpTestSMCIPMI(self.args.bmc_ip,
                                   self.args.bmc_usernameipmi,
                                   self.args.bmc_passwordipmi,
                                   logfile=self.logfile,
                                   host=host,
-                )
-                bmc = OpTestSMC(ip=self.args.bmc_ip,
+                    )
+                    bmc = OpTestSMC(ip=self.args.bmc_ip,
                                 username=self.args.bmc_username,
                                 password=self.args.bmc_password,
                                 ipmi=ipmi,
                                 web=web,
                                 check_ssh_keys=self.args.check_ssh_keys,
                                 known_hosts_file=self.args.known_hosts_file
+                    )
+                self.op_system = common.OpTestSystem.OpTestSystem(
+                    state=self.startState,
+                    bmc=bmc,
+                    host=host,
                 )
-            self.op_system = common.OpTestSystem.OpTestSystem(
-                state=self.startState,
-                bmc=bmc,
-                host=host,
-            )
-            ipmi.set_system(self.op_system)
-            bmc.set_system(self.op_system)
-        elif self.args.bmc_type in ['FSP']:
-            ipmi = OpTestIPMI(self.args.bmc_ip,
+                ipmi.set_system(self.op_system)
+                bmc.set_system(self.op_system)
+            elif self.args.bmc_type in ['FSP']:
+                ipmi = OpTestIPMI(self.args.bmc_ip,
                               None, # FSP does not use UID
                               self.args.bmc_passwordipmi,
                               host=host,
                               logfile=self.logfile)
-            bmc = OpTestFSP(self.args.bmc_ip,
+                bmc = OpTestFSP(self.args.bmc_ip,
                             self.args.bmc_username,
                             self.args.bmc_password,
                             ipmi=ipmi,
-            )
-            self.op_system = common.OpTestSystem.OpTestFSPSystem(
-                state=self.startState,
-                bmc=bmc,
-                host=host,
-            )
-            ipmi.set_system(self.op_system)
-        elif self.args.bmc_type in ['OpenBMC']:
-            ipmi = OpTestIPMI(self.args.bmc_ip,
+                )
+                self.op_system = common.OpTestSystem.OpTestFSPSystem(
+                    state=self.startState,
+                    bmc=bmc,
+                    host=host,
+                )
+                ipmi.set_system(self.op_system)
+            elif self.args.bmc_type in ['OpenBMC']:
+                ipmi = OpTestIPMI(self.args.bmc_ip,
                               self.args.bmc_usernameipmi,
                               self.args.bmc_passwordipmi,
                               host=host,
                               logfile=self.logfile)
-            rest_api = HostManagement(self.args.bmc_ip,
+                rest_api = HostManagement(self.args.bmc_ip,
                                 self.args.bmc_username,
                                 self.args.bmc_password)
-            bmc = OpTestOpenBMC(self.args.bmc_ip,
+                bmc = OpTestOpenBMC(self.args.bmc_ip,
                                 self.args.bmc_username,
                                 self.args.bmc_password,
                                 logfile=self.logfile,
                                 ipmi=ipmi, rest_api=rest_api,
                                 check_ssh_keys=self.args.check_ssh_keys,
                                 known_hosts_file=self.args.known_hosts_file)
-            self.op_system = common.OpTestSystem.OpTestOpenBMCSystem(
-                host=host,
-                bmc=bmc,
-                state=self.startState,
-            )
-            bmc.set_system(self.op_system)
-        elif self.args.bmc_type in ['qemu']:
-            print(repr(self.args))
-            bmc = OpTestQemu(self.args.qemu_binary,
+                self.op_system = common.OpTestSystem.OpTestOpenBMCSystem(
+                    host=host,
+                    bmc=bmc,
+                    state=self.startState,
+                )
+                bmc.set_system(self.op_system)
+            elif self.args.bmc_type in ['qemu']:
+                print(repr(self.args))
+                bmc = OpTestQemu(self.args.qemu_binary,
                              self.args.host_pnor,
                              self.args.flash_skiboot,
                              self.args.flash_kernel,
@@ -570,20 +572,26 @@ class OpTestConfiguration():
                              cdrom=self.args.os_cdrom,
                              logfile=self.logfile,
                              hda=self.args.host_scratch_disk)
-            self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host, bmc=bmc,
+                self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host, bmc=bmc,
                     state=self.startState)
-            bmc.set_system(self.op_system)
-        # Check that the bmc_type exists in our loaded addons then create our objects
-        elif self.args.bmc_type in optAddons:
-            (bmc, self.op_system) = optAddons[self.args.bmc_type].createSystem(self, host)
-        else:
-            self.util.cleanup()
-            raise Exception("Unsupported BMC Type '{}', check your upper/lower cases for bmc_type and verify "
-                            "any credentials used from HostLocker or "
-                            "AES Version (see aes_get_creds version_mappings)".format(self.args.bmc_type))
+                bmc.set_system(self.op_system)
+            # Check that the bmc_type exists in our loaded addons then create our objects
+            elif self.args.bmc_type in optAddons:
+                (bmc, self.op_system) = optAddons[self.args.bmc_type].createSystem(self, host)
+            else:
+                self.util.cleanup()
+                raise Exception("Unsupported BMC Type '{}', check your "
+                                "upper/lower cases for bmc_type and verify "
+                                "any credentials used from HostLocker or "
+                                "AES Version (see aes_get_creds "
+                                "version_mappings)".format(self.args.bmc_type))
 
-        host.set_system(self.op_system)
-        return
+            host.set_system(self.op_system)
+            return
+        except Exception as e:
+            traceback.print_exc()
+            self.util.cleanup()
+            raise e
 
     def bmc(self):
         return self.op_system.bmc

--- a/testcases/DeviceTreeValidation.py
+++ b/testcases/DeviceTreeValidation.py
@@ -133,11 +133,11 @@ class DeviceTreeValidation(unittest.TestCase):
             "ibm,opal/power-mgt/ibm,cpu-idle-state-latencies-ns")
         idle_state_residency_ns = self.dt_prop_read_u32_arr(
             "ibm,opal/power-mgt/ibm,cpu-idle-state-residency-ns")
-        if self.cv_HOST.host_get_proc_gen() in ["POWER8", "POWER8E"]:
+        if self.cv_HOST.host_get_proc_gen(console=1) in ["POWER8", "POWER8E"]:
             has_stop_inst = False
             control_prop = "ibm,opal/power-mgt/ibm,cpu-idle-state-pmicr"
             mask_prop = "ibm,opal/power-mgt/ibm,cpu-idle-state-pmicr-mask"
-        elif "POWER9" in self.cv_HOST.host_get_proc_gen():
+        elif "POWER9" in self.cv_HOST.host_get_proc_gen(console=1):
             has_stop_inst = True
             control_prop = "ibm,opal/power-mgt/ibm,cpu-idle-state-psscr"
             mask_prop = "ibm,opal/power-mgt/ibm,cpu-idle-state-psscr-mask"
@@ -213,10 +213,10 @@ class DeviceTreeValidation(unittest.TestCase):
                                                 nr_pstates))
 
         if (nr_pstates <= 1 or nr_pstates > 128):
-            if self.cv_HOST.host_get_proc_gen() in ["POWER8", "POWER8E"]:
+            if self.cv_HOST.host_get_proc_gen(console=1) in ["POWER8", "POWER8E"]:
                 self.assertTrue(False, "pstates range {} is not valid".format(
                     nr_pstates))
-            elif "POWER9" in self.cv_HOST.host_get_proc_gen():
+            elif "POWER9" in self.cv_HOST.host_get_proc_gen(console=1):
                 self.assertTrue(False, "More than 128 pstates found {}"
                                 "in pstate table".format(nr_pstates))
 
@@ -225,13 +225,13 @@ class DeviceTreeValidation(unittest.TestCase):
                          "Expected %s, found %s".format(nr_pstates,
                                                         len(pstate_ids)))
 
-        if self.cv_HOST.host_get_proc_gen() in ["POWER8", "POWER8E"]:
+        if self.cv_HOST.host_get_proc_gen(console=1) in ["POWER8", "POWER8E"]:
             id_list = []
             for id in pstate_ids:
                 id_list.append(self.twos_comp(int(id, 16), 32))
             self.assertTrue(self.strictly_decreasing(id_list),
                             "Non monotonocity observed for pstate ids")
-        elif "POWER9" in self.cv_HOST.host_get_proc_gen():
+        elif "POWER9" in self.cv_HOST.host_get_proc_gen(console=1):
             self.assertTrue(self.strictly_increasing(pstate_ids),
                             "Non monotonocity observed for pstate ids")
 
@@ -262,10 +262,10 @@ class DeviceTreeValidation(unittest.TestCase):
 
 class DeviceTreeValidationSkiroot(DeviceTreeValidation):
     def runTest(self):
-        if self.cv_HOST.host_get_proc_gen() not in ["POWER8", "POWER8E",
+        if self.cv_HOST.host_get_proc_gen(console=1) not in ["POWER8", "POWER8E",
                                                     "POWER9"]:
             self.skipTest("Unknown CPU type {}".format(
-                self.cv_HOST.host_get_proc_gen()))
+                self.cv_HOST.host_get_proc_gen(console=1)))
 
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         system_state = self.cv_SYSTEM.get_state()
@@ -289,10 +289,10 @@ class DeviceTreeValidationSkiroot(DeviceTreeValidation):
 
 class DeviceTreeValidationHost(DeviceTreeValidation):
     def runTest(self):
-        if self.cv_HOST.host_get_proc_gen() not in ["POWER8", "POWER8E",
+        if self.cv_HOST.host_get_proc_gen(console=1) not in ["POWER8", "POWER8E",
                                                     "POWER9"]:
             self.skipTest("Unknown CPU type {}".format(
-                self.cv_HOST.host_get_proc_gen()))
+                self.cv_HOST.host_get_proc_gen(console=1)))
 
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
         self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()


### PR DESCRIPTION
FSP IPMI commands do not need UID, so remove from ipmitool usage.

OpTestConfiguration exception handling improvements to catch for release on reservations.

Use host console object for host methods for DeviceTreeValidation testcases.