### PR TITLE
Pull gcov data at end of skiroot and host test runs

### DIFF
--- a/op-test
+++ b/op-test
@@ -182,6 +182,7 @@ class SkirootSuite():
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(OpalSysfsTests.Skiroot))
         self.s.addTest(OpalMsglog.Skiroot())
         self.s.addTest(KernelLog.Skiroot())
+        self.s.addTest(gcov.Skiroot())
         self.s.addTest(DPO.DPOSkiroot())
 #        self.s.addTest(OpTestEnergyScale.runtime_suite())
     def suite(self):
@@ -256,6 +257,7 @@ class HostSuite():
         self.s.addTest(OpalMsglog.Host())
         self.s.addTest(KernelLog.Host())
         self.s.addTest(OpTestOCC.OCC_RESET())
+        self.s.addTest(gcov.Host())
     def suite(self):
         return self.s
 


### PR DESCRIPTION
This is an interim solution until we can do this magically by obvserving
a state transition request and going "oh, we need to pull gcov data".

But, this commit will pull into the test run log directory a dump of the
gcov data from skiboot for both the skiroot and host suites. With this
we can get a code coverage report of what code is being covered by
op-test.

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>