### PR TITLE
OpTestUtil: Cleanup utility invocations

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -563,7 +563,8 @@ class OpTestConfiguration():
                           scratch_disk=self.args.host_scratch_disk,
                           proxy=self.args.proxy,
                           check_ssh_keys=self.args.check_ssh_keys,
-                          known_hosts_file=self.args.known_hosts_file)
+                          known_hosts_file=self.args.known_hosts_file,
+                          conf=self)
             if self.args.bmc_type in ['AMI', 'SMC']:
                 web = OpTestWeb(self.args.bmc_ip,
                             self.args.bmc_usernameipmi,
@@ -605,6 +606,7 @@ class OpTestConfiguration():
                     state=self.startState,
                     bmc=bmc,
                     host=host,
+                    conf=self,
                 )
                 ipmi.set_system(self.op_system)
                 bmc.set_system(self.op_system)
@@ -623,6 +625,7 @@ class OpTestConfiguration():
                     state=self.startState,
                     bmc=bmc,
                     host=host,
+                    conf=self,
                 )
                 ipmi.set_system(self.op_system)
             elif self.args.bmc_type in ['OpenBMC']:
@@ -631,35 +634,40 @@ class OpTestConfiguration():
                               self.args.bmc_passwordipmi,
                               host=host,
                               logfile=self.logfile)
-                rest_api = HostManagement(self,
-                                self.args.bmc_ip,
-                                self.args.bmc_username,
-                                self.args.bmc_password)
-                bmc = OpTestOpenBMC(self.args.bmc_ip,
-                                self.args.bmc_username,
-                                self.args.bmc_password,
+                rest_api = HostManagement(conf=self,
+                                ip=self.args.bmc_ip,
+                                username=self.args.bmc_username,
+                                password=self.args.bmc_password)
+                bmc = OpTestOpenBMC(ip=self.args.bmc_ip,
+                                username=self.args.bmc_username,
+                                password=self.args.bmc_password,
+                                ipmi=ipmi,
+                                rest_api=rest_api,
                                 logfile=self.logfile,
-                                ipmi=ipmi, rest_api=rest_api,
                                 check_ssh_keys=self.args.check_ssh_keys,
                                 known_hosts_file=self.args.known_hosts_file)
                 self.op_system = common.OpTestSystem.OpTestOpenBMCSystem(
                     host=host,
                     bmc=bmc,
                     state=self.startState,
+                    conf=self,
                 )
                 bmc.set_system(self.op_system)
             elif self.args.bmc_type in ['qemu']:
                 print(repr(self.args))
-                bmc = OpTestQemu(self.args.qemu_binary,
-                             self.args.host_pnor,
-                             self.args.flash_skiboot,
-                             self.args.flash_kernel,
-                             self.args.flash_initramfs,
+                bmc = OpTestQemu(qemu_binary=self.args.qemu_binary,
+                             pnor=self.args.host_pnor,
+                             skiboot=self.args.flash_skiboot,
+                             kernel=self.args.flash_kernel,
+                             initramfs=self.args.flash_initramfs,
                              cdrom=self.args.os_cdrom,
                              logfile=self.logfile,
                              hda=self.args.host_scratch_disk)
-                self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host, bmc=bmc,
-                    state=self.startState)
+                self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host,
+                    bmc=bmc,
+                    state=self.startState,
+                    conf=self,
+                )
                 bmc.set_system(self.op_system)
             elif self.args.bmc_type in ['mambo']:
                 if not (os.stat(self.args.mambo_binary).st_mode & stat.S_IXOTH):
@@ -679,15 +687,18 @@ class OpTestConfiguration():
                         " R/W permissions"
                         " flash-kernel={}"
                         .format(self.args.flash_kernel))
-                bmc = OpTestMambo(self.args.mambo_binary,
-                             self.args.mambo_initial_run_script,
-                             self.args.mambo_autorun,
-                             self.args.flash_skiboot,
-                             self.args.flash_kernel,
-                             self.args.flash_initramfs,
+                bmc = OpTestMambo(mambo_binary=self.args.mambo_binary,
+                             mambo_initial_run_script=self.args.mambo_initial_run_script,
+                             mambo_autorun=self.args.mambo_autorun,
+                             skiboot=self.args.flash_skiboot,
+                             kernel=self.args.flash_kernel,
+                             initramfs=self.args.flash_initramfs,
                              logfile=self.logfile)
-                self.op_system = common.OpTestSystem.OpTestMamboSystem(host=host, bmc=bmc,
-                    state=self.startState)
+                self.op_system = common.OpTestSystem.OpTestMamboSystem(host=host,
+                    bmc=bmc,
+                    state=self.startState,
+                    conf=self,
+                )
                 bmc.set_system(self.op_system)
 
             # Check that the bmc_type exists in our loaded addons then create our objects

--- a/common/Exceptions.py
+++ b/common/Exceptions.py
@@ -57,18 +57,6 @@ class SSHSessionDisconnected(Exception):
             self.notice)
 
 
-class LoginFailure(Exception):
-    '''
-    SSH/IPMI Login failure - username/password may be wrong
-    '''
-    def __init__(self, notice):
-        self.notice = notice
-
-    def __str__(self):
-        return "Login failure due to '{}'".format(
-            self.notice)
-
-
 class BMCDisconnected(Exception):
     '''
     BMC Cosnole was disconnected unexpectedly. e.g. it may have crashed

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -70,6 +70,7 @@ class OpTestBMC():
         self.known_hosts_file = known_hosts_file
         self.ssh = OpTestSSH(ip, username, password, logfile, prompt=None,
                 block_setup_term=0, check_ssh_keys=check_ssh_keys, known_hosts_file=known_hosts_file)
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
 
     def set_system(self, system):

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -48,7 +48,6 @@ import commands
 import OpTestConfiguration
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
-from OpTestUtil import OpTestUtil
 from OpTestSSH import OpTestSSH
 import OpTestQemu
 from Exceptions import CommandFailed, NoKernelConfig, KernelModuleNotLoaded, KernelConfigNotSet, ParameterCheck
@@ -67,11 +66,12 @@ class OpTestHost():
     '''
     def __init__(self, i_hostip, i_hostuser, i_hostpasswd, i_bmcip, i_results_dir,
                  scratch_disk="", proxy="", logfile=sys.stdout,
-                 check_ssh_keys=False, known_hosts_file=None):
+                 check_ssh_keys=False, known_hosts_file=None, conf=None):
+        self.conf = conf
+        self.util = conf.util
         self.ip = i_hostip
         self.user = i_hostuser
         self.passwd = i_hostpasswd
-        self.util = OpTestUtil()
         self.bmcip = i_bmcip
         self.results_dir = i_results_dir
         self.logfile = logfile
@@ -81,7 +81,6 @@ class OpTestHost():
         self.scratch_disk = scratch_disk
         self.proxy = proxy
         self.scratch_disk_size = None
-        self.conf = OpTestConfiguration.conf
         self.check_ssh_keys = check_ssh_keys
         self.known_hosts_file = known_hosts_file
 

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -179,6 +179,7 @@ class IPMIConsole():
         self.state = IPMIConsoleState.DISCONNECTED
         self.delaybeforesend = delaybeforesend
         self.system = None
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
         self.prompt = prompt
         self.expect_prompt = self.util.build_prompt(prompt) + "$"
@@ -329,6 +330,7 @@ class OpTestIPMI():
                                password=i_bmcPwd)
         self.console = IPMIConsole(ipmitool=self.ipmitool,
                                    delaybeforesend=delaybeforesend)
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
         self.host = host
 

--- a/common/OpTestMambo.py
+++ b/common/OpTestMambo.py
@@ -65,6 +65,7 @@ class MamboConsole():
         self.logfile = logfile
         self.delaybeforesend = delaybeforesend
         self.system = None
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
         self.prompt = prompt
         self.expect_prompt = self.util.build_prompt(prompt) + "$"

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -28,182 +28,14 @@ import requests
 import cgi
 
 from OpTestSSH import OpTestSSH
-from OpTestIPMI import OpTestIPMI
-from OpTestUtil import OpTestUtil
 from OpTestBMC import OpTestBMC
-from Exceptions import CommandFailed, LoginFailure, HTTPCheck
-from common.OpTestError import OpTestError
+from Exceptions import HTTPCheck
 from OpTestConstants import OpTestConstants as BMC_CONST
 import OpTestSystem
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
-
-class FailedCurlInvocation(Exception):
-    def __init__(self, command, output):
-        self.command = command
-        self.output = output
-
-    def __str__(self):
-        return "CURL invocation '%s' failed\nOutput:\n%s" % (self.command, self.output)
-
-
-class CurlTool():
-    def __init__(self, binary="curl",
-                 ip=None, username=None, password=None):
-        self.ip = ip
-        self.username = username
-        self.password = password
-        self.binary = binary
-        self.logresult = True
-        self.cmd_bkup = ""
-        self.login_retry = 0
-
-    def feed_data(self, dbus_object=None, action=None,
-                  operation=None, command=None,
-                  data=None, header=None, upload_file=None, remote_name=None):
-        self.object = dbus_object
-        self.action = action
-        self.operation = operation # 'r-read, w-write, rw-read/write'
-        self.command = command
-        self.data = data
-        self.header = self.custom_header(header)
-        self.upload_file = upload_file
-        self.remote_file = remote_name
-
-    def binary_name(self):
-        return self.binary
-
-    # -H, --header LINE   Pass custom header LINE to server (H)'
-    def custom_header(self, header=None):
-        if not header:
-            self.header = " \'Content-Type: application/json\' "
-        else:
-            self.header = header
-        return self.header
-
-    def http_post_data(self):
-        '''
-        Example data formats
-        data = '\'{"data": [ "root", "0penBmc" ] }\''
-        data = '\'{"data" : []}\''
-        '''
-        return self.data
-
-    # -b, --cookie STRING/FILE  Read cookies from STRING/FILE (H)
-    def read_cookie(self):
-        self.cookies = ' -b cjar '
-        return self.cookies
-
-    # -c, --cookie-jar FILE  Write cookies to FILE after operation (H)
-    def write_cookie(self):
-        self.cookies = ' -c cjar '
-        return self.cookies
-
-    def get_cookies(self):
-        if self.operation == 'r':
-            return self.read_cookie()
-        elif self.operation == 'w':
-            return self.write_cookie()
-        elif self.operation == 'rw':
-            cookies = self.read_cookie() + self.write_cookie()
-            return cookies
-        else:
-            raise Exception("Invalid operation")
-
-    def request_command(self):
-        if not self.command:
-            # default is GET command
-            self.command = "GET"
-        return self.command
-
-    def dbus_interface(self):
-        s = 'https://%s/' % self.ip
-        if self.object:
-            s += '/%s' % (self.object)
-        if self.action:
-            s += '/%s' % (self.action)
-        return s
-
-    def arguments(self):
-        args = " -s"
-        args += " %s " % self.get_cookies()
-        args += " -k "
-        # -J, --remote-header-name  Use the header-provided filename (H)
-        #  -O, --remote-name   Write output to a file named as the remote file
-        if self.remote_file:
-            args += " -O -J "
-        if self.header:
-            args += " -H %s " % self.header
-        if self.data:
-            args += " -d %s " % self.http_post_data()
-        if self.upload_file:
-            args += " -T %s " % self.upload_file
-        if self.command:
-            args += " -X %s " % self.request_command()
-        args += self.dbus_interface()
-        return args
-
-    def bkup_cmd(self, cmd):
-        self.cmd_bkup = cmd
-
-    def run(self, background=False, cmdprefix=None):
-        if self.cmd_bkup:
-            cmd = self.cmd_bkup
-        elif cmdprefix:
-            cmd = cmdprefix + self.binary + self.arguments() + cmd
-        else:
-            cmd = self.binary + self.arguments()
-        log.debug("CurlTool cmd={}".format(cmd))
-        if background:
-            try:
-                child = subprocess.Popen(cmd, shell=True)
-            except:
-                l_msg = "curl command failed: {}".format(cmd)
-                log.error(l_msg)
-                raise OpTestError(l_msg)
-            return child
-        else:
-            # TODO - need python 2.7
-            # output = check_output(cmd, stderr=subprocess.STDOUT, shell=True)
-            try:
-                obj = subprocess.Popen(cmd, stderr=subprocess.STDOUT,
-                                       stdout=subprocess.PIPE, shell=True)
-            except Exception as e:
-                l_msg = "Curl Command '{}' Failed: {}".format(cmd,str(e))
-                log.error(l_msg)
-                raise OpTestError(l_msg)
-            output = obj.communicate()[0]
-            if self.logresult:
-                log.debug("Curl Output: {}".format(output))
-            if '"description": "Login required"' in output:
-                if self.login_retry > 5:
-                    raise LoginFailure("Rest Login retry exceeded")
-                output = ""
-                cmd_bkup =  cmd
-                self.login()
-                self.login_retry += 1
-                self.bkup_cmd(cmd_bkup)
-                output = self.run()
-                self.cmd_bkup = ""
-            if '"status": "error"' in output:
-                log.error(output)
-                raise FailedCurlInvocation(cmd, output)
-            return output
-
-    def log_result(self):
-        self.logresult = True
-
-    def login(self):
-        data = '\'{"data": [ "%s", "%s" ] }\'' % (self.username, self.password)
-        self.feed_data(dbus_object="/login", operation='w', command="POST", data=data)
-        try:
-            output = self.run()
-        except FailedCurlInvocation as fci:
-            output = fci.output
-        if '"description": "Invalid username or password"' in output:
-            raise LoginFailure("Rest login invalid username or password")
 
 class HostManagement():
     '''
@@ -215,13 +47,10 @@ class HostManagement():
                     username=None,
                     password=None):
         self.conf = conf
+        self.util = conf.util
         self.hostname = ip
         self.username = username
         self.password = password
-        self.curl = CurlTool(ip=ip,
-                             username=username,
-                             password=password)
-        self.util = OpTestUtil() # too early in bring-up to use self.conf.util
         self.util.PingFunc(self.hostname, totalSleepTime=BMC_CONST.PING_RETRY_FOR_STABILITY)
         if self.conf.util_bmc_server is None:
             self.conf.util.setup(config='REST')

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -61,6 +61,7 @@ class QemuConsole():
         self.delaybeforesend = delaybeforesend
         self.system = None
         self.cdrom = cdrom
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
         self.prompt = prompt
         self.expect_prompt = self.util.build_prompt(prompt) + "$"

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -61,6 +61,7 @@ class OpTestSSH():
         self.known_hosts_file=known_hosts_file
         self.delaybeforesend = delaybeforesend
         self.system = None
+        # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()
         self.prompt = prompt
         self.expect_prompt = self.util.build_prompt(prompt) + "$"

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -87,13 +87,15 @@ class OpTestSystem(object):
     def __init__(self,
                  bmc=None, host=None,
                  prompt=None,
+                 conf=None,
                  state=OpSystemState.UNKNOWN):
+        self.conf = conf
+        self.util = conf.util
         self.bmc = self.cv_BMC = bmc
         self.cv_HOST = host
         self.cv_IPMI = bmc.get_ipmi()
         self.rest = self.bmc.get_rest_api()
         self.console = self.bmc.get_host_console()
-        self.util = OpTestUtil()
         self.prompt = prompt # build_prompt located in OpTestUtil
         # system console state tracking, reset on boot and state changes, set when valid
         self.PS1_set = -1
@@ -1188,10 +1190,12 @@ class OpTestFSPSystem(OpTestSystem):
     def __init__(self,
                  host=None,
                  bmc=None,
+                 conf=None,
                  state=OpSystemState.UNKNOWN):
         bmc.fsp_get_console()
         super(OpTestFSPSystem, self).__init__(host=host,
                                               bmc=bmc,
+                                              conf=conf,
                                               state=state)
 
     def sys_wait_for_standby_state(self, i_timeout=120):
@@ -1227,12 +1231,14 @@ class OpTestOpenBMCSystem(OpTestSystem):
     def __init__(self,
                  host=None,
                  bmc=None,
+                 conf=None,
                  state=OpSystemState.UNKNOWN):
         # Ensure we grab host console early, in order to not miss
         # any messages
         self.console = bmc.get_host_console()
         super(OpTestOpenBMCSystem, self).__init__(host=host,
                                                   bmc=bmc,
+                                                  conf=conf,
                                                   state=state)
     # REST Based management
     def sys_inventory(self):
@@ -1261,12 +1267,7 @@ class OpTestOpenBMCSystem(OpTestSystem):
         self.rest.power_off()
 
     def sys_sdr_clear(self):
-        try:
-            # Try clearing all with DeleteAllAPI
-            self.rest.clear_sel()
-        except FailedCurlInvocation as f:
-            # Which may not be implemented, so we try by ID instead
-            self.rest.clear_sel_by_id()
+        self.rest.clear_sel()
 
     def sys_get_sel_list(self):
         self.rest.list_sel()
@@ -1321,6 +1322,7 @@ class OpTestQemuSystem(OpTestSystem):
     def __init__(self,
                  host=None,
                  bmc=None,
+                 conf=None,
                  state=OpSystemState.UNKNOWN):
         # Ensure we grab host console early, in order to not miss
         # any messages
@@ -1329,6 +1331,7 @@ class OpTestQemuSystem(OpTestSystem):
             host.scratch_disk = "/dev/sda"
         super(OpTestQemuSystem, self).__init__(host=host,
                                                bmc=bmc,
+                                               conf=conf,
                                                state=state)
 
     def sys_wait_for_standby_state(self, i_timeout=120):
@@ -1361,12 +1364,14 @@ class OpTestMamboSystem(OpTestSystem):
     def __init__(self,
                  host=None,
                  bmc=None,
+                 conf=None,
                  state=OpSystemState.UNKNOWN):
         # Ensure we grab host console early, in order to not miss
         # any messages
         self.console = bmc.get_host_console()
         super(OpTestMamboSystem, self).__init__(host=host,
                                                bmc=bmc,
+                                               conf=conf,
                                                state=state)
 
     def sys_wait_for_standby_state(self, i_timeout=120):

--- a/op-test
+++ b/op-test
@@ -34,7 +34,6 @@ import re
 import signal
 import logging
 import OpTestLogger
-from common.OpTestUtil import OpTestUtil
 # op-test is the parent logger
 optestlog = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger)
 import OpTestConfiguration

--- a/testcases/AT24driver.py
+++ b/testcases/AT24driver.py
@@ -46,7 +46,6 @@ import unittest
 
 import OpTestConfiguration
 from testcases.I2C import I2C
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed, KernelModuleNotLoaded
 from common.Exceptions import KernelConfigNotSet
@@ -63,7 +62,6 @@ class AT24driver(I2C, unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
         self.test = "host"
 
     def at24_init(self):

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -30,7 +30,6 @@ a specific state.
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestError import OpTestError
 
@@ -46,7 +45,6 @@ class BasicIPL(unittest.TestCase):
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
         self.cv_BMC = conf.bmc()
-        self.util = OpTestUtil()
         self.pci_good_data_file = conf.lspci_file()
 
 

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -35,7 +35,6 @@ import time
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
-from common.OpTestUtil import OpTestUtil
 import common.OpTestMambo as OpTestMambo
 
 import logging
@@ -51,7 +50,7 @@ class Console():
         conf = OpTestConfiguration.conf
         self.cv_BMC = conf.bmc()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
+        self.util = conf.util
 
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
@@ -118,7 +117,7 @@ class ControlC(unittest.TestCase):
         conf = OpTestConfiguration.conf
         self.cv_BMC = conf.bmc()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
+        self.util = conf.util
         self.prompt = self.util.build_prompt()
 
     def cleanup(self):

--- a/testcases/DPO.py
+++ b/testcases/DPO.py
@@ -55,7 +55,6 @@ class Base(unittest.TestCase):
         self.cv_SYSTEM = conf.system()
         self.cv_HOST = conf.host()
         self.bmc_type = conf.args.bmc_type
-        self.util = self.cv_SYSTEM.util
 
 
 class DPOSkiroot(Base):

--- a/testcases/HelloWorld.py
+++ b/testcases/HelloWorld.py
@@ -29,7 +29,6 @@ Only useful as a unittest of `op-test` itself.
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 
 

--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -40,7 +40,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed, KernelModuleNotLoaded
 from common.Exceptions import KernelConfigNotSet
@@ -65,7 +64,6 @@ class I2C():
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
 
     def set_up(self):
         if self.test == "skiroot":

--- a/testcases/InstallHostOS.py
+++ b/testcases/InstallHostOS.py
@@ -30,7 +30,6 @@ import unittest
 import os
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common import OpTestInstallUtil
 
@@ -42,7 +41,6 @@ class InstallHostOS(unittest.TestCase):
         self.cv_IPMI = self.conf.ipmi()
         self.cv_SYSTEM = self.conf.system()
         self.cv_BMC = self.conf.bmc()
-        self.util = OpTestUtil()
         self.bmc_type = self.conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation, --os-repo is missing")

--- a/testcases/InstallRhel.py
+++ b/testcases/InstallRhel.py
@@ -29,7 +29,6 @@ import unittest
 import os
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common import OpTestInstallUtil
 
@@ -41,7 +40,6 @@ class InstallRhel(unittest.TestCase):
         self.cv_IPMI = self.conf.ipmi()
         self.cv_SYSTEM = self.conf.system()
         self.cv_BMC = self.conf.bmc()
-        self.util = OpTestUtil()
         self.bmc_type = self.conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation, --os-repo is missing")

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -34,7 +34,6 @@ import pexpect
 import os
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common import OpTestInstallUtil
 
@@ -46,7 +45,6 @@ class MyIPfromHost(unittest.TestCase):
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
         self.cv_BMC = conf.bmc()
-        self.util = OpTestUtil()
 
     def runTest(self):
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
@@ -63,7 +61,6 @@ class InstallUbuntu(unittest.TestCase):
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
         self.cv_BMC = conf.bmc()
-        self.util = OpTestUtil()
         self.bmc_type = conf.args.bmc_type
         if not (self.conf.args.os_repo or self.conf.args.os_cdrom):
             self.fail("Provide installation media for installation with --os-repo or --os-cdrom")

--- a/testcases/OpTestEEH.py
+++ b/testcases/OpTestEEH.py
@@ -44,7 +44,6 @@ import os
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 
@@ -97,7 +96,6 @@ class OpTestEEH(unittest.TestCase):
         cls.cv_HOST = conf.host()
         cls.cv_IPMI = conf.ipmi()
         cls.cv_SYSTEM = conf.system()
-        cls.util = OpTestUtil()
         # By default test will run on all PHBs/PE's, if one want to skip certain ones mention in this format.
         cls.skip_phbs = [] # ['PCI0001', 'PCI0002', 'PCI0003', 'PCI0004', 'PCI0005', 'PCI0030', 'PCI0031', 'PCI0032']
         cls.skip_pes = [] # ['0002:00:00.0']

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -45,7 +45,6 @@ import decimal
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 from common.OpTestIPMI import IPMIConsoleState
@@ -62,7 +61,6 @@ class OpTestEM():
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
         self.ppc64cpu_freq_re = re.compile(r"([a-z]+):\s+([\d.]+)")
         self.c = None # use this for tearDown
 

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -43,7 +43,6 @@ import sys
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
@@ -54,7 +53,7 @@ class OpTestEnergyScale(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
+        self.util = conf.util
         self.cv_PLATFORM = conf.platform()
 
     def run_ipmi_cmd(self, i_cmd):

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -50,7 +50,6 @@ import unittest
 import tarfile
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
@@ -70,7 +69,7 @@ class OpTestFlashBase(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.platform = conf.platform()
-        self.util = OpTestUtil()
+        self.util = conf.util
         self.OpIU = OpTestInstallUtil.InstallUtil()
         self.bmc_type = conf.args.bmc_type
         self.bmc_ip = conf.args.bmc_ip

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -48,7 +48,6 @@ import pexpect
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestSSH import ConsoleState as SSHConnectionState
 from common.OpTestIPMI import IPMIConsoleState
@@ -68,7 +67,7 @@ class OpTestHMIHandling(unittest.TestCase):
         cls.cv_FSP = conf.bmc()
         cls.cv_SYSTEM = conf.system()
         cls.bmc_type = conf.args.bmc_type
-        cls.util = OpTestUtil()
+        cls.util = conf.util
 
     def setUp(self):
         if self.cv_SYSTEM.get_state() == OpSystemState.UNKNOWN_BAD:

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -46,7 +46,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 
 import logging
@@ -76,7 +75,6 @@ class OpTestIPMILockMode(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
         self.platform = conf.platform()
 
     def runTest(self):

--- a/testcases/OpTestIPMIReprovision.py
+++ b/testcases/OpTestIPMIReprovision.py
@@ -45,7 +45,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 
 class OpTestIPMIReprovision(unittest.TestCase):
@@ -54,7 +53,6 @@ class OpTestIPMIReprovision(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
         self.platform = conf.platform()
 
 class NVRAM(OpTestIPMIReprovision):

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -47,7 +47,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestIPMI import IPMIConsoleState
 from common.Exceptions import CommandFailed
@@ -73,7 +72,6 @@ class OpTestInbandIPMIBase(object):
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
         self.cv_BMC = conf.bmc()
-        self.util = OpTestUtil()
         if (isinstance(self.cv_BMC, OpTestMambo.OpTestMambo)):
             raise unittest.SkipTest("Mambo so skipping InbandIPMI tests")
 

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -50,7 +50,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from testcases.OpTestInbandIPMI import BasicInbandIPMI, OpTestInbandIPMI, ExperimentalInbandIPMI
 from testcases.OpTestInbandIPMI import SkirootBasicInbandIPMI, SkirootFullInbandIPMI

--- a/testcases/OpTestNVRAM.py
+++ b/testcases/OpTestNVRAM.py
@@ -45,7 +45,6 @@ import os.path
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
@@ -69,7 +68,6 @@ class OpTestNVRAM(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
 
     def nvram_update_part_config(self, i_part, key='test-cfg', value='test-value'):
         part = i_part

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -43,7 +43,6 @@ import os.path
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
@@ -58,7 +57,6 @@ class OpTestPNOR():
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.util = OpTestUtil()
 
     def pflashErase(self, offset, length):
         self.c.run_command("pflash -e -f -a %d -s %d" % (offset,length))

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -42,7 +42,6 @@ import re
 import unittest
 
 import OpTestConfiguration
-from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 
@@ -58,7 +57,6 @@ class FullRTC(unittest.TestCase):
         cls.cv_HOST = conf.host()
         cls.cv_IPMI = conf.ipmi()
         cls.cv_SYSTEM = conf.system()
-        cls.util = OpTestUtil()
         cls.test = None
 
     def setUp(self):

--- a/testcases/fspTODCorruption.py
+++ b/testcases/fspTODCorruption.py
@@ -55,7 +55,6 @@ class fspTODCorruption():
         self.cv_SYSTEM = conf.system()
         self.cv_FSP = self.cv_SYSTEM.bmc
         self.cv_HOST = conf.host()
-        self.util = self.cv_SYSTEM.util
         self.bmc_type = conf.args.bmc_type
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
 


### PR DESCRIPTION
Remove unused util parms and various cleanup.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>