### PR TITLE
OpTestKernelArg: add/remove kernel cmdline options

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -276,6 +276,14 @@ def get_parser():
                             help="PNOR partition container to flash, Ex: --test-container CAPP capp_unsigned.bin")
     stbgroup.add_argument("--secure-mode", action='store_true', default=False, help="Secureboot mode")
     stbgroup.add_argument("--trusted-mode", action='store_true', default=False, help="Trustedboot mode")
+    kernelcmdgroup = parser.add_argument_group("Kernel cmdline options",
+                                               "add/remove kernel commandline arguments")
+    kernelcmdgroup.add_argument("--add-kernel-args",
+                                help="Kernel commandline option to be added",
+                                default="")
+    kernelcmdgroup.add_argument("--remove-kernel-args",
+                                help="Kernel commandline option to be removed",
+                                default="")
 
     return parser
 

--- a/op-test
+++ b/op-test
@@ -119,6 +119,7 @@ from testcases import TrustedBoot
 from testcases import IplParams
 from testcases import CpuHotPlug
 from testcases import EnergyScale_BaseLine
+from testcases import OpTestKernelArg
 import testcases
 
 signal.signal(signal.SIGHUP, optest_handler)

--- a/testcases/OpTestKernelArg.py
+++ b/testcases/OpTestKernelArg.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+import unittest
+
+import OpTestConfiguration
+from common import OpTestInstallUtil
+
+
+class OpTestKernelArg(unittest.TestCase):
+    '''
+    KernelArgTest
+    -------------
+
+    Test will add/remove kernel commandline argument based on the user input
+    from --add-kernel-args/--remove-kernel-args and reboots the system to get
+    it reflected
+
+    Example: ./op-test --add-kernel-args "hugepagesz=1G default_hugepagesz=1G hugepages=5" \
+             --remove-kernel-args "disable_radix" <other args..>
+    '''
+    def setUp(self):
+        self.conf = OpTestConfiguration.conf
+        self.kernel_add_args = self.conf.args.add_kernel_args
+        self.kernel_remove_args = self.conf.args.remove_kernel_args
+        if not (self.kernel_add_args or self.kernel_remove_args):
+            self.fail("Provide either --add-kernel-args and "
+                      "--remove-kernel-args option")
+
+    def runTest(self):
+        obj = OpTestInstallUtil.InstallUtil()
+        if not obj.update_kernel_cmdline(self.kernel_add_args,
+                                         self.kernel_remove_args):
+            self.fail("KernelArgTest failed to update kernel args")


### PR DESCRIPTION
1. Introduce API to update kernel cmdline option and reboot that can be used from tests.
2. support for kernelcmdgroup parser to provide `--add-kernel-args` and `--remove-kernel-args`.
3. OpTestKernelArg test to bringup host with updated kernel cmdline option by adding/removing/both.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>
Signed-off-by: Harish <harish@linux.vnet.ibm.com>