### PR TITLE
OpTestSystem: Recover lost sys_pty

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -907,6 +907,9 @@ class OpTestUtil():
           pty.sendcontrol('c')
           time.sleep(1)
           try_rc = pty.expect([".*#", "Petitboot", "login: ", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+          log.debug("try_rc={}".format(try_rc))
+          log.debug("pty.before={}".format(pty.before))
+          log.debug("pty.after={}".format(pty.after))
           if try_rc in [0,1,2]:
             log.warning("OpTestSystem recovered from temporary issue, continuing")
             return


### PR DESCRIPTION
When we are unable to properly search the pty buffer for expected
strings, we perform a recovery path.  When this recovery path
is performed we need to get a new console object to properly
continue operations.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>