### PR TITLE
mambo: Disable Console suite in Mambo

### DIFF
--- a/op-test
+++ b/op-test
@@ -230,7 +230,7 @@ class MamboSuite():
         self.s.addTest(OpTestFastReboot.OpTestFastReboot())
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())
-        self.s.addTest(Console.suite())
+        #self.s.addTest(Console.suite())
         self.s.addTest(OpTestPNOR.Skiroot())
         self.s.addTest(DeviceTreeValidation.DeviceTreeValidationSkiroot())
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(OpalSysfsTests.Skiroot))


### PR DESCRIPTION
The Console32k test is buggy and seemingly fails at random, and it also
takes a long time.  In mambo the objective isn't to test the "BMC", so
it doesn't make sense to include the test.