### PR TITLE
Catch git describe failure

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -511,10 +511,13 @@ class OpTestConfiguration():
         OpTestLogger.optest_logger_glob.optest_logger.debug(
             "conf file defaults={}".format(defaults))
         cmd = "git describe --always"
-        git_output = subprocess.check_output(cmd.split())
-        # log for triage of how dated the repo is
-        OpTestLogger.optest_logger_glob.optest_logger.debug(
-            "op-test-framework git level = {}".format(git_output))
+        try:
+            git_output = subprocess.check_output(cmd.split())
+            # log for triage of how dated the repo is
+            OpTestLogger.optest_logger_glob.optest_logger.debug(
+                "op-test-framework git level = {}".format(git_output))
+        except Exception as e:
+            OpTestLogger.optest_logger_glob.optest_logger.debug("Unable to get git describe")
         # setup AES and Hostlocker configs after the logging is setup
         locker_timeout = time.time() + 60*self.args.locker_wait
         locker_code = errno.ETIME # 62


### PR DESCRIPTION
In some situations the file system may not allow the git
describe --always to cross file system boundaries

fatal: Not a git repository (or any parent up to mount point /tmp)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)

Ignore the failure and just log that we tried.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>