### PR TITLE
Check Skiboot NVRAM options before testcase

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -372,6 +372,7 @@ class OpTestConfiguration():
         self.util_bmc_server = None # OpenBMC REST Server
         atexit.register(self.__del__) # allows cleanup handler to run (OpExit)
         self.firmware_versions = None
+        self.nvram_debug_opts = None
 
         for dir in (os.walk(os.path.join(self.basedir, 'addons')).next()[1]):
             optAddons[dir] = importlib.import_module("addons." + dir + ".OpTest" + dir + "Setup")

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -378,6 +378,11 @@ class OpTestSystem(object):
                          message=("OpTestSystem something set the system to UNKNOWN,"
                            " check the logs for details, we will be stopping the system"))
 
+        # If we haven't checked for dangerous NVRAM options yet and
+        # checking won't disrupt the test, do so now.
+        if self.conf.nvram_debug_opts is None and state in [OpSystemState.PETITBOOT_SHELL, OpSystemState.OS]:
+            self.util.check_nvram_options(self.console)
+
     def run_DETECT(self, target_state):
         self.detect_counter += 1
         detect_state = OpSystemState.UNKNOWN


### PR DESCRIPTION
Skiboot parses configuration options in NVRAM at boot time which affect
runtime behaviour, and several of these can be potentially dangerous or
detrimental. When possible check NVRAM for any Skiboot configuration
options and warn about them and the end of the test run.

Fixes #492

Example:
2019-05-10 13:42:57,768:op-test.common.OpTestUtil:dump_nvram_opts:WARNING:
2 NVRAM debugging options set
These may adversely affect test results; verify these are appropriate if a failure occurs:
----------------------------------------------------------
bootargs=modprobe.blacklist=amdgpu
test-cfg=test-value
----------------------------------------------------------

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>