### PR TITLE
gcov: Skip test if not a gcov build

### DIFF
--- a/testcases/gcov.py
+++ b/testcases/gcov.py
@@ -35,6 +35,10 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 from common import OpTestInstallUtil
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 NR_GCOV_DUMPS = 0
 
 class gcov():
@@ -58,8 +62,12 @@ class gcov():
 
     def runTest(self):
         self.setup_test()
-        exports = self.c.run_command(
-            "ls -1 --color=never /sys/firmware/opal/exports/")
+	try:
+            exports = self.c.run_command(
+                "ls -1 --color=never /sys/firmware/opal/exports/")
+	except CommandFailed as cf:
+	    log.debug("exports cf.output={}".format(cf.output))
+	    exports = "EMPTY"
         if 'gcov' not in exports:
             self.skipTest("Not a GCOV build")
 


### PR DESCRIPTION
Skip the testcase which helps construct code coverage reports
if skiboot is NOT built with GCOV enabled.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>