### PR TITLE
Fix thread monitoring in RunHostTest

### DIFF
--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -32,7 +32,7 @@ import os
 
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
-from common.OpTestThread import OpSOLMonitorThread
+from common.OpTestSOL import OpSOLMonitorThread
 
 
 class RunHostTest(unittest.TestCase):


### PR DESCRIPTION
Patch fixes a recent change in SOL thread monitor causing an error for starting a thread

Signed-off-by: Harish <harish@linux.vnet.ibm.com>