### PR TITLE
qemu: Add BMC simulator to Qemu command line

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -129,6 +129,7 @@ class QemuConsole():
         cmd = ("%s" % (self.qemu_binary)
                + " -machine powernv -m 4G"
                + " -nographic -nodefaults"
+               + " -device ipmi-bmc-sim,id=bmc0 -device isa-ipmi-bt,bmc=bmc0,irq=10"
            )
         if self.pnor:
             cmd = cmd + " -drive file={},format=raw,if=mtd".format(self.pnor)


### PR DESCRIPTION
This enables skiboot to talk to a simulated BMC device, which lets it do
things such as cause the guest to exit when a shutdown occurs.

It's also required for skiboot as of commit 8340a9642bba ("plat/qemu:
use the common OpenPOWER routines to initialize").

Signed-off-by: Joel Stanley <joel@jms.id.au>