### PR TITLE
Run qemu suite as part of travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 
 cache:
   apt: true
+  ccache: true
 
 git:
   depth: false
@@ -30,7 +31,10 @@ install:
 script:
   - python op-test --help
   - python op-test --bmc-type AMI --run testcases.HelloWorld
-  - cd doc/; make latexpdf html
+  - (cd doc/; make latexpdf html)
+  - ./ci/build-qemu-powernv.sh
+  - wget https://openpower.xyz/job/openpower/job/openpower-op-build/label=slave,target=palmetto/lastSuccessfulBuild/artifact/images/palmetto.pnor
+  - PATH=$(pwd)/qemu:$PATH ./op-test --bmc-type qemu --qemu-binary `pwd`/qemu/ppc64-softmmu/qemu-system-ppc64 --host-pnor palmetto.pnor --run-suite qemu
 
 deploy:
   provider: pages

--- a/ci/build-qemu-powernv.sh
+++ b/ci/build-qemu-powernv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+set -vx
+
+git clone --depth=1 -b qemu-powernv-for-skiboot-7 git://github.com/open-power/qemu.git
+cd qemu
+git submodule update --init dtc
+export CC="ccache gcc"
+export CXX="ccache g++"
+./configure --target-list=ppc64-softmmu --disable-werror
+make -j $(grep -c processor /proc/cpuinfo)

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -66,6 +66,8 @@ class OpalMsglog():
             filter_out.append('NVRAM: Failed to load')
             filter_out.append("FLASH: Can't load resource id:")
             filter_out.append('CAPP: Error loading ucode lid.')
+            # Palmetto qemu model hits this:
+            filter_out.append('STB: container NOT VERIFIED, resource_id=. secureboot not yet initialized')
 
         if self.bmc_type in ["mambo"]:
             filter_out.append('SBE: Master chip ID not found.')


### PR DESCRIPTION
Pulling palmetto.pnor from openpower.xyz, we can run the full qemu suite as part of travis-ci, and thus for our pull requests as well.