### PR TITLE
Install OS: Look for 'Starting new kernel' for kexec occuring

### DIFF
--- a/testcases/InstallRhel.py
+++ b/testcases/InstallRhel.py
@@ -109,7 +109,8 @@ class InstallRhel(unittest.TestCase):
         else:
             pass
         # Do things
-        raw_pty.expect('Sent SIGKILL to all processes', timeout=60)
+        raw_pty.expect(['Sent SIGKILL to all processes','Starting new kernel'],
+                       timeout=60)
         r = None
         while r != 0:
             r = raw_pty.expect(['Running post-installation scripts',

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -181,7 +181,8 @@ class InstallUbuntu(unittest.TestCase):
             raw_pty.sendline("kexec -e")
 
         # Do things
-        raw_pty.expect('Sent SIGKILL to all processes', timeout=60)
+        raw_pty.expect(['Sent SIGKILL to all processes','Starting new kernel'],
+                       timeout=60)
         r = raw_pty.expect(['Loading additional components','Configure the keyboard'], timeout=300)
         if r == 1:
             print("# Preseed isn't perfect when it comes to keyboard selection. Urgh")


### PR DESCRIPTION
Since op-build 61d9a2ee4af05e139d57bbb848ef9bdceac5d58e we won't get
the 'Sent SIGKILL to all processes' message on the console. So, we
should look for the sign that kexec is doing something as well.

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>