### PR TITLE
op-test: include fedora to be considered for installation

### DIFF
--- a/op-test
+++ b/op-test
@@ -558,7 +558,7 @@ class InstallHost():
             if "ubuntu" in target.lower():
                 self.s.addTest(InstallUbuntu.InstallUbuntu())
                 optestlog.info('InstallUbuntu added to default suite')
-            elif "rhel" in target.lower():
+            elif "rhel" or "fedora" in target.lower():
                 self.s.addTest(InstallRhel.InstallRhel())
                 optestlog.info('InstallRhel added to default suite')
             elif "hostos" in target.lower():


### PR DESCRIPTION
`InstallRhel` test can be reused to install Fedora from target
os repo.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>