### PR TITLE
InstallUpstreamKernel: Change execution order for grubby and grub2-mkconfig commands

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -108,8 +108,8 @@ class InstallUpstreamKernel(unittest.TestCase):
             con.run_command("make -j %d -s && make modules && make modules_install && make install" % onlinecpus, timeout=self.host_cmd_timeout)
             if not self.use_kexec:
                 # FIXME: Handle distributions which do not support grub
-                con.run_command("grub2-mkconfig  --output=/boot/grub2/grub.cfg")
                 con.run_command('grubby --set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`')
+                con.run_command("grub2-mkconfig  --output=/boot/grub2/grub.cfg")
                 log.debug("Rebooting after kernel install...")
                 self.console_thread.console_terminate()
                 con.close()


### PR DESCRIPTION
While using op-test to build and boot an upstream kernel on a P9 box,
grubby --set-default command does not reliably work (atleast in my CI
environment) on every instance. A lot of time machine fails to boot kernel
and drops to petitboot shell possibly due to to corrupted grub2 boot loader.
Only way to recover the machine is by running grub2-mkconfig command manually.

This patch changes the order of grub2-mkconfig and grubby commands to
ensure default kernel boots successfully.

Signed-off-by: Sachin Sant<sachinp@linux.vnet.ibm.com>