### PR TITLE
op-test: Add test suites for per-commit and pull-request

### DIFF
--- a/op-test
+++ b/op-test
@@ -613,6 +613,28 @@ class OpenBMCPalmettoSkirootSuite():
     def suite(self):
         return self.s
 
+class OpTestPerCommitSuite():
+    '''Simple Suite to run for CI on per-commit basis'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(OpTestExample.skiroot_full_suite())
+        self.s.addTest(OpTestExample.host_full_suite())
+        self.s.addTest(SystemLogin.system_access_suite())
+
+    def suite(self):
+        return self.s
+
+class OpTestPullRequestSuite():
+    '''Simple Suite to run for CI on pull-request basis'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(OpTestExample.skiroot_full_suite())
+        self.s.addTest(OpTestExample.host_full_suite())
+        self.s.addTest(SystemLogin.system_access_suite())
+
+    def suite(self):
+        return self.s
+
 suites = {
     'system-access' : SystemAccessSuite(),
     'skiroot' : SkirootSuite(),
@@ -648,6 +670,8 @@ suites = {
     'hostboot' : OpTestHostbootSuite(),
     'example' : OpTestExampleSuite(),
     'palmetto-ci' : OpenBMCPalmettoSkirootSuite(),
+    'per-commit' : OpTestPerCommitSuite(),
+    'pull-request' : OpTestPullRequestSuite(),
 }
 
 try:


### PR DESCRIPTION
Add test suites which identify tests to be run on a per-commit
or pull-request basis.

Idea being that the CI will run the desired suite and as the
content of the suite needs to be updated that can be done
without changing the externals for the CI jobs.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>