### PR TITLE
OpTestUtil: Trigger refresh of host login prompt

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1263,7 +1263,11 @@ class OpTestUtil():
           raise ConsoleSettings(before=pty.before, after=pty.after,
                   msg="Getting login and sudo not successful, probably connection or credential issue, retry")
         # now just timeout
-        pty.sendcontrol('l')
+        if system_obj.state == 6: # OpSystemState.OS
+            # The login prompt doesn't respond properly to Ctrl-L
+            pty.sendline()
+        else:
+            pty.sendcontrol('l')
         # Ctrl-L may cause a esc[J (erase) character to appear in the buffer.
         # Include this in the patterns that expect $ (end of line)
         rc = pty.expect(['login: (\x1b\[J)*$', ".*#(\x1b\[J)*$", ".*# (\x1b\[J)*$", ".*\$(\x1b\[J)*", "~>(\x1b\[J)", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)


### PR DESCRIPTION
When logging into the host OS out-of-band (eg. IPMI) the login prompt
does not respond to Ctrl-L as expected. If we know we're waiting for a
host login prompt (eg. we know the state or we're booting up from
Petitboot), trigger a proper refresh by hitting enter at the prompt.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>