### PR TITLE
OpTestMambo: Integrate Mambo

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -8,6 +8,7 @@ from common.OpTestBMC import OpTestBMC, OpTestSMC
 from common.OpTestFSP import OpTestFSP
 from common.OpTestOpenBMC import OpTestOpenBMC
 from common.OpTestQemu import OpTestQemu
+from common.OpTestMambo import OpTestMambo
 import common.OpTestSystem
 import common.OpTestHost
 from common.OpTestIPMI import OpTestIPMI, OpTestSMCIPMI
@@ -41,12 +42,16 @@ import logging
 
 import importlib
 import os
+import stat
 import addons
 
 optAddons = dict() # Store all addons found.  We'll loop through it a couple time below
 # Look at the top level of the addons for any directories and load their Setup modules
 
 qemu_default = "qemu-system-ppc64"
+mambo_default = "/opt/ibm/systemsim-p9/run/p9/power9"
+mambo_initial_run_script = "skiboot.tcl"
+mambo_autorun = "1"
 
 # HostLocker credentials need to be in Notes Web section ('comment' section of JSON)
 # bmc_type:OpenBMC
@@ -122,6 +127,10 @@ default_val_qemu = {
      # see OpTestQemu.py
 }
 
+default_val_mambo = {
+    'bmc_type'            : 'mambo',
+}
+
 default_templates = {
     # lower case insensitive lookup used later
     'openbmc'             : default_val,
@@ -129,6 +138,7 @@ default_templates = {
     'ami'                 : default_val_ami,
     'smc'                 : default_val_smc,
     'qemu'                : default_val_qemu,
+    'mambo'               : default_val_mambo,
 }
 
 
@@ -192,7 +202,7 @@ def get_parser():
     bmcgroup = parser.add_argument_group('BMC',
                                          'Options for Service Processor')
     # The default supported BMC choices in --bmc-type
-    bmcChoices = ['AMI', 'SMC', 'FSP', 'OpenBMC', 'qemu']
+    bmcChoices = ['AMI', 'SMC', 'FSP', 'OpenBMC', 'qemu', 'mambo']
     # Loop through any addons let it append the extra bmcChoices
     for opt in optAddons:
         bmcChoices = optAddons[opt].addBMCType(bmcChoices)
@@ -210,6 +220,12 @@ def get_parser():
     bmcgroup.add_argument("--smc-presshipmicmd")
     bmcgroup.add_argument("--qemu-binary", default=qemu_default,
                           help="[QEMU Only] qemu simulator binary")
+    bmcgroup.add_argument("--mambo-binary", default=mambo_default,
+                          help="[Mambo Only] mambo simulator binary, defaults to /opt/ibm/systemsim-p9/run/p9/power9")
+    bmcgroup.add_argument("--mambo-initial-run-script", default=mambo_initial_run_script,
+                          help="[Mambo Only] mambo simulator initial run script, defaults to skiboot.tcl")
+    bmcgroup.add_argument("--mambo-autorun", default=mambo_autorun,
+                          help="[Mambo Only] mambo autorun, defaults to '1' to autorun")
 
     hostgroup = parser.add_argument_group('Host', 'Installed OS information')
     hostgroup.add_argument("--host-ip", help="Host address")
@@ -332,6 +348,11 @@ class OpTestConfiguration():
         if defaults.get('qemu_binary'):
             qemu_default = defaults['qemu_binary']
 
+        if defaults.get('mambo_binary'):
+            mambo_default = defaults['mambo_binary']
+        if defaults.get('mambo_initial_run_script'):
+            mambo_default = defaults['mambo_initial_run_script']
+
         parser.add_argument("--check-ssh-keys", action='store_true', default=False,
                                 help="Check remote host keys when using SSH (auto-yes on new)")
         parser.add_argument("--known-hosts-file",
@@ -437,7 +458,7 @@ class OpTestConfiguration():
         self.util.check_lockers()
 
         if self.args.machine_state == None:
-            if self.args.bmc_type in ['qemu']:
+            if self.args.bmc_type in ['qemu', 'mambo']:
                 # Force UNKNOWN_BAD so that we don't try to setup the console early
                 self.startState = common.OpTestSystem.OpSystemState.UNKNOWN_BAD
             else:
@@ -582,6 +603,35 @@ class OpTestConfiguration():
                 self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host, bmc=bmc,
                     state=self.startState)
                 bmc.set_system(self.op_system)
+            elif self.args.bmc_type in ['mambo']:
+                if not (os.stat(self.args.mambo_binary).st_mode & stat.S_IXOTH):
+                    raise ParameterCheck(msg="Check that the file exists with"
+                        " X permissions"
+                        " mambo-binary={}"
+                        .format(self.args.mambo_binary))
+                if self.args.flash_skiboot is None \
+                    or not os.access(self.args.flash_skiboot, os.R_OK|os.W_OK|os.X_OK):
+                    raise ParameterCheck(msg="Check that the file exists with"
+                        " R/W/X permissions"
+                        " flash-skiboot={}"
+                        .format(self.args.flash_skiboot))
+                if self.args.flash_kernel is None \
+                    or not os.access(self.args.flash_kernel, os.R_OK|os.W_OK):
+                    raise ParameterCheck(msg="Check that the file exists with"
+                        " R/W permissions"
+                        " flash-kernel={}"
+                        .format(self.args.flash_kernel))
+                bmc = OpTestMambo(self.args.mambo_binary,
+                             self.args.mambo_initial_run_script,
+                             self.args.mambo_autorun,
+                             self.args.flash_skiboot,
+                             self.args.flash_kernel,
+                             self.args.flash_initramfs,
+                             logfile=self.logfile)
+                self.op_system = common.OpTestSystem.OpTestMamboSystem(host=host, bmc=bmc,
+                    state=self.startState)
+                bmc.set_system(self.op_system)
+
             # Check that the bmc_type exists in our loaded addons then create our objects
             elif self.args.bmc_type in optAddons:
                 (bmc, self.op_system) = optAddons[self.args.bmc_type].createSystem(self, host)

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -43,7 +43,7 @@ import requests
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
 from Exceptions import CommandFailed, RecoverFailed, ConsoleSettings
-from Exceptions import HostLocker, AES, ParameterCheck, HTTPCheck
+from Exceptions import HostLocker, AES, ParameterCheck, HTTPCheck, UnexpectedCase
 
 import logging
 import OpTestLogger
@@ -1301,6 +1301,37 @@ class OpTestUtil():
             output = cf.output
         return output
 
+    def mambo_run_command(self, term_obj, command, timeout=60, retry=0):
+        expect_prompt = "systemsim %"
+        term_obj.get_console().sendline(command)
+        rc = term_obj.get_console().expect([expect_prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+        output_list = []
+        output_list += term_obj.get_console().before.replace("\r\r\n","\n").splitlines()
+        try:
+          del output_list[:1] # remove command from the list
+        except Exception as e:
+          pass # nothing there
+        return output_list
+
+    def mambo_enter(self, term_obj):
+        term_obj.get_console().sendcontrol('c')
+        rc = term_obj.get_console().expect(["systemsim %", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        if rc != 0:
+            raise UnexpectedCase(state="Mambo", msg="We tried to send control-C"
+                " to Mambo and we failed, probably just retry")
+
+    def mambo_exit(self, term_obj):
+        # this method will remove the mysim go from the output
+        expect_prompt = self.build_prompt(term_obj.prompt) + "$"
+        term_obj.get_console().sendline("mysim go")
+        rc = term_obj.get_console().expect(["mysim go", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        output_list = []
+        output_list += term_obj.get_console().before.replace("\r\r\n","\n").splitlines()
+        try:
+          del output_list[:1] # remove command from the list
+        except Exception as e:
+          pass # nothing there
+        return output_list
 
 class Server(object):
 

--- a/skiboot.tcl
+++ b/skiboot.tcl
@@ -1,0 +1,562 @@
+# need to get images path defined early
+source $env(LIB_DIR)/ppc/util.tcl
+if { [file exists qtrace_utils.tcl] == 1} {
+    source qtrace_utils.tcl
+}
+
+#
+# Call tclreadline's Loop to move to friendlier
+# commandline if one exists
+#
+proc readline { } {
+    set readline [catch { package require tclreadline }]
+    if { $readline == 0 } {
+        ::tclreadline::Loop
+    }
+}
+
+proc mconfig { name env_name def } {
+    global mconf
+    global env
+
+    if { [info exists env($env_name)] } { set mconf($name) $env($env_name) }
+    if { ![info exists mconf($name)] } { set mconf($name) $def }
+}
+
+mconfig cpus CPUS 1
+mconfig threads THREADS 1
+mconfig memory MEM_SIZE 4G
+
+# Create multiple memory nodes? This will create a MEM_SIZE region
+# on each chip (CPUS above).
+mconfig numa MAMBO_NUMA 0
+
+# Should we stop on an illeagal instruction
+mconfig stop_on_ill MAMBO_STOP_ON_ILL false
+
+# Location of application binary to load
+mconfig boot_image SKIBOOT ../../skiboot.lid
+
+# Boot: Memory location to load boot_image, for binary or vmlinux
+mconfig boot_load MAMBO_BOOT_LOAD 0x30000000
+
+# Boot: Value of PC after loading, for binary or vmlinux
+mconfig boot_pc	MAMBO_BOOT_PC 0x30000010
+
+# Payload: Allow for a Linux style ramdisk/initrd
+if { ![info exists env(SKIBOOT_ZIMAGE)] } {
+	error "Please set SKIBOOT_ZIMAGE to the path of your zImage.epapr"
+}
+mconfig payload PAYLOAD $env(SKIBOOT_ZIMAGE)
+
+mconfig linux_cmdline LINUX_CMDLINE ""
+
+# Paylod: Memory location for a Linux style ramdisk/initrd
+mconfig payload_addr PAYLOAD_ADDR 0x20000000;
+
+# FW: Where should ePAPR Flat Devtree Binary be loaded
+mconfig epapr_dt_addr EPAPR_DT_ADDR 0x1f00000;# place at 31M
+
+# Disk: Location of file to use a bogus disk 0
+mconfig rootdisk ROOTDISK none
+
+# Disk: File to use for re COW file: none or <file>
+mconfig rootdisk_cow MAMBO_ROOTDISK_COW none
+
+# Disk: COW method to use
+mconfig rootdisk_cow_method MAMBO_ROOTDISK_COW_METHOD newcow
+
+# Disk: COW hash size
+mconfig rootdisk_cow_hash MAMBO_ROOTDISK_COW_HASH 1024
+
+# Net: What type of networking: none, phea, bogus
+mconfig net MAMBO_NET none
+
+# Net: What is the base interface for the tun/tap device
+mconfig tap_base MAMBO_NET_TAP_BASE 0
+
+# Enable (default) or disable the "speculation-policy-favor-security" setting,
+# set to 0 to disable. When enabled it causes Linux's RFI flush to be enabled.
+mconfig speculation_policy_favor_security MAMBO_SPECULATION_POLICY_FAVOR_SECURITY 1
+
+#
+# Create machine config
+#
+set default_config [display default_configure]
+define dup $default_config myconf
+myconf config cpus $mconf(cpus)
+myconf config processor/number_of_threads $mconf(threads)
+myconf config memory_size $mconf(memory)
+myconf config processor_option/ATTN_STOP true
+myconf config processor_option/stop_on_illegal_instruction $mconf(stop_on_ill)
+myconf config UART/0/enabled false
+myconf config SimpleUART/enabled false
+myconf config enable_rtas_support false
+myconf config processor/cpu_frequency 512M
+myconf config processor/timebase_frequency 1/1
+myconf config enable_pseries_nvram false
+myconf config machine_option/NO_RAM TRUE
+myconf config machine_option/NO_ROM TRUE
+
+if { $default_config == "PEGASUS" } {
+    # We need to be DD2 or greater on p8 for the HILE HID bit.
+    myconf config processor/initial/PVR 0x4b0201
+
+    if { $mconf(numa) } {
+        myconf config memory_region_id_shift 35
+    }
+}
+
+if { $default_config == "P9" } {
+    # PVR configured for POWER9 DD2.0 Scale out 24 Core (ie SMT4)
+    myconf config processor/initial/PVR 0x4e1200
+    myconf config processor/initial/SIM_CTRL1 0xc228100400000000
+
+    if { $mconf(numa) } {
+        myconf config memory_region_id_shift 45
+    }
+}
+
+if { $mconf(numa) } {
+    myconf config memory_regions $mconf(cpus)
+}
+
+if { [info exists env(SKIBOOT_SIMCONF)] } {
+    source $env(SKIBOOT_SIMCONF)
+}
+
+define machine myconf mysim
+
+#
+# Include various utilities
+#
+
+source $env(LIB_DIR)/common/epapr.tcl
+if {![info exists of::encode_compat]} {
+    source $env(LIB_DIR)/common/openfirmware_utils.tcl
+}
+
+# Only source mambo_utils.tcl if it exists in the current directory. That
+# allows running mambo in another directory to the one skiboot.tcl is in.
+if { [file exists mambo_utils.tcl] } then {
+	source mambo_utils.tcl
+
+	if { [info exists env(VMLINUX_MAP)] } {
+		global linux_symbol_map
+
+		set fp [open $env(VMLINUX_MAP) r]
+		set linux_symbol_map [read $fp]
+		close $fp
+	}
+
+	if { [info exists env(SKIBOOT_MAP)] } {
+		global skiboot_symbol_map
+
+		set fp [open $env(SKIBOOT_MAP) r]
+		set skiboot_symbol_map [read $fp]
+		close $fp
+	}
+}
+
+#
+# Instantiate xscom
+#
+
+set xscom_base 0x1A0000000000
+mysim xscom create $xscom_base
+
+# Setup bogus IO
+
+if { $mconf(rootdisk) != "none" } {
+    # Now load the bogus disk image
+    switch $mconf(rootdisk_cow) {
+	none {
+	    mysim bogus disk init 0 $mconf(rootdisk) rw
+	    puts "bogusdisk initialized for $mconf(rootdisk)"
+	}
+	default {
+	    mysim bogus disk init 0 $mconf(rootdisk) \
+		$mconf(rootdisk_cow_method) \
+		$mconf(rootdisk_cow) $mconf(rootdisk_cow_hash)
+	}
+    }
+}
+switch $mconf(net) {
+    none {
+	puts "No network support selected"
+    }
+    bogus - bogusnet {
+	set net_tap [format "tap%d" $mconf(tap_base)]
+	mysim bogus net init 0 $mconf(net_mac) $net_tap
+    }
+    default {
+	error "Bad net \[none | bogus]: $mconf(net)"
+    }
+}
+
+# Device tree fixups
+
+set root_node [mysim of find_device "/"]
+
+mysim of addprop $root_node string "epapr-version" "ePAPR-1.0"
+mysim of setprop $root_node "compatible" "ibm,powernv"
+
+set cpus_node [mysim of find_device "/cpus"]
+mysim of addprop $cpus_node int "#address-cells" 1
+mysim of addprop $cpus_node int "#size-cells" 0
+
+set mem0_node [mysim of find_device "/memory@0"]
+mysim of addprop $mem0_node int "ibm,chip-id" 0
+
+set xscom_node [ mysim of addchild $root_node xscom [format %x $xscom_base]]
+set reg [list $xscom_base 0x10000000]
+mysim of addprop $xscom_node array64 "reg" reg
+mysim of addprop $xscom_node empty "scom-controller" ""
+mysim of addprop $xscom_node int "ibm,chip-id" 0
+mysim of addprop $xscom_node int "#address-cells" 1
+mysim of addprop $xscom_node int "#size-cells" 1
+set compat [list]
+lappend compat "ibm,xscom"
+lappend compat "ibm,power8-xscom"
+set compat [of::encode_compat $compat]
+mysim of addprop $xscom_node byte_array "compatible" $compat
+
+# Load any initramfs
+set cpio_start 0x80000000
+set cpio_end $cpio_start
+set cpio_size 0
+if { [info exists env(SKIBOOT_INITRD)] } {
+
+    set cpios [split $env(SKIBOOT_INITRD) ","]
+
+    foreach cpio_file $cpios {
+	    set cpio_file [string trim $cpio_file]
+	    set cpio_size [file size $cpio_file]
+	    mysim mcm 0 memory fread $cpio_end $cpio_size $cpio_file
+	    set cpio_end [expr $cpio_end + $cpio_size]
+    }
+
+    set chosen_node [mysim of find_device /chosen]
+    mysim of addprop $chosen_node int "linux,initrd-start" $cpio_start
+    mysim of addprop $chosen_node int "linux,initrd-end"   $cpio_end
+}
+
+
+# Map persistent memory disks
+proc pmem_node_add { root start size } {
+    set start_hex [format %x $start]
+    set node [mysim of addchild $root "pmem@$start_hex" ""]
+    set reg [list [expr $start >> 32] [expr $start & 0xffffffff] [expr $size >> 32] [expr $size & 0xffffffff] ]
+    mysim of addprop $node array "reg" reg
+    mysim of addprop $node string "compatible" "pmem-region"
+    mysim of addprop $node empty "volatile" "1"
+    return [expr $start + $size]
+}
+
+set pmem_files ""
+if { [info exists env(PMEM_DISK)] } {
+    set pmem_files [split $env(PMEM_DISK) ","]
+}
+set pmem_sizes ""
+if { [info exists env(PMEM_VOLATILE)] } {
+    set pmem_sizes [split $env(PMEM_VOLATILE) ","]
+}
+set pmem_root [mysim of addchild $root_node "pmem" ""]
+mysim of addprop $pmem_root int "#address-cells" 2
+mysim of addprop $pmem_root int "#size-cells" 2
+mysim of addprop $pmem_root empty "ranges" ""
+# Start above where XICS normally is at 0x1A0000000000
+set pmem_start [expr 0x20000000000]
+foreach pmem_file $pmem_files { # PMEM_DISK
+    set pmem_file [string trim $pmem_file]
+    set pmem_size [file size $pmem_file]
+    if {[catch {mysim memory mmap $pmem_start $pmem_size $pmem_file rw}]} {
+	puts "ERROR: pmem: 'mysim mmap' command needs newer mambo"
+	exit
+    }
+    set pmem_start [pmem_node_add $pmem_root $pmem_start $pmem_size]
+}
+foreach pmem_size $pmem_sizes { # PMEM_VOLATILE
+    set pmem_start [pmem_node_add $pmem_root $pmem_start $pmem_size]
+}
+
+
+# Default NVRAM is blank and will be formatted by Skiboot if no file is provided
+set fake_nvram_start $cpio_end
+set fake_nvram_size 0x40000
+# Load any fake NVRAM file if provided
+if { [info exists env(SKIBOOT_NVRAM)] } {
+    # Set up and write NVRAM file
+    set fake_nvram_file $env(SKIBOOT_NVRAM)
+    set fake_nvram_size [file size $fake_nvram_file]
+    mysim mcm 0 memory fread $fake_nvram_start $fake_nvram_size $fake_nvram_file
+}
+
+# Add device tree entry for NVRAM
+set reserved_memory [mysim of addchild $root_node "reserved-memory" ""]
+mysim of addprop $reserved_memory int "#size-cells" 2
+mysim of addprop $reserved_memory int "#address-cells" 2
+mysim of addprop $reserved_memory empty "ranges" ""
+
+set initramfs_res [mysim of addchild $reserved_memory "initramfs" ""]
+set reg [list $cpio_start $cpio_size ]
+mysim of addprop $initramfs_res array64 "reg" reg
+mysim of addprop $initramfs_res empty "name" "initramfs"
+
+set fake_nvram_node [mysim of addchild $reserved_memory "ibm,fake-nvram" ""]
+set reg [list $fake_nvram_start $fake_nvram_size ]
+mysim of addprop $fake_nvram_node array64 "reg" reg
+mysim of addprop $fake_nvram_node empty "name" "ibm,fake-nvram"
+
+set opal_node [mysim of addchild $root_node "ibm,opal" ""]
+
+# Allow P9 to use all idle states
+if { $default_config == "P9" } {
+    set power_mgt_node [mysim of addchild $opal_node "power-mgt" ""]
+    mysim of addprop $power_mgt_node int "ibm,enabled-stop-levels" 0xffffffff
+}
+
+proc add_feature_node { parent name { value 1 } } {
+    if { $value != 1 } {
+	set value "disabled"
+    } else {
+	set value "enabled"
+    }
+    set np [mysim of addchild $parent $name ""]
+    mysim of addprop $np empty $value ""
+}
+
+set np [mysim of addchild $opal_node "fw-features" ""]
+add_feature_node $np "speculation-policy-favor-security" $mconf(speculation_policy_favor_security)
+add_feature_node $np "needs-l1d-flush-msr-hv-1-to-0"
+add_feature_node $np "needs-l1d-flush-msr-pr-0-to-1"
+add_feature_node $np "needs-spec-barrier-for-bound-checks"
+
+
+# Init CPUs
+set pir 0
+for { set c 0 } { $c < $mconf(cpus) } { incr c } {
+    set cpu_node [mysim of find_device "/cpus/PowerPC@$pir"]
+    mysim of addprop $cpu_node int "ibm,pir" $pir
+    set reg  [list 0x0000001c00000028 0xffffffffffffffff]
+    mysim of addprop $cpu_node array64 "ibm,processor-segment-sizes" reg
+
+    mysim of addprop $cpu_node int "ibm,chip-id" $c
+
+    # Create a chip node to tell skiboot to create another chip for this CPU.
+    # This bubbles up to Linux which will then see a new chip (aka nid).
+    # For chip 0 the xscom node above has already definied chip 0, so skip it.
+    if { $c > 0 } {
+        set node [mysim of addchild $root_node "mambo-chip" [format %x $c]]
+        mysim of addprop $node int "ibm,chip-id" $c
+        mysim of addprop $node string "compatible" "ibm,mambo-chip"
+
+        if { $mconf(numa) } {
+            set shift [myconf query memory_region_id_shift]
+            set addr [format %lx [expr (1 << $shift) * $c]]
+            set node [mysim of find_device "/memory@$addr"]
+            mysim of addprop $node int "ibm,chip-id" $c
+        }
+    }
+
+    set reg {}
+    lappend reg 0x0000000c 0x00000010 0x00000018 0x00000022
+    mysim of addprop $cpu_node array "ibm,processor-page-sizes" reg
+
+    set reg {}
+    lappend reg 0x0c 0x000 3 0x0c 0x0000 ;#  4K seg  4k pages
+    lappend reg              0x10 0x0007 ;#  4K seg 64k pages
+    lappend reg              0x18 0x0038 ;#  4K seg 16M pages
+    lappend reg 0x10 0x110 2 0x10 0x0001 ;# 64K seg 64k pages
+    lappend reg              0x18 0x0008 ;# 64K seg 16M pages
+    lappend reg 0x18 0x100 1 0x18 0x0000 ;# 16M seg 16M pages
+    lappend reg 0x22 0x120 1 0x22 0x0003 ;# 16G seg 16G pages
+    mysim of addprop $cpu_node array "ibm,segment-page-sizes" reg
+
+    if { $default_config == "P9" } {
+        # Set actual page size encodings
+        set reg {}
+        # 4K pages
+        lappend reg 0x0000000c
+        # 64K pages
+        lappend reg 0xa0000010
+        # 2M pages
+        lappend reg 0x20000015
+        # 1G pages
+        lappend reg 0x4000001e
+        mysim of addprop $cpu_node array "ibm,processor-radix-AP-encodings" reg
+
+        set reg {}
+	# POWER9 PAPR defines upto bytes 62-63
+	# header + bytes 0-5
+	lappend reg 0x4000f63fc70080c0
+	# bytes 6-13
+	lappend reg 0x8000000000000000
+	# bytes 14-21
+	lappend reg 0x0000800080008000
+	# bytes 22-29 22/23=TM
+	lappend reg 0x8000800080008000
+	# bytes 30-37
+	lappend reg 0x80008000C0008000
+	# bytes 38-45 40/41=radix
+	lappend reg 0x8000800080008000
+	# bytes 46-55
+	lappend reg 0x8000800080008000
+	# bytes 54-61 58/59=seg tbl
+	lappend reg 0x8000800080008000
+	# bytes 62-69
+	lappend reg 0x8000000000000000
+	mysim of addprop $cpu_node array64 "ibm,pa-features" reg
+    } else {
+        set reg {}
+	lappend reg 0x6000f63fc70080c0
+	mysim of addprop $cpu_node array64 "ibm,pa-features" reg
+    }
+
+    set irqreg [list]
+    for { set t 0 } { $t < $mconf(threads) } { incr t } {
+	mysim mcm 0 cpu $c thread $t set spr pc $mconf(boot_pc)
+	mysim mcm 0 cpu $c thread $t set gpr 3 $mconf(epapr_dt_addr)
+	mysim mcm 0 cpu $c thread $t config_on
+	mysim mcm 0 cpu $c thread $t set spr pir $pir
+	lappend irqreg $pir
+	incr pir
+    }
+    mysim of addprop $cpu_node array "ibm,ppc-interrupt-server#s" irqreg
+}
+
+#Add In-Memory Collection Counter nodes
+if { $default_config == "P9" } {
+   #Add the base node "imc-counters"
+   set imc_c [mysim of addchild $root_node "imc-counters" ""]
+   mysim of addprop $imc_c string "compatible" "ibm,opal-in-memory-counters"
+   mysim of addprop $imc_c int "#address-cells" 1
+   mysim of addprop $imc_c int "#size-cells" 1
+   mysim of addprop $imc_c int "version-id" 1
+
+      #Add a common mcs event node
+      set mcs_et [mysim of addchild $imc_c "nest-mcs-events" ""]
+      mysim of addprop $mcs_et int "#address-cells" 1
+      mysim of addprop $mcs_et int "#size-cells" 1
+
+         #Add a event
+         set et [mysim of addchild $mcs_et event [format %x 0]]
+         mysim of addprop  $et string "event-name" "64B_RD_OR_WR_DISP_PORT01"
+         mysim of addprop  $et string "unit" "MiB/s"
+         mysim of addprop  $et string "scale" "4"
+         mysim of addprop  $et int "reg" 0
+
+        #Add a event
+        set et [mysim of addchild $mcs_et event [format %x 1]]
+        mysim of addprop  $et string "event-name" "64B_WR_DISP_PORT01"
+        mysim of addprop  $et string "unit" "MiB/s"
+        mysim of addprop  $et int "reg" 40
+
+        #Add a event
+        set et [mysim of addchild $mcs_et event [format %x 2]]
+        mysim of addprop  $et string "event-name" "64B_RD_DISP_PORT01"
+        mysim of addprop  $et string "scale" "100"
+        mysim of addprop  $et int "reg" 64
+
+        #Add a event
+        set et [mysim of addchild $mcs_et event [format %x 3]]
+        mysim of addprop  $et string "event-name" "64B_XX_DISP_PORT01"
+        mysim of addprop  $et int "reg" 32
+
+     #Add a mcs device node
+     set mcs_01 [mysim of addchild $imc_c "mcs01" ""]
+     mysim of addprop $mcs_01 string "compatible" "ibm,imc-counters"
+     mysim of addprop  $mcs_01 string "events-prefix" "PM_MCS01_"
+     mysim of addprop  $mcs_01 int "reg" 65536
+     mysim of addprop  $mcs_01 int "size" 262144
+     mysim of addprop  $mcs_01 int "offset" 1572864
+     mysim of addprop  $mcs_01 int "events" $mcs_et
+     mysim of addprop  $mcs_01 int "type" 16
+     mysim of addprop $mcs_01 string "unit" "KiB/s"
+     mysim of addprop $mcs_01 string "scale" "8"
+
+      #Add a common core event node
+      set ct_et [mysim of addchild $imc_c "core-thread-events" ""]
+      mysim of addprop $ct_et int "#address-cells" 1
+      mysim of addprop $ct_et int "#size-cells" 1
+
+         #Add a event
+         set cet [mysim of addchild $ct_et event [format %x 200]]
+         mysim of addprop  $cet string "event-name" "0THRD_NON_IDLE_PCYC"
+         mysim of addprop  $cet string "desc" "The number of processor cycles when all threads are idle"
+         mysim of addprop  $cet int "reg" 200
+
+     #Add a core device node
+     set core [mysim of addchild $imc_c "core" ""]
+     mysim of addprop $core string "compatible" "ibm,imc-counters"
+     mysim of addprop  $core string "events-prefix" "CPM_"
+     mysim of addprop  $core int "reg" 24
+     mysim of addprop  $core int "size" 8192
+     mysim of addprop  $core string "scale" "512"
+     mysim of addprop  $core int "events" $ct_et
+     mysim of addprop  $core int "type" 4
+
+     #Add a thread device node
+     set thread [mysim of addchild $imc_c "thread" ""]
+     mysim of addprop $thread string "compatible" "ibm,imc-counters"
+     mysim of addprop  $thread string "events-prefix" "CPM_"
+     mysim of addprop  $thread int "reg" 24
+     mysim of addprop  $thread int "size" 8192
+     mysim of addprop  $thread string "scale" "512"
+     mysim of addprop  $thread int "events" $ct_et
+     mysim of addprop  $thread int "type" 1
+}
+
+mconfig enable_stb SKIBOOT_ENABLE_MAMBO_STB 0
+
+if { [info exists env(SKIBOOT_ENABLE_MAMBO_STB)] } {
+    set stb_node [ mysim of addchild $root_node "ibm,secureboot" "" ]
+    mysim of addprop $stb_node string "compatible" "ibm,secureboot-v1-softrom"
+#    mysim of addprop $stb_node string "secure-enabled" ""
+    mysim of addprop $stb_node string "trusted-enabled" ""
+    mysim of addprop $stb_node string "hash-algo" "sha512"
+    set hw_key_hash {}
+    lappend hw_key_hash 0x40d487ff
+    lappend hw_key_hash 0x7380ed6a
+    lappend hw_key_hash 0xd54775d5
+    lappend hw_key_hash 0x795fea0d
+    lappend hw_key_hash 0xe2f541fe
+    lappend hw_key_hash 0xa9db06b8
+    lappend hw_key_hash 0x466a42a3
+    lappend hw_key_hash 0x20e65f75
+    lappend hw_key_hash 0xb4866546
+    lappend hw_key_hash 0x0017d907
+    lappend hw_key_hash 0x515dc2a5
+    lappend hw_key_hash 0xf9fc5095
+    lappend hw_key_hash 0x4d6ee0c9
+    lappend hw_key_hash 0xb67d219d
+    lappend hw_key_hash 0xfb708535
+    lappend hw_key_hash 0x1d01d6d1
+    mysim of addprop $stb_node array "hw-key-hash" hw_key_hash
+}
+
+# Kernel command line args, appended to any from the device tree
+# e.g.: of::set_bootargs "xmon"
+#
+# Can be set from the environment by setting LINUX_CMDLINE.
+of::set_bootargs $mconf(linux_cmdline)
+
+# Load images
+
+set boot_size [file size $mconf(boot_image)]
+mysim memory fread $mconf(boot_load) $boot_size $mconf(boot_image)
+
+set payload_size [file size $mconf(payload)]
+mysim memory fread $mconf(payload_addr) $payload_size $mconf(payload)
+
+# Flatten it
+epapr::of2dtb mysim $mconf(epapr_dt_addr)
+
+# Set run speed
+mysim mode fastest
+
+if { [info exists env(SKIBOOT_AUTORUN)] } {
+    if [catch { mysim go }] {
+	readline
+    }
+}

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -36,6 +36,7 @@ import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 from common.OpTestUtil import OpTestUtil
+import common.OpTestMambo as OpTestMambo
 
 import logging
 import OpTestLogger
@@ -55,6 +56,10 @@ class Console():
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         console = self.cv_BMC.get_host_console()
+        if (isinstance(self.cv_BMC, OpTestMambo.OpTestMambo)):
+            adjustment = 4 # Mambo echos command extra time
+        else:
+            adjustment = 3
         bs = self.bs
         count = self.count
         self.assertTrue((bs * count) % 16 == 0,
@@ -71,7 +76,7 @@ class Console():
                 pass
             else:
                 raise cf
-        expected = 3 + (count * bs) / 16
+        expected = adjustment + (count * bs) / 16
         self.assertTrue(len(zeros) == expected,
                         "Unexpected length of zeros {} != {}".format(
                             len(zeros), expected))
@@ -125,7 +130,8 @@ class ControlC(unittest.TestCase):
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         console = self.cv_BMC.get_host_console()
-        # I should really make this API less nasty...
+        if (isinstance(self.cv_BMC, OpTestMambo.OpTestMambo)):
+            raise unittest.SkipTest("Mambo so skipping Control-C tests")
         raw_pty = console.get_console()
         raw_pty.sendline("find /")
         time.sleep(2)

--- a/testcases/DPO.py
+++ b/testcases/DPO.py
@@ -41,6 +41,7 @@ import pexpect
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 import common.OpTestQemu as OpTestQemu
+import common.OpTestMambo as OpTestMambo
 
 import logging
 import OpTestLogger
@@ -71,9 +72,10 @@ class DPOSkiroot(Base):
         self.setup_test()
         # retry added for IPMI cases, seems more sensitive with initial start
         # of state=4
-        if isinstance(self.cv_SYSTEM.console, OpTestQemu.QemuConsole):
-            raise self.skipTest("Performing \"ipmitool power soft\" will "
-                                "terminate QEMU so skipped")
+        if isinstance(self.cv_SYSTEM.console, OpTestQemu.QemuConsole) \
+            or isinstance(self.cv_SYSTEM.console, OpTestMambo.MamboConsole):
+                raise self.skipTest("Performing \"ipmitool power soft\" will "
+                                "terminate QEMU/Mambo so skipped")
         self.cv_SYSTEM.console.run_command("uname -a", retry=5)
         if self.host == "Host":
             self.cv_SYSTEM.load_ipmi_drivers(True)

--- a/testcases/FWTS.py
+++ b/testcases/FWTS.py
@@ -42,6 +42,7 @@ import OpTestConfiguration
 import unittest
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
+import common.OpTestMambo as OpTestMambo
 
 import json
 
@@ -52,6 +53,11 @@ class FWTSCommandFailed(unittest.TestCase):
     def runTest(self):
         self.assertEqual(self.FAIL, None, str(self.FAIL))
 
+class FWTSCommandSkipped(unittest.TestCase):
+    SKIP = None
+
+    def runTest(self):
+        raise unittest.SkipTest("Mambo running so skipping FWTS tests")
 
 class FWTSVersion(unittest.TestCase):
     MAJOR = None
@@ -231,6 +237,12 @@ class FWTS(unittest.TestSuite):
         try:
             self.cv_SYSTEM.goto_state(OpSystemState.OS)
         except Exception as e:
+            if (isinstance(self.cv_SYSTEM.console, OpTestMambo.MamboConsole)):
+                m = FWTSCommandSkipped()
+                m.SKIP = e
+                self.real_fwts_suite.addTest(m)
+                self.real_fwts_suite.run(result)
+                return
             # In the event of something going wrong during IPL,
             # We need to catch that here as we're abusing UnitTest
             # TestSuite infra and we don't have the catch-all that

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -51,6 +51,7 @@ from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestIPMI import IPMIConsoleState
 from common.Exceptions import CommandFailed
+import common.OpTestMambo as OpTestMambo
 
 import logging
 import OpTestLogger
@@ -73,7 +74,8 @@ class OpTestInbandIPMIBase(object):
         self.cv_SYSTEM = conf.system()
         self.cv_BMC = conf.bmc()
         self.util = OpTestUtil()
-        pass
+        if (isinstance(self.cv_BMC, OpTestMambo.OpTestMambo)):
+            raise unittest.SkipTest("Mambo so skipping InbandIPMI tests")
 
     def set_up(self):
         if self.test == "skiroot":

--- a/testcases/OpTestMamboSim.py
+++ b/testcases/OpTestMamboSim.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2017
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# POWER9 Functional Simulator User Guide
+# http://public.dhe.ibm.com/software/server/powerfuncsim/p9/docs/P9funcsim_ug_v1.0_pub.pdf
+#
+# POWER9 Functional Simulator Command Reference Guide
+# http://public.dhe.ibm.com/software/server/powerfuncsim/p9/docs/P9funcsim_cr_v1.0_pub.pdf
+
+'''
+Mambo Sim
+---------
+Tests that illustrate the use cases and provides comments on special handling
+needed to switch context between the target OS and the Mambo simulator.
+
+Debug logging is done to output both examples of command run and to
+provide pertinent information regarding the state of the mambo config.
+
+'''
+
+import unittest
+import time
+import pexpect
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+from common.Exceptions import CommandFailed
+import common.OpTestMambo as OpTestMambo
+
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+class OpTestMamboSim(unittest.TestCase):
+    '''
+    Provide an illustrative example of class methods to run
+    both target OS commands as well as switching to the
+    Mambo Simulator and running mambo commands and then switching back
+    '''
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.ipmi = conf.ipmi()
+        self.system = conf.system()
+        self.host = conf.host()
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.prompt = self.system.util.build_prompt()
+        self.c = self.system.console
+        self.pty = self.c.get_console()
+        if not isinstance(self.c, OpTestMambo.MamboConsole):
+            raise unittest.SkipTest("Must be running Mambo to perform this test")
+
+    def runTest(self):
+        # need to first perform run_command initially
+        # which sets up the pexpect prompt for subsequent run_command(s)
+
+        # mambo echos twice so turn off
+        # this stays persistent even after switching context
+        # from target OS to mambo and back
+        self.c.run_command('stty -echo')
+
+        target_OS_command_1 = "lsprop /sys/firmware/devicetree/base/ibm,opal/firmware"
+        lsprop_output = self.c.run_command(target_OS_command_1)
+        log.debug("target OS command 1 '{}'".format(target_OS_command_1))
+        for i in lsprop_output:
+            log.debug("lsprop output = {}".format(i))
+
+        # exit target OS and enter mambo
+        self.c.mambo_enter()
+
+        # mambo command
+        mambo_command_1 = "mysim of print"
+        mambo_output = self.c.mambo_run_command(mambo_command_1)
+        log.debug("mambo command 1 '{}'".format(mambo_command_1))
+        for i in mambo_output:
+            log.debug("mysim of print output = {}".format(i))
+
+        # return to target OS
+        self.c.mambo_exit()
+        # need to sync pexpect buffer from mambo_exit
+        # extra character appears and depending on commands
+        # run in mambo caller may or may not want to sync
+        # e.g. if mambo commands were queued and results need parsed
+        self.pty.sendline() # sync up pexpect buffer
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+
+        lsprop_output = self.c.run_command('lsprop /sys/firmware/devicetree/base/ibm,opal/firmware')
+        cmdline_output = self.c.run_command('cat /proc/cmdline')
+
+        # exit target OS and enter mambo
+        self.c.mambo_enter()
+
+        mambo_command_2 = "ls --color=never -l /"
+        mambo_command_3 = "nvram --partitions"
+        mambo_command_4 = "cat /proc/powerpc/eeh"
+        mambo_command_5 = "cat /proc/cmdline"
+        mambo_command_6 = "cat /sys/devices/system/cpu/present"
+        mambo_command_7 = "cat /proc/version"
+        # mysim command 2
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_2))
+
+        # mysim command 3
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_3))
+
+        # mysim command 4
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_4))
+
+        # mysim command 5
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_5))
+
+        # mysim command 6
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_6))
+
+        # mysim command 7
+        self.c.mambo_run_command("mysim console create input in string \"{}\"".format(mambo_command_7))
+
+        # return to target OS
+        self.c.mambo_exit()
+
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 2 '{}'".format(mambo_command_2))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 2 before=\"{}\"".format(i))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 3 '{}'".format(mambo_command_3))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 3 before=\"{}\"".format(i))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 4 '{}'".format(mambo_command_4))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 4 before=\"{}\"".format(i))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 5 '{}'".format(mambo_command_5))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 5 before=\"{}\"".format(i))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 6 '{}'".format(mambo_command_6))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 6 before=\"{}\"".format(i))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        log.debug("mambo command 7 '{}'".format(mambo_command_7))
+        for i in self.pty.before.replace("\r\r\n", "\n").splitlines():
+            log.debug("mambo command 7 before=\"{}\"".format(i))
+
+        # exit target OS and enter mambo
+        self.c.mambo_enter()
+
+        # mysim command 8
+        self.c.mambo_run_command("mysim console create input in string \"echo 'hello world command 8'\"")
+
+        # mambo commands
+        version_list = self.c.mambo_run_command("version list")
+        log.debug("version list={}".format(version_list))
+        define_list = self.c.mambo_run_command("define list") # list machines available
+        log.debug("define list ={}".format(define_list))
+        display_configures = self.c.mambo_run_command("display configures") # all active configuration objects and machines
+        log.debug("display configures={}".format(display_configures))
+
+        # return to target OS
+        # queued_echo_output will NOT contain the command 8 echo of 'hello world command 8'
+        # when returning to the target OS the pexpect buffer is awaiting retrieval, "expecting"
+        queued_echo_output = self.c.mambo_exit()
+        log.debug("mambo_exit command 8 queued_echo_output={}".format(queued_echo_output))
+        rc = self.pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        # now retrieve the echo output which sat awaiting
+        log.debug("delayed queued_echo_output=\"{}\"".format(self.pty.before))
+
+        osrelease = self.c.run_command('ls --color=never -al /etc/os-release')
+        for i in osrelease:
+            log.debug("osrelease={}".format(i))

--- a/testcases/Petitbooti18n.py
+++ b/testcases/Petitbooti18n.py
@@ -35,6 +35,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
+import common.OpTestMambo as OpTestMambo
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
@@ -47,6 +48,8 @@ class Petitbooti18n(unittest.TestCase):
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
         log.debug("Test i18n strings appear correctly in Petitboot")
+        if (isinstance(self.cv_SYSTEM.console, OpTestMambo.MamboConsole)):
+            raise unittest.SkipTest("Mambo so skipping Language tests")
 
         # Wait a moment for pb-discover to connect
         time.sleep(3)

--- a/testcases/SystemLogin.py
+++ b/testcases/SystemLogin.py
@@ -37,6 +37,8 @@ import unittest
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
+import common.OpTestQemu as OpTestQemu
+import common.OpTestMambo as OpTestMambo
 
 import logging
 import OpTestLogger
@@ -78,6 +80,9 @@ class BMCLogin(unittest.TestCase):
         self.cv_BMC = conf.bmc()
 
     def runTest(self):
+        if (isinstance(self.cv_BMC, OpTestMambo.OpTestMambo)) \
+            or (isinstance(self.cv_BMC, OpTestQemu.OpTestQemu)):
+                raise unittest.SkipTest("QEMU/Mambo so skipping BMCLogin test")
         r = self.cv_BMC.run_command("echo 'Hello World'")
         self.assertIn("Hello World", r)
         try:


### PR DESCRIPTION
Integrate Mambo simulator to provide mechanism to run op-test testcases.

Need to have a mambo binary, --mambo-binary, defaults to
/opt/ibm/systemsim-p9/run/p9/power9.

Need to configure --bmc-type mambo, --flash-skiboot (skiboot.lid) and
--flash-kernel (zImage.epapr or vmlinux) and conditionally
--flash-initramfs.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>