### PR TITLE
OpTestOpenBMC: Download dumps to logdir

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -473,7 +473,7 @@ class OpTestConfiguration():
 
         OpTestLogger.optest_logger_glob.setUpLoggerFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.main.log')
         OpTestLogger.optest_logger_glob.setUpLoggerDebugFile(datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.debug.log')
-        OpTestLogger.optest_logger_glob.optest_logger.info('TestCase Log files: {}/*{}*'.format(self.output, self.outsuffix))
+        OpTestLogger.optest_logger_glob.optest_logger.info('TestCase Log files: {}/*'.format(self.output))
         OpTestLogger.optest_logger_glob.optest_logger.info('StreamHandler setup {}'.format('quiet' if self.args.quiet else 'normal'))
 
         self.logfile_proc = subprocess.Popen(logcmd,

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -26,6 +26,7 @@ import subprocess
 import json
 import requests
 import cgi
+import os
 
 from OpTestSSH import OpTestSSH
 from OpTestBMC import OpTestBMC
@@ -662,7 +663,7 @@ class HostManagement():
         uri = "/download/dump/{}".format(dump_id)
         r = self.conf.util_bmc_server.get(uri=uri, stream=True, minutes=minutes)
         value, params = cgi.parse_header(r.headers.get('Content-Disposition'))
-        with open(params.get('filename'), 'wb') as f:
+        with open(os.path.join(self.conf.logdir, params.get('filename')), 'wb') as f:
             f.write(r.content)
 
     def delete_dump(self, dump_id, minutes=BMC_CONST.HTTP_RETRY):


### PR DESCRIPTION
Download the openbmc dumps to logdir to allow for running
--run testcases.testRestAPI.HostOff.test_obmc_download_dumps
(possibly as an additional component of automation).

Additional issue opened on openbmc:

BMC Capture journal ->
https://github.com/openbmc/phosphor-debug-collector/issues/6

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>