### PR TITLE
op-test: Add argv to debug logs

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -476,6 +476,9 @@ class OpTestConfiguration():
         self.signal_ready = True
         # atexit viable for cleanup to run
         self.atexit_ready = True
+        # now that we have loggers, dump conf file to help debug later
+        OpTestLogger.optest_logger_glob.optest_logger.debug(
+            "conf file defaults={}".format(defaults))
         # setup AES and Hostlocker configs after the logging is setup
         locker_timeout = time.time() + 60*self.args.locker_wait
         locker_code = errno.ETIME # 62

--- a/op-test
+++ b/op-test
@@ -716,6 +716,7 @@ def run_tests(t, failfast):
 
 try:
     res = None
+    optestlog.debug("op-test argv={}".format(sys.argv))
 
     if not OpTestConfiguration.conf.args.noflash:
         if any(s in OpTestConfiguration.conf.args.bmc_type for s in ("QEMU", "qemu")):


### PR DESCRIPTION
Add the args to the debug log to aide in problem determination.

Additionally dump the conf file to debug log as well for later use.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>