### PR TITLE
OpTestInbandIPMI: Log failure info to debug logs

### DIFF
--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -307,7 +307,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
             try:
                 self.run_ipmi_cmds(c, [self.ipmi_method + "fru print %d" % fru_id])
             except CommandFailed as cf:
-                print("FRU {} failed: {} {}".format(fru_id, cf.exitcode, cf.output))
+                log.debug("FRU {} failed: {} {}".format(fru_id, cf.exitcode, cf.output))
                 if cf.exitcode in [1, -1]:
                     nr_sequential_fail = nr_sequential_fail + 1
                     continue


### PR DESCRIPTION
When printing directly to stdout, the XML runner will capture the stdout
cumulatively and this shows up in all subsequent XML files which may appear
odd to the consumer looking at non-related XML files.

This info can also appear as noise in other stdout captures.

/usr/local/lib/python2.7/dist-packages/xmlrunner/result.py
line 276 _save_output_data

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>