### PR TITLE
rhel.ks: add `--ignoremissing` avoid interruption if packages are missing

### DIFF
--- a/osimages/rhel/rhel.ks
+++ b/osimages/rhel/rhel.ks
@@ -14,7 +14,7 @@ ignoredisk --only-use={}
 autopart --type=lvm --fstype=ext4
 services --enabled=NetworkManager,sshd
 reboot
-%packages
+%packages --ignoremissing
 @core
 kexec-tools
 telnet


### PR DESCRIPTION
automated installation gets interrupted if packages are not available
and asks for user input, instead continue the installation.

```
The following packages are missing,
packages name
;; ;;

Would you like to ignore this and continue with installation? Please respond 'yes' or 'no':

```

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>