### PR TITLE
OpTestQemu: Cleanup temp disk file

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -239,6 +239,7 @@ def get_parser():
     hostgroup.add_argument("--host-password", help="SSH password for Host")
     hostgroup.add_argument("--host-lspci", help="Known 'lspci -n -m' for host")
     hostgroup.add_argument("--host-scratch-disk", help="A block device we can erase", default="")
+    hostgroup.add_argument("--qemu-scratch-disk", help="A block device for qemu", default=None)
     hostgroup.add_argument("--host-prompt", default="#",
                            help="Prompt for Host SSH session")
 
@@ -687,14 +688,14 @@ class OpTestConfiguration():
                 bmc.set_system(self.op_system)
             elif self.args.bmc_type in ['qemu']:
                 print(repr(self.args))
-                bmc = OpTestQemu(qemu_binary=self.args.qemu_binary,
+                bmc = OpTestQemu(conf=self,
+                             qemu_binary=self.args.qemu_binary,
                              pnor=self.args.host_pnor,
                              skiboot=self.args.flash_skiboot,
                              kernel=self.args.flash_kernel,
                              initramfs=self.args.flash_initramfs,
                              cdrom=self.args.os_cdrom,
-                             logfile=self.logfile,
-                             hda=self.args.host_scratch_disk)
+                             logfile=self.logfile)
                 self.op_system = common.OpTestSystem.OpTestQemuSystem(host=host,
                     bmc=bmc,
                     state=self.startState,

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -285,6 +285,20 @@ class OpTestUtil():
           self.conf.dump = False # possible for multiple passes here
           self.dump_versions()
 
+        # leave closing the qemu scratch disk until last
+        # no known reasons at this point, document in future
+        try:
+            log.debug("self.conf.args.qemu_scratch_disk={}"
+                      .format(self.conf.args.qemu_scratch_disk))
+            if self.conf.args.qemu_scratch_disk is not None:
+                self.conf.args.qemu_scratch_disk.close()
+                log.debug("Successfully closed qemu_scratch_disk")
+                self.conf.args.qemu_scratch_disk = None # in case we pass here again
+        except Exception as e:
+            log.debug("self.conf.args.qemu_scratch_disk={} "
+                      "closing Exception={}"
+                      .format(self.conf.args.qemu_scratch_disk, e))
+
     def dump_versions(self):
         log.info("Log Location: {}/*debug*".format(self.conf.output))
         log.info("\n----------------------------------------------------------\n"


### PR DESCRIPTION
When exit path is via optest_handler (via a signal) we need to
cleanup the temp disk file created and/or opened.

Add the qemu_scratch_disk to the cleanup routine.

Add a new qemu_scratch_disk option (overloading the
host_scratch_disk does not allow for proper handling
since the Install* tests require other parameters) and
we need the temp or consumer provided qemu_scratch_disk
to properly close.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>