### PR TITLE
README: Remove old xmlrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ You need python 2.7 or greater and also needs below modules to be installed
 
     pip install pexpect importlib ptyprocess requests pysocks
 
-    Optionally:  pip install unittest-xml-reporting unittest2 xmlrunner
+    Optionally:  pip install unittest-xml-reporting unittest2
+    For XML output: sudo apt-get install python-xmlrunner
 
 You will also need below packages to be installed
 


### PR DESCRIPTION
Found a bug in the pip install xmlrunner where failures were being
reported as errors.

While investigating where to submit the fix it seems that
unittest-xml-reporting is the proper python package
which properly reflects failures and errors.

To document the problem found if installed the pip xmlrunner:

line 184 /usr/lib/python2.7/site-packages/xmlrunner/xmlrunner.py
        testinfo = _TestInfo(self, test, _TestInfo.ERROR, err)
        self.errors.append((

should be:
        testinfo = _TestInfo(self, test, _TestInfo.FAILURE, err)
        self.failures.append((

So we update op-test README to only suggest unittest-xml-reporting

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>