### PR TITLE
OpTestInbandIPMI: Disable dcmi power reading

### DIFF
--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -95,7 +95,7 @@ class OpTestInbandIPMIBase(object):
         '''
         try:
             for cmd in cmds:
-                c.run_command(cmd)
+                c.run_command(cmd, timeout=120)
         except CommandFailed as cf:
             my_responses = ["Invalid command",
                             "Error loading interface usb"]
@@ -567,8 +567,11 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
         c = self.set_up()
         try:
             self.run_ipmi_cmds(c, [self.ipmi_method + BMC_CONST.IPMI_DCMI_DISCOVER,
-                                   self.ipmi_method + BMC_CONST.IPMI_DCMI_POWER_READING,
-                                   self.ipmi_method + BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT,
+                                   # disable for now, unreliable at best
+                                   # self.ipmi_method + BMC_CONST.IPMI_DCMI_POWER_READING,
+                                   # opened ipmitool inband issue for dcmi get_limit
+                                   # https://github.com/open-power/boston-openpower/issues/1396
+                                   # self.ipmi_method + BMC_CONST.IPMI_DCMI_POWER_GET_LIMIT,
                                    self.ipmi_method + BMC_CONST.IPMI_DCMI_GET_MC_ID_STRING,
                                    self.ipmi_method + BMC_CONST.IPMI_DCMI_GET_TEMP_READING,
                                    self.ipmi_method + BMC_CONST.IPMI_DCMI_GET_CONF_PARAM,


### PR DESCRIPTION
Disable for now some dcmi commands, unreliable at best.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>