### PR TITLE
qemu: Allow setting of path and filename

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -135,7 +135,12 @@ class QemuConsole():
         if self.pnor:
             cmd = cmd + " -drive file={},format=raw,if=mtd".format(self.pnor)
         if self.skiboot:
-            cmd = cmd + " -bios %s" % (self.skiboot)
+            skibootdir = os.path.dirname(self.skiboot)
+            skibootfile = os.path.basename(self.skiboot)
+            if skibootfile:
+                cmd = cmd + " -bios %s" % (skibootfile)
+            if skibootdir:
+                cmd = cmd + " -L %s" % (skibootdir)
         if self.kernel:
             cmd = cmd + " -kernel %s" % (self.kernel)
             if self.initramfs is not None:


### PR DESCRIPTION
Qemu expects a name of the 'bios' and the path to be passed in separate
options:

       -L  path
           Set the directory for the BIOS, VGA BIOS and keymaps.

           To list all the data directories, use "-L help".

       -bios file
           Set the filename for the BIOS.

This uses the same config option, but splits out the path and filename
components.

Signed-off-by: Joel Stanley <joel@jms.id.au>