### PR TITLE
OpTestSystem: Aide PTY tracing

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -108,6 +108,7 @@ class OpTestSSH():
             self.pty.send("\r")
             self.pty.send('~.')
             close_rc = self.pty.expect([pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+            log.debug("CLOSE Expect Buffer ID={}".format(hex(id(self.pty))))
             rc_child = self.pty.close()
             exitCode = signalstatus = None
             if self.pty.status != -1: # leaving here for debug
@@ -173,6 +174,7 @@ class OpTestSSH():
         self.pty.logfile_read = OpTestLogger.FileLikeLogger(self.log)
         time.sleep(2) # delay here in case messages like afstokenpassing unsupported show up which mess up setup_term
         self.check_set_term()
+        log.debug("CONNECT starts Expect Buffer ID={}".format(hex(id(self.pty))))
         return self.pty
 
     def check_set_term(self):

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -532,11 +532,12 @@ class OpTestSystem(object):
               x += 1
               log.debug("\n *** WaitForIt CURRENT STATE \"{:02}\" TARGET STATE \"{:02}\"\n"
                       " *** WaitForIt working on transition\n"
+                      " *** Expect Buffer ID={}\n"
                       " *** Current loop iteration \"{:02}\"             - Reconnect attempts \"{:02}\" - loop_max \"{:02}\"\n"
                       " *** WaitForIt timeout interval \"{:02}\" seconds - Stale buffer check every \"{:02}\" times\n"
                       " *** WaitForIt variables \"{}\"\n"
                       " *** WaitForIt Refresh=\"{}\" Buffer Kicker=\"{}\" - Kill Cord=\"{:02}\"\n".format(self.state, self.target_state,
-                      x, reconnect_count, kwargs['loop_max'], kwargs['timeout'], kwargs['threshold'],
+                      hex(id(sys_pty)), x, reconnect_count, kwargs['loop_max'], kwargs['timeout'], kwargs['threshold'],
                       sorted(kwargs['expect_dict'].keys()), kwargs['refresh'], kwargs['buffer_kicker'], self.kill_cord))
             if (x >= kwargs['loop_max']):
               if kwargs['last_try']:
@@ -1090,6 +1091,7 @@ class OpTestSystem(object):
 
     def petitboot_exit_to_shell(self):
         sys_pty = self.console.get_console()
+        log.debug("USING PES Expect Buffer ID={}".format(hex(id(sys_pty))))
         for i in range(3):
           pp = self.get_petitboot_prompt()
           if pp == 1:
@@ -1102,6 +1104,7 @@ class OpTestSystem(object):
     def get_petitboot_prompt(self):
         my_pp = 0
         sys_pty = self.console.get_console()
+        log.debug("USING GPP Expect Buffer ID={}".format(hex(id(sys_pty))))
         sys_pty.sendline()
         pes_rc = sys_pty.expect([".*#", ".*# $", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
         if pes_rc in [0,1]:
@@ -1116,6 +1119,7 @@ class OpTestSystem(object):
 
     def exit_petitboot_shell(self):
         sys_pty = self.console.get_console()
+        log.debug("USING EPS 1 Expect Buffer ID={}".format(hex(id(sys_pty))))
         eps_rc = self.try_exit(sys_pty)
         if eps_rc == 0: # Petitboot
           return
@@ -1125,6 +1129,7 @@ class OpTestSystem(object):
               # if we get back here we're good and at the prompt
               # but we lost our sys_pty, so get a new one
               sys_pty = self.console.get_console()
+              log.debug("USING EPS 2 Expect Buffer ID={}".format(hex(id(sys_pty))))
               sys_pty.sendline()
               eps_rc = self.try_exit(sys_pty)
               if eps_rc == 0: # Petitboot
@@ -1138,6 +1143,7 @@ class OpTestSystem(object):
 
     def try_exit(self, sys_pty):
           self.util.clear_state(self)
+          log.debug("USING TE Expect Buffer ID={}".format(hex(id(sys_pty))))
           sys_pty.sendline()
           sys_pty.sendline("exit")
           rc_return = sys_pty.expect(["Petitboot", pexpect.TIMEOUT, pexpect.EOF], timeout=10)

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -905,6 +905,7 @@ class OpTestUtil():
         for i in range(counter):
           log.warning("OpTestSystem detected something, working on recovery")
           pty = term_obj.connect()
+          log.debug("USING TR Expect Buffer ID={}".format(hex(id(pty))))
           pty.sendcontrol('c')
           time.sleep(1)
           try_rc = pty.expect([".*#", "Petitboot", "login: ", pexpect.TIMEOUT, pexpect.EOF], timeout=10)
@@ -922,6 +923,7 @@ class OpTestUtil():
 
     def try_sendcontrol(self, term_obj, command, counter=3):
         pty = term_obj.get_console()
+        log.debug("USING TSC Expect Buffer ID={}".format(hex(id(pty))))
         res = pty.before
         log.warning("OpTestSystem detected something, working on recovery")
         pty.sendcontrol('c')


### PR DESCRIPTION
Add some debug tracing to aide during problem determination
for pexpect pty buffer management.

When the pty object gets closed, dies, or some other state that
renders the pty object not usable, then the old pty buffer and sockets
get closed and any data waiting or pending on the old socket is lost.

A new pty object is created (new pexpect spawn of pty process, etc)
and this new process and new buffer are empty upon creation.

Until new data arrives on this new pty object buffer there is nothing
to be read.  The application writer (you!) will need to either kick
something in the new buffer or know that some future action will
pipe data to the new socket so that things are not hung (timing issues
can make this unpredictable), so its best that an explicit action
occurs, e.g. sendline "date".  This methodology requires that
you are at a predictable location and predictable reactions
can occur.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>