### PR TITLE
OpTestQemu: Fix variable name missed pty

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -185,7 +185,7 @@ class QemuConsole():
             self.connect()
         else:
             if self.system.SUDO_set != 1 or self.system.LOGIN_set != 1 or self.system.PS1_set != 1:
-                self.util.setup_term(self.system, self.sol, None, self.system.block_setup_term)
+                self.util.setup_term(self.system, self.pty, None, self.system.block_setup_term)
 
         return self.pty
 


### PR DESCRIPTION
Missed a change of sol variable name to pty.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>