### PR TITLE
Add check for root in get_sudo(), and some cleanups

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1156,8 +1156,15 @@ class OpTestUtil():
         if term_obj.setup_term_disable == 1:
           return -1, -1
         pty.sendline()
-        expect_prompt = prompt + "$"
-        my_user = host.username()
+
+        try:
+            # If we logged in as root or we're in the Petitboot shell we may
+            # already be root.
+            self.check_root(pty, prompt)
+            return 1, 1
+        except:
+            pass
+
         my_pwd = host.password()
         pty.sendline("which sudo && sudo -s")
         rc = pty.expect([r"[Pp]assword for", pexpect.TIMEOUT, pexpect.EOF], timeout=5)


### PR DESCRIPTION
Checks if we're already root in get_sudo() and exits early if so. This avoids issues with multiple sub-shells in Petitboot and otherwise shouldn't have an effect since the prompt should already be set up.

Probably a good idea to merge after the Skiboot v6.2.x branch receives the required backport for QEMU CI to run to make sure I haven't found a new corner case :)