### PR TITLE
OpTestConfiguration: logfile abstraction cleanup

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -581,6 +581,7 @@ class OpTestConfiguration():
                           self.output,
                           scratch_disk=self.args.host_scratch_disk,
                           proxy=self.args.proxy,
+                          logfile=self.logfile,
                           check_ssh_keys=self.args.check_ssh_keys,
                           known_hosts_file=self.args.known_hosts_file,
                           conf=self)

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -175,6 +175,7 @@ def set_system_to_UNKNOWN_BAD(system):
 class IPMIConsole():
     def __init__(self, ipmitool=None, logfile=sys.stdout, prompt=None,
             block_setup_term=None, delaybeforesend=None):
+        self.logfile = logfile
         self.ipmitool = ipmitool
         self.state = IPMIConsoleState.DISCONNECTED
         self.delaybeforesend = delaybeforesend
@@ -255,6 +256,7 @@ class IPMIConsole():
         cmd = self.ipmitool.binary_name() + self.ipmitool.arguments() + ' sol activate'
         try:
           self.pty = OPexpect.spawn(cmd,
+                                  logfile=self.logfile,
                                   failure_callback=set_system_to_UNKNOWN_BAD,
                                   failure_callback_data=self.system)
         except Exception as e:
@@ -334,6 +336,7 @@ class OpTestIPMI():
                                username=i_bmcUser,
                                password=i_bmcPwd)
         self.console = IPMIConsole(ipmitool=self.ipmitool,
+                                   logfile=self.logfile,
                                    delaybeforesend=delaybeforesend)
         # OpTestUtil instance is NOT conf's
         self.util = OpTestUtil()

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -940,6 +940,7 @@ class OpTestOpenBMC():
         self.bmc = OpTestBMC(ip=self.hostname,
                             username=self.username,
                             password=self.password,
+                            logfile=self.logfile,
                             check_ssh_keys=check_ssh_keys,
                             known_hosts_file=known_hosts_file)
 

--- a/op-test
+++ b/op-test
@@ -751,6 +751,7 @@ def run_tests(t, failfast):
         kwargs.update({
                 'output': OpTestConfiguration.conf.output,
                 'outsuffix': OpTestConfiguration.conf.outsuffix,
+                'stream': OpTestConfiguration.conf.logfile,
             })
 
         # xmlrunner pre v1.13 doesn't support failfast


### PR DESCRIPTION
Cleanup a few places where the logfile abstraction parameters need
to be filtered to the various classes to have the logs capture as
appropriate.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>