### PR TITLE
OpTestSystem: Reduce kill_cord ceiling

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -163,7 +163,7 @@ class OpTestSystem(object):
         self.ipl_timeout = 4 # needs consideration with petitboot timeout
         self.booting_watermark = 100
         self.booting_timeout = 5
-        self.kill_cord = 150 # just a ceiling on giving up
+        self.kill_cord = 102 # just a ceiling on giving up
 
         # We have a state machine for going in between states of the system
         # initially, everything in UNKNOWN, so we reset things.


### PR DESCRIPTION
Reduce the kill_cord ceiling to a reasonable time to allow tests
to stop when not being successful in booting.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>