### PR TITLE
op-test: Remove HMIHandling temporarily

### DIFF
--- a/op-test
+++ b/op-test
@@ -264,7 +264,8 @@ class HostSuite():
 #        self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(OpalSysfsTests.Host))
         #disabling temporarily
 #        self.s.addTest(KernelLog.Host()) # We run before HMI to clear out HMI errors from kernel log
-        self.s.addTest(OpTestHMIHandling.suite())
+        # Skip HMIHandling for now, opal-gard clear all forces interactive
+#        self.s.addTest(OpTestHMIHandling.suite())
         self.s.addTest(OpTestPNOR.Host())
         # disabling temporarily
 #        self.s.addTest(OpalMsglog.Host())


### PR DESCRIPTION
Remove the OpTestHMIHandling temporarily to stablize running
default test suite.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>