### PR TITLE
common: Improve Petitboot detection and shell exit

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -192,6 +192,9 @@ class OpTestSSH():
     def get_console(self, logger=None):
         if self.state == ConsoleState.DISCONNECTED:
           self.connect(logger)
+          if self.pty.isalive():
+              # connect() will have already setup term
+              return self.pty
 
         count = 0
         while (not self.pty.isalive()):

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -394,7 +394,7 @@ class OpTestSystem(object):
         self.console.enable_setup_term_quiet()
         sys_pty = self.console.get_console()
         self.console.disable_setup_term_quiet()
-        sys_pty.sendcontrol('c')
+        sys_pty.sendcontrol('l')
 
         r = sys_pty.expect(["x=exit", "Petitboot", ".*#", ".*\$", "login:", pexpect.TIMEOUT, pexpect.EOF], timeout=5)
         if r in [0,1]:
@@ -1100,8 +1100,8 @@ class OpTestSystem(object):
     def petitboot_exit_to_shell(self):
         sys_pty = self.console.get_console()
         log.debug("USING PES Expect Buffer ID={}".format(hex(id(sys_pty))))
-        sys_pty.sendcontrol('c')
         for i in range(3):
+          sys_pty.send('x')
           pp = self.get_petitboot_prompt()
           if pp == 1:
             break;
@@ -1122,8 +1122,6 @@ class OpTestSystem(object):
           self.block_setup_term = 0 # unblock in case connections are lost during state=4 the get_console/connect can properly setup again
           self.previous_state = OpSystemState.PETITBOOT_SHELL # preserve state
           my_pp = 1
-        else:
-          sys_pty = self.console.connect() # try new connect, sometimes stale buffers
         return my_pp
 
     def exit_petitboot_shell(self):

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1248,8 +1248,10 @@ class OpTestUtil():
           raise ConsoleSettings(before=pty.before, after=pty.after,
                   msg="Getting login and sudo not successful, probably connection or credential issue, retry")
         # now just timeout
-        pty.sendline()
-        rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+        pty.sendcontrol('l')
+        # Ctrl-L may cause a esc[J (erase) character to appear in the buffer.
+        # Include this in the patterns that expect $ (end of line)
+        rc = pty.expect(['login: (\x1b\[J)*$', ".*#(\x1b\[J)*$", ".*# (\x1b\[J)*$", ".*\$(\x1b\[J)*", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
         if rc == 0:
           track_obj.PS1_set, track_obj.LOGIN_set = self.get_login(system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
           track_obj.PS1_set, track_obj.SUDO_set = self.get_sudo(system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))


### PR DESCRIPTION
Commit 97b808e3 "OpTestSystem: Improve Petitboot transitions" made
several improvements to reliably dealing with the Petitboot menu. Part
of this was using Ctrl-C to exit the UI. While this is better for making
sure the UI is exited, it drops the system to a less functional shell
than the one normally started by exiting Petitboot normally.

Return to using 'x' to exit the UI but properly this time and with a bit
more paranoia. Instead of using sendline() or Ctrl-C to drive output,
use Ctrl-L and handle the extra 'erase' character that frustrated
previous efforts at its use. In petitboot_exit_to_shell() an 'x' is sent
on each attempt to gain the prompt in case the system is currently in a
Petitboot submenu.

This maintains reliability when dealing with the Petitboot state and
avoids issues with Ctrl-C and similar signals when dropped to a shell.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>