### PR TITLE
OpTestUtil: Generalize the lsprop filtering

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -941,7 +941,7 @@ class OpTestUtil():
 
     def get_versions(self, term_obj, pty, expect_prompt):
         check_list = ["No such file or directory",
-                      "command not found",
+                      "not found",
                      ]
         if term_obj.system.conf.firmware_versions is None:
             pty.sendline("date")


### PR DESCRIPTION
When flashing systems with limited shell we get various
messages, so make the filter more generic to catch more variations.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>