### PR TITLE
 RunHostTest: Monitor console on running host commands

### DIFF
--- a/common/OpTestThread.py
+++ b/common/OpTestThread.py
@@ -240,7 +240,7 @@ class OpSolMonitorThread3(threading.Thread):
     on other SSH threads. This thread can be terminated by just calling console_terminate
     from parent process.
     '''
-    def __init__(self, log_file):
+    def __init__(self):
         threading.Thread.__init__(self)
         conf = OpTestConfiguration.conf
         self.system = conf.system()
@@ -258,7 +258,7 @@ class OpSolMonitorThread3(threading.Thread):
                 pass
             except pexpect.EOF:
                 self.c.state = IPMIConsoleState.DISCONNECTED
-                self.c = self.system.console
+                self.c = self.system.get_console()
 
             if self.c_terminate:
                 break

--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -32,6 +32,7 @@ import os
 
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
+from common.OpTestThread import OpSolMonitorThread3
 
 
 class RunHostTest(unittest.TestCase):
@@ -43,6 +44,8 @@ class RunHostTest(unittest.TestCase):
         self.host_cmd_timeout = self.conf.args.host_cmd_timeout
         if not (self.host_cmd or self.host_cmd_file):
             self.fail("Provide either --host-cmd and --host-cmd-file option")
+        self.console_thread = OpSolMonitorThread3()
+        self.console_thread.start()
 
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
@@ -61,3 +64,6 @@ class RunHostTest(unittest.TestCase):
                     con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
                     continue
                 con.run_command(line, timeout=self.host_cmd_timeout)
+
+    def tearDown(self):
+        self.console_thread.console_terminate()


### PR DESCRIPTION
1) Fix OpTestThread: Minor fixes for OpSolMonitorThread3
Patch has the following minor fixes
a) OpSolMonitorThread3 has an unused log_file
b) Use get_console() to re-initiate console access

2) RunHostTest: Monitor console on running host commands
This patch adds support to monitor console when running host command(s).

Signed-off-by: Harish <harish@linux.vnet.ibm.com>