### PR TITLE
OpTestQemu: Better PHB handling, multi-disk setups, proper NIC support

### DIFF
--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -71,6 +71,7 @@ class QemuConsole():
         self.block_setup_term = block_setup_term # allows caller specific control of when to block setup_term
         self.setup_term_quiet = 0 # tells setup_term to not throw exceptions, like when system off
         self.setup_term_disable = 0 # flags the object to abandon setup_term operations, like when system off
+        self.mac_str = '52:54:00:22:34:56'
 
         # state tracking, reset on boot and state changes
         # console tracking done on System object for the system console
@@ -154,12 +155,18 @@ class QemuConsole():
                 + " -device pcie-pci-bridge,id=pcie.5,bus=pcie.2,addr=0x0"
             )
 
-        prefilled_slots = 0
+        # Put the NIC in slot 2 of the second PHB (1st is reserved for later)
+        cmd = (cmd
+                + " -netdev user,id=u1 -device e1000e,netdev=u1,mac={},bus=pcie.4,addr=2"
+                .format(self.mac_str)
+                )
+        prefilled_slots = 1
+
         if self.cdrom is not None:
-            # Put the CDROM in slot 2 of the second PHB (1 is reserved for later)
+            # Put the CDROM in slot 3 of the second PHB
             cmd = (cmd
                     + " -drive file={},id=cdrom01,if=none,media=cdrom".format(self.cdrom)
-                    + " -device virtio-blk-pci,drive=cdrom01,id=virtio02,bus=pcie.4,addr=2"
+                    + " -device virtio-blk-pci,drive=cdrom01,id=virtio02,bus=pcie.4,addr=3"
                 )
             prefilled_slots += 1
 

--- a/testcases/Petitboot10000Disks.py
+++ b/testcases/Petitboot10000Disks.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python2
+
+import time
+import unittest
+
+import OpTestConfiguration
+from common.OpTestUtil import OpTestUtil
+from common.OpTestSystem import OpSystemState
+from common.OpTestError import OpTestError
+from common.OpTestKeys import OpTestKeys as keys
+
+class ManyDisksTestCase(unittest.TestCase):
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+        self.system = conf.system()
+        self.bmc = conf.bmc()
+
+        if OpTestConfiguration.conf.args.bmc_type != "qemu":
+            self.skipTest("10,000 disks requires QEMU")
+
+        # Realistically you probably don't have a machine on hand that has the
+        # memory to do 10,000 disks. This starts at five, change this number to
+        # push it further.
+        for i in range(1,5):
+            self.bmc.add_temporary_disk("500K")
+
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+    def testListDisks(self):
+        c = self.system.console
+
+        c.run_command("ls -l /dev/vd* | wc -l")


### PR DESCRIPTION
The powernv QEMU model only has 3 free slots which doesn't leave a lot of room for tests that want more complicated setups. Instead fill each of these slots with a PHB which we can insert further devices into.
  
This also extends the scratch disk concept to support an arbitrary number of disks. The Petitboot10000Disks testcase provides an example of this functionality. The intended use case for this is to extend the Petitboot testcases to test against different source devices, filesystems, and configuration formats.

For particularly ambitious testcases the QEMU setup will also dynamically insert more PHBs into the model to support an arbitrary number of devices.

As a bonus fix the NIC setup so that we can properly use it in powernv with a consistent MAC address.
