### PR TITLE
OpTestHMIhandling: Fix the HMI handling for Power8

### DIFF
--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -84,12 +84,8 @@ class OpTestHMIHandling(unittest.TestCase):
                            .format(self.cpu, self.revision))
                 raise unittest.SkipTest("HMIHandling not supported on CPU={} Revision={}"
                                          .format(self.cpu, self.revision))
-        else:
-            log.debug("Skipping, HMIHandling NOT supported on CPU={} Revision={}"
-                        .format(self.cpu, self.revision))
-            raise unittest.SkipTest("HMIHandling not supported on CPU={} Revision={}"
-                                     .format(self.cpu, self.revision))
-        log.debug("Setting up to run HMIHandling on CPU={} Revision={}".format(self.cpu, self.revision))
+
+            log.debug("Setting up to run HMIHandling on CPU={} Revision={}".format(self.cpu, self.revision))
 
     def clear_stop(self):
         self.cv_SYSTEM.stop = 0


### PR DESCRIPTION
The commit 4fd2225 mistakenly disables HMI tests for Power8. This is
because the 'else' condition got under wrong 'if'. This patch fixes that.

Fixes: 4fd2225 ("OpTestHMIHandling: opal-gard interactive support")
Signed-off-by: Mahesh Salgaonkar <mahesh@linux.vnet.ibm.com>