### PR TITLE
Add support for dracut detection during boot

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -123,6 +123,7 @@ class OpTestSystem(object):
           'x=exit'                                 : None,
           'login: '                                : self.login_callback,
           'mon> '                                  : self.xmon_callback,
+          'dracut:/#'                              : self.dracut_callback,
           'System shutting down with error status' : self.guard_callback,
           'Aborting!'                              : self.skiboot_callback,
         }
@@ -131,6 +132,7 @@ class OpTestSystem(object):
           'login: '                           : None,
           '/ #'                               : self.petitboot_callback,
           'mon> '                             : self.xmon_callback,
+          'dracut:/#'                         : self.dracut_callback,
         }
 
         # tunables for customizations, put them here all together
@@ -266,6 +268,18 @@ class OpTestSystem(object):
         xmon_exception = UnexpectedCase(state=self.state, message=my_msg)
         self.state = OpSystemState.UNKNOWN_BAD
         raise xmon_exception
+
+    def dracut_callback(self, **kwargs):
+        default_vals = {'my_r': None, 'value': None}
+        for key in default_vals:
+            if key not in kwargs.keys():
+                kwargs[key] = default_vals[key]
+        self.state = OpSystemState.UNKNOWN_BAD
+        self.stop = 1
+        msg = ("We hit the dracut_callback value={}, "
+               "manually restart the system\n".format(kwargs['value']))
+        dracut_exception = UnexpectedCase(state=self.state, message=msg)
+        raise dracut_exception
 
     def skiboot_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -274,6 +274,11 @@ class OpTestSystem(object):
         for key in default_vals:
             if key not in kwargs.keys():
                 kwargs[key] = default_vals[key]
+        try:
+            sys_pty = self.console.get_console()
+            sys_pty.sendline('cat /run/initramfs/rdsosreport.txt')
+        except Exception as err:
+            log.warning("Could not get dracut failure messages:\n %s", err)
         self.state = OpSystemState.UNKNOWN_BAD
         self.stop = 1
         msg = ("We hit the dracut_callback value={}, "


### PR DESCRIPTION
In some cases, kernel booting would drop down to
dracut console, this patch would detect that
state and properly errorout the testcase.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>