### PR TITLE
mambo: Multiply all timeouts by a user-defined factor

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -54,6 +54,7 @@ qemu_default = "qemu-system-ppc64"
 mambo_default = "/opt/ibm/systemsim-p9/run/p9/power9"
 mambo_initial_run_script = "skiboot.tcl"
 mambo_autorun = "1"
+mambo_timeout_factor = 2
 
 # HostLocker credentials need to be in Notes Web section ('comment' section of JSON)
 # bmc_type:OpenBMC
@@ -232,6 +233,8 @@ def get_parser():
                           help="[Mambo Only] mambo simulator initial run script, defaults to skiboot.tcl")
     bmcgroup.add_argument("--mambo-autorun", default=mambo_autorun,
                           help="[Mambo Only] mambo autorun, defaults to '1' to autorun")
+    bmcgroup.add_argument("--mambo-timeout-factor", default=mambo_timeout_factor,
+                          help="[Mambo Only] factor to multiply all timeouts by, defaults to 2")
 
     hostgroup = parser.add_argument_group('Host', 'Installed OS information')
     hostgroup.add_argument("--host-ip", help="Host address")
@@ -719,6 +722,7 @@ class OpTestConfiguration():
                              skiboot=self.args.flash_skiboot,
                              kernel=self.args.flash_kernel,
                              initramfs=self.args.flash_initramfs,
+                             timeout_factor=self.args.mambo_timeout_factor,
                              logfile=self.logfile)
                 self.op_system = common.OpTestSystem.OpTestMamboSystem(host=host,
                     bmc=bmc,

--- a/common/OpTestMambo.py
+++ b/common/OpTestMambo.py
@@ -54,6 +54,7 @@ class MamboConsole():
             initramfs=None,
             block_setup_term=None,
             delaybeforesend=None,
+            timeout_factor=1,
             logfile=sys.stdout):
         self.mambo_binary = mambo_binary
         self.mambo_initial_run_script = mambo_initial_run_script
@@ -73,6 +74,7 @@ class MamboConsole():
         self.block_setup_term = block_setup_term # allows caller specific control of when to block setup_term
         self.setup_term_quiet = 0 # tells setup_term to not throw exceptions, like when system off
         self.setup_term_disable = 0 # flags the object to abandon setup_term operations, like when system off
+        self.timeout_factor = timeout_factor # functional simulators are notoriously slow, so multiply all default timeouts by this factor
 
         # state tracking, reset on boot and state changes
         # console tracking done on System object for the system console
@@ -187,13 +189,13 @@ class MamboConsole():
         return self.pty
 
     def run_command(self, command, timeout=60, retry=0):
-        return self.util.run_command(self, command, timeout, retry)
+        return self.util.run_command(self, command, timeout*self.timeout_factor, retry)
 
     def run_command_ignore_fail(self, command, timeout=60, retry=0):
-        return self.util.run_command_ignore_fail(self, command, timeout, retry)
+        return self.util.run_command_ignore_fail(self, command, timeout*self.timeout_factor, retry)
 
     def mambo_run_command(self, command, timeout=60, retry=0):
-        return self.util.mambo_run_command(self, command, timeout, retry)
+        return self.util.mambo_run_command(self, command, timeout*self.timeout_factor, retry)
 
     def mambo_exit(self):
         return self.util.mambo_exit(self)
@@ -241,6 +243,7 @@ class OpTestMambo():
                  prompt=None,
                  block_setup_term=None,
                  delaybeforesend=None,
+                 timeout_factor=None,
                  logfile=sys.stdout):
         self.console = MamboConsole(mambo_binary=mambo_binary,
             mambo_initial_run_script=mambo_initial_run_script,
@@ -248,6 +251,7 @@ class OpTestMambo():
             skiboot=skiboot,
             kernel=kernel,
             initramfs=initramfs,
+            timeout_factor=timeout_factor,
             logfile=logfile)
         self.ipmi = MamboIPMI(self.console)
         self.system = None


### PR DESCRIPTION
The default timeouts for things are already pretty liberal, but
functional simulators are *incredibly* slow, especially when running on
shared hardware.  Add a new configuration option that (by default)
doubles all timeouts, and allow users to expect things to be even slower.

Signed-off-by: Russell Currey <ruscur@russell.cc>