### PR TITLE
Use git-describe --always to get op-test version

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -510,7 +510,7 @@ class OpTestConfiguration():
         # now that we have loggers, dump conf file to help debug later
         OpTestLogger.optest_logger_glob.optest_logger.debug(
             "conf file defaults={}".format(defaults))
-        cmd = "git describe"
+        cmd = "git describe --always"
         git_output = subprocess.check_output(cmd.split())
         # log for triage of how dated the repo is
         OpTestLogger.optest_logger_glob.optest_logger.debug(


### PR DESCRIPTION
Otherwise, if using a shallow clone without tags present (common
in jenkins setups), we're not going to get what version is being used.

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>