### PR TITLE
InstallHost: Unexpected configuration

### DIFF
--- a/op-test
+++ b/op-test
@@ -532,7 +532,10 @@ class InstallHost():
                 conf.util.cleanup()
                 exit(-1)
         else:
-            optestlog.info("Missing parameters for InstallHost suite")
+            optestlog.info("Missing parameters for InstallHost suite, if this"
+                " is unexpected, check AES/Hostlocker for Attached Disk."
+                " This was triggered with host_scratch_disk={} target={}"
+                .format(conf.args.host_scratch_disk, target))
             conf.util.cleanup()
             exit(-1)
 


### PR DESCRIPTION
AES/Hostlocker providing default values for credentials and other
parameters can trigger unexpected workflows.

Clarify the message to help the user determine what to adjust to make
the tests work.

During op-test suite setup the InstallHost class triggers the flow.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>