### PR TITLE
BasicIPL: import pexpect for EOF

### DIFF
--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -28,6 +28,7 @@ a specific state.
 '''
 
 import unittest
+import pexpect
 
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState


### PR DESCRIPTION
When EOF encountered we need the pexpect imports.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>