### PR TITLE
Add FastRebootHostStressTorture: test fast-reboot while host is stressed

### DIFF
--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -522,7 +522,7 @@ class ThreadedHTTPHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                     packages+= "libvirt-dev numactl libosinfo-1.0-0 python-pip "
                     packages+= "linux-tools-common linux-tools-generic lm-sensors "
                     packages+= "ipmitool i2c-tools pciutils opal-prd opal-utils "
-                    packages+= "device-tree-compiler fwts"
+                    packages+= "device-tree-compiler fwts stress"
 
                     ps = d.format("openpower", "example.com",
                                   PROXY, PASSWORD, PASSWORD, user, PASSWORD, PASSWORD, DISK, packages)


### PR DESCRIPTION
There's been some reports of some issues with SRESET on POWER8 while the
host is under load.

This is an attempt to test for any such problem by using the 'stress'
utility to produce some workload on the host and then do fast reboot.

Currently this appears to work okay on POWER8, so work on locating the
bug is ongoing.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>