### PR TITLE
OpTestUtil: Add log location at end of run

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -285,6 +285,7 @@ class OpTestUtil():
           self.dump_versions()
 
     def dump_versions(self):
+        log.info("Log Location: {}/*debug*".format(self.conf.output))
         log.info("\n----------------------------------------------------------\n"
                  "OpTestSystem Firmware Versions Tested\n"
                  "(if flashed things like skiboot.lid, may not be accurate)\n"


### PR DESCRIPTION
Add the log location at the end of the op-test run so its helpful
to know which directory the current run is dumping logs,
especially helpful if running multiple sessions with long output.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>