### PR TITLE
OpTestPNOR: Add retry

### DIFF
--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -189,8 +189,9 @@ class OpTestPNOR():
         if not self.cv_SYSTEM.has_mtd_pnor_access():
             self.skipTest("Host doesn't have MTD PNOR access")
 
-        self.c.run_command("uname -a")
-        self.c.run_command("cat /etc/os-release")
+        # retry in case this comes after a hung console recovery
+        self.c.run_command("uname -a", retry=5)
+        self.c.run_command("cat /etc/os-release", retry=5)
 
         # Read Erase Write NVRAM
         self.runTestReadEraseWriteNVRAM()


### PR DESCRIPTION
Add a retry for commands in case SOL connections (typically) may
encounter some glitches.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>