### PR TITLE
OpTestUtil: Filter firmware versions message

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -940,7 +940,9 @@ class OpTestUtil():
         return try_list, echo_rc
 
     def get_versions(self, term_obj, pty, expect_prompt):
-        check_list = ["No such file or directory"]
+        check_list = ["No such file or directory",
+                      "command not found",
+                     ]
         if term_obj.system.conf.firmware_versions is None:
             pty.sendline("date")
             rc = pty.expect([expect_prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)


### PR DESCRIPTION
When flashing firmware the bmc does not have lsprop to list
the firmware versions, so ignore command not found message
and display appropriate message.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>