### PR TITLE
op-test: Provide helpful info when suite not found

### DIFF
--- a/op-test
+++ b/op-test
@@ -677,7 +677,13 @@ try:
 
     if OpTestConfiguration.conf.args.run_suite:
         for suite in OpTestConfiguration.conf.args.run_suite:
-            t.addTest(suites[suite].suite())
+            try:
+                t.addTest(suites[suite].suite())
+            except Exception as e:
+                optestlog.error("We encountered a problem adding suite={},"
+                    " see if its a valid suite name and retry"
+                    .format(suite))
+                raise e
 
     if OpTestConfiguration.conf.args.run:
         t.addTest(unittest.TestLoader().loadTestsFromNames(OpTestConfiguration.conf.args.run))


### PR DESCRIPTION
When an unknown suite name is input, provide log traces available
to help determine the issue.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>