### PR TITLE
OpTestSystem: Force prompt refresh if unresponsive in detect_target

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -396,7 +396,11 @@ class OpTestSystem(object):
         self.console.enable_setup_term_quiet()
         sys_pty = self.console.get_console()
         self.console.disable_setup_term_quiet()
-        sys_pty.sendcontrol('l')
+        if self.detect_counter > 1:
+            # May be sitting at the host prompt - send a carriage return to force it to refresh
+            sys_pty.sendline()
+        else:
+            sys_pty.sendcontrol('l')
 
         r = sys_pty.expect(["x=exit", "Petitboot", ".*#", ".*\$", "login:", pexpect.TIMEOUT, pexpect.EOF], timeout=5)
         if r in [0,1]:
@@ -455,7 +459,6 @@ class OpTestSystem(object):
           else:
             return OpSystemState.UNKNOWN
         elif (r == 5) or (r == 6):
-          self.detect_counter += 1
           return OpSystemState.UNKNOWN
 
     def check_kernel(self):


### PR DESCRIPTION
Similar to b8629a8 "OpTestUtil: Trigger refresh of host login prompt"
the same problem is present in detect_target(). detect_target() is
called in a loop from run_DETECT() - if it fails to detect a state the
first time, send a carriage return to force the host login prompt to
print since it doesn't respond to Ctrl-L.

Additionally if detect_target() fails to detect a state it increments
detect_counter, however the loop in run_DETECT() also does this and the
detect loop only ever executes once. Remove the increment in
detect_target() and leave it to run_DETECT().

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>