### PR TITLE
Bmc reboot then host reboot

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -940,19 +940,6 @@ class OpTestSystem(object):
 
         return output
 
-    def sys_bmc_reboot(self):
-        '''
-        Reboot the BMC
-
-        This may use ``ipmitool mc reset cold`` or it may do an inline ``reboot``
-        '''
-        try:
-            rc = self.cv_BMC.reboot()
-        except OpTestError as e:
-            return BMC_CONST.FW_FAILED
-
-        return BMC_CONST.FW_SUCCESS
-
     ##
     # @brief Validates the partition and waits for partition to connect
     #        important to perform before all inband communications

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -177,6 +177,7 @@ class OutOfBandWarmReset(BasicIPL):
         self.cv_SYSTEM.sys_warm_reset()
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
         self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT)
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
         log.debug("IPL: OutOfBandWarmReset test completed")
 
 
@@ -217,6 +218,7 @@ def suite():
     suite.addTest(BMCReset())
     suite.addTest(BootToOS())
     suite.addTest(OutOfBandWarmReset())
+    suite.addTest(BMCResetThenRebootHost())
     suite.addTest(HardPowerCycle())
     suite.addTest(PowerOff())
     return suite

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -127,6 +127,25 @@ class BMCReset(BasicIPL):
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
         log.debug("IPL: BMCReset test completed")
 
+class BMCResetThenRebootHost(BasicIPL):
+    """
+    Reboot the BMC with the host on and once the BMC is back, reboot
+    the host.
+    """
+    def runTest(self):
+        self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        self.cv_BMC.reboot()
+        console = self.cv_SYSTEM.console
+        console.run_command_ignore_fail("dmesg -r|grep '<[4321]>'")
+        console.run_command_ignore_fail(
+            "grep ',[0-4]\]' /sys/firmware/opal/msglog")
+        console.pty.sendline("reboot")
+        self.cv_SYSTEM.set_state(OpSystemState.IPLing)
+        try:
+            self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        except pexpect.EOF:
+            self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+            self.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
 class BootToOS(BasicIPL):
     '''


### PR DESCRIPTION
With HIOMAP we had a bug where things would go poorly if you rebooted the BMC and then rebooted the host.

So, let's add a test.