### PR TITLE
OpTestUtil: Exception handling

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1531,10 +1531,10 @@ class Server(object):
                     "r.request.headers={}"
                     .format(r.status_code, r.text,
                      r.headers, r.request.headers))
+            return r
         except Exception as e:
             log.debug("Requests post problem logging out"
                        " URL={} Exception={}".format(self._url(uri), e))
-        return r
 
     def get(self, **kwargs):
         kwargs['cmd'] = 'get'


### PR DESCRIPTION
Exception path on logout needs to not reference r.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>