### PR TITLE
OpTestSOL: remove the argument `logger` passed to get_console()

### DIFF
--- a/common/OpTestSOL.py
+++ b/common/OpTestSOL.py
@@ -59,7 +59,7 @@ class OpSOLMonitorThread(threading.Thread):
         self.system.goto_state(OpSystemState.OS)
         logfile = os.path.join(conf.output, "console.log")
         self.sol_logger(logfile)
-        self.c = self.system.console.get_console(logger=self.logger)
+        self.c = self.system.console.get_console()
         self.c_terminate = False;
 
     def run(self):


### PR DESCRIPTION
get_console() of OpTestSSH.py, doesn't have the `logger` argument
and we would hit,

TypeError: get_console() got an unexpected keyword argument \'logger\'\n')

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>