### PR TITLE
OpTestUtil: Dump Firmware Versions Tested

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -316,6 +316,7 @@ class OpTestConfiguration():
         self.signal_ready = False # indicator for properly initialized
         self.atexit_ready = False # indicator for properly initialized
         self.aes_print_helpers = True # Need state for locker_wait
+        self.dump = True # Need state for cleanup
         self.lock_dict = { 'res_id'     : None,
                            'name'       : None,
                            'Group_Name' : None,
@@ -325,6 +326,7 @@ class OpTestConfiguration():
         self.util_server = None # Hostlocker or AES
         self.util_bmc_server = None # OpenBMC REST Server
         atexit.register(self.__del__) # allows cleanup handler to run (OpExit)
+        self.firmware_versions = None
 
         for dir in (os.walk(os.path.join(self.basedir, 'addons')).next()[1]):
             optAddons[dir] = importlib.import_module("addons." + dir + ".OpTest" + dir + "Setup")

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -85,7 +85,8 @@ class OpTestSystem(object):
     #
 
     def __init__(self,
-                 bmc=None, host=None,
+                 bmc=None,
+                 host=None,
                  prompt=None,
                  conf=None,
                  state=OpSystemState.UNKNOWN):


### PR DESCRIPTION
Dump out the firmware versions being tested at the conclusion of the run.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>