### PR TITLE
PetitbootConfig: Update configuration tests

### DIFF
--- a/common/OpTestKeys.py
+++ b/common/OpTestKeys.py
@@ -10,4 +10,5 @@ class OpTestKeys():
     PGUP    = '\x1b[5~'
     ENTER   = '\n'
     SPACE   = ' '
+    BACKSPACE = '\x7f'
 

--- a/testcases/PetitbootConfig.py
+++ b/testcases/PetitbootConfig.py
@@ -9,6 +9,11 @@ from common.OpTestSystem import OpSystemState
 from common.OpTestError import OpTestError
 from common.OpTestKeys import OpTestKeys as keys
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+
 class ConfigEditorTestCase(unittest.TestCase):
     def setUp(self):
         conf = OpTestConfiguration.conf
@@ -29,6 +34,7 @@ class ConfigEditorTestCase(unittest.TestCase):
         c.send('x')
 
         c.expect("e=edit, n=new")
+
 
 class TimeoutConfigTestCase(unittest.TestCase):
     default_timeout = 10
@@ -87,8 +93,10 @@ class TimeoutConfigTestCase(unittest.TestCase):
 
         # exit to shell, check saved timeout
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        timeout = self.console.run_command_ignore_fail('nvram --print-config=petitboot,timeout')
-        self.assertTrue(str(self.new_timeout) in timeout, "New timeout value not seen")
+        timeout = self.console.run_command_ignore_fail(
+            'nvram --print-config=petitboot,timeout')
+        self.assertTrue(str(self.new_timeout) in timeout,
+                        "New timeout value not seen")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
 
@@ -101,7 +109,8 @@ class TimeoutConfigTestCase(unittest.TestCase):
         # exit to shell and check setting
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
         self.console.run_command('ls')
-        timeout = self.console.run_command('nvram --print-config=petitboot,timeout')
+        timeout = self.console.run_command(
+            'nvram --print-config=petitboot,timeout')
         self.assertTrue("314" in timeout, "New timeout value not seen")
 
         # back to UI
@@ -115,10 +124,12 @@ class TimeoutConfigTestCase(unittest.TestCase):
 
         # exit to shell and expect no setting
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        timeout = self.console.run_command_ignore_fail('nvram --print-config | grep -c petitboot,timeout')
+        timeout = self.console.run_command_ignore_fail(
+            'nvram --print-config | grep -c petitboot,timeout')
         self.assertTrue("0" in timeout, "Timeout doesn't appear to be reset")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
+
 
 class StaticNetworkConfigTestCase(unittest.TestCase):
     def setUp(self):
@@ -127,17 +138,34 @@ class StaticNetworkConfigTestCase(unittest.TestCase):
         self.bmc = conf.bmc()
         self.console = self.system.console
 
-        if conf.args.bmc_type is not 'qemu':
+        if conf.args.bmc_type != 'qemu':
             self.skipTest("This test is intended for qemu")
 
-        # TODO extend to use real network device in qemu / real machine
-        self.network_config_str = (self.bmc.console.mac_str +
+        self.network_config_str = (
+            self.bmc.console.mac_str +
             ',static,192.168.0.1/24,192.168.0.2 dns,192.168.0.3')
+
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        try:
+            self.console.run_command("pflash -r /tmp/nvram-save -P NVRAM")
+        except CommandFailed:
+            log.debug("Failed to save NVRAM, changes may persist")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
 
         # Let Petitboot discovery settle
         time.sleep(10)
+
+    def tearDown(self):
+
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        try:
+            self.console.run_command(
+                "pflash -f -e -p /tmp/nvram-save -P NVRAM")
+        except CommandFailed:
+            log.debug("Failed to restore NVRAM, changes may persist")
 
     def testConfigStaticNetworkVar(self):
         c = self.console.get_console()
@@ -146,57 +174,73 @@ class StaticNetworkConfigTestCase(unittest.TestCase):
         c.expect('Static IP')
         time.sleep(1)
 
+        # make stuff consistent by turning auto-boot on
+        c.send(keys.DOWN)
+        c.send(' ')
+
         # navigate to network-type widget
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
 
         # select static
-        c.send(self.KEY_DOWN)
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
+        c.send(keys.DOWN)
         c.send(' ')
 
         # navigate to ip params
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
+        c.send(keys.TAB)
+        c.send(keys.DOWN)
+        c.send(' ')
+        c.send(keys.TAB)
 
-        # set up, mask, gateway, DNS
+        # set up, mask, gateway, DNS.
+        # we need to clear any existing configuration first
+        for i in range(20):
+            c.send(keys.BACKSPACE)
         c.send('192.168.0.1')
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
+        for i in range(4):
+            c.send(keys.BACKSPACE)
         c.send('24')
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
+        for i in range(20):
+            c.send(keys.BACKSPACE)
         c.send('192.168.0.2')
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
         # skip URL field
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
+        for i in range(20):
+            c.send(keys.BACKSPACE)
         c.send('192.168.0.3')
 
         # OK!
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_UP)
-        c.send(self.KEY_UP)
+        c.send(keys.PGDOWN)
+        c.send(keys.UP)
+        c.send(keys.UP)
         c.send(' ')
         c.expect("e=edit, n=new")
 
         # drop to shell
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
         config = self.console.run_command('nvram --print-config')
-        self.assertTrue('petitboot,network=%s' % self.network_config_str in tconfig, "Network config not correct")
+        self.assertTrue(
+            'petitboot,network=%s' %
+            self.network_config_str in config,
+            "Network config not correct")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
 
     def testReconfig(self):
         # Test saving an un-changed config.
         # We should see the same results as the first save
-
+        # testConfigStaticNetworkVar leaves us in PETITBOOT
         self.testConfigStaticNetworkVar()
 
-        # return to petitboot UI
-        c.send('exit')
-        c.expect('Petitboot')
+        c = self.console.get_console()
 
         # enter system config
         c.send('c')
@@ -205,18 +249,22 @@ class StaticNetworkConfigTestCase(unittest.TestCase):
 
         # select 'OK' button to save config
         time.sleep(0.1)
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_BTAB)
-        c.send(self.KEY_BTAB)
+        c.send(keys.PGDOWN)
+        c.send(keys.BTAB)
+        c.send(keys.BTAB)
         c.send(' ')
         time.sleep(0.1)
 
         # back to shell, check for the same config string
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
         config = self.console.run_command('nvram --print-config')
-        self.assertTrue('petitboot,network=%s' % self.network_config_str in tconfig, "Network config not correct")
+        self.assertTrue(
+            'petitboot,network=%s' %
+            self.network_config_str in config,
+            "Network config not correct")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
+
 
 class RestoreConfigDefaultTestCase(unittest.TestCase):
     def setUp(self):
@@ -225,17 +273,34 @@ class RestoreConfigDefaultTestCase(unittest.TestCase):
         self.bmc = conf.bmc()
         self.console = self.system.console
 
-        if conf.args.bmc_type is not 'qemu':
+        if conf.args.bmc_type != 'qemu':
             self.skipTest("This test is intended for qemu")
 
-        # TODO extend to use real network device in qemu / real machine
-        self.network_config_str = (self.bmc.console.mac_str +
+        self.network_config_str = (
+            self.bmc.console.mac_str +
             ',static,192.168.0.1/24,192.168.0.2 dns,192.168.0.3')
+
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        try:
+            self.console.run_command("pflash -r /tmp/nvram-save -P NVRAM")
+        except CommandFailed:
+            log.debug("Failed to save NVRAM, changes may persist")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
 
         # Let Petitboot discovery settle
         time.sleep(10)
+
+    def tearDown(self):
+
+        self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
+
+        try:
+            self.console.run_command(
+                "pflash -f -e -p /tmp/nvram-save -P NVRAM")
+        except CommandFailed:
+            log.debug("Failed to restore NVRAM, changes may persist")
 
     def testRestoreDefaultAutoboot(self):
         c = self.console.get_console()
@@ -243,24 +308,28 @@ class RestoreConfigDefaultTestCase(unittest.TestCase):
         # enter config
         c.send('c')
         c.expect('Petitboot System Configuration')
-        c.expect('Boot Order')
+
+        # make sure auto-boot is enabled
+        c.send(keys.DOWN)
+        c.send(' ')
 
         # clear boot order list
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_DOWN)
-        c.send(self.KEY_DOWN)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.DOWN)
+        c.send(keys.DOWN)
         c.send(' ')
 
         # save config, exit from UI
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_BTAB)
-        c.send(self.KEY_BTAB)
+        c.send(keys.PGDOWN)
+        c.send(keys.BTAB)
+        c.send(keys.BTAB)
         c.send(' ')
 
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        config = self.console.run_command('nvram --print-config | grep auto-boot')
-        self.assertTrue("auto-boot?=false" in config, "Autoboot not disabled")
+        config = self.console.run_command_ignore_fail(
+            'nvram --print-config | grep auto-boot')
+        self.assertTrue("auto-boot?=false" not in config, "Autoboot disabled!")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
         c.send('c')
@@ -269,26 +338,29 @@ class RestoreConfigDefaultTestCase(unittest.TestCase):
         c.expect('Autoboot:')
 
         # re-enable autoboot
-        c.send(self.KEY_DOWN)
+        c.send(keys.DOWN)
         c.send(' ')
         # set autoboot option
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
         c.send(' ')
-        c.send(self.KEY_UP)
-        c.send(self.KEY_UP)
+        c.send(keys.UP)
+        c.send(keys.UP)
         c.send(' ')
 
         # save config again, exit from UI
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_BTAB)
-        c.send(self.KEY_BTAB)
+        c.send(keys.PGDOWN)
+        c.send(keys.BTAB)
+        c.send(keys.BTAB)
         c.send(' ')
 
         # we should see that the auto-boot nvram setting has been removed
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        config = self.console.run_command_ignore_fail('nvram --print-config | grep -q auto-boot; echo $?')
-        self.assertTrue("auto-boot?=false" not in config, "Autoboot still disabled")
+        config = self.console.run_command_ignore_fail(
+            'nvram --print-config | grep -q auto-boot; echo $?')
+        self.assertTrue(
+            "auto-boot?=false" not in config,
+            "Autoboot still disabled")
 
         self.system.goto_state(OpSystemState.PETITBOOT)
 
@@ -301,24 +373,27 @@ class RestoreConfigDefaultTestCase(unittest.TestCase):
         c.expect('Boot Order')
 
         # set timeout to non-default
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
         c.sendcontrol('h')
         c.sendcontrol('h')
         c.send('42')
 
         # save config, exit from UI
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_BTAB)
-        c.send(self.KEY_BTAB)
+        c.send(keys.PGDOWN)
+        c.send(keys.BTAB)
+        c.send(keys.BTAB)
         c.send(' ')
 
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
-        timeout = self.console.run_command('nvram --print-config | grep petitboot,timeout')
-        self.assertTrue("petitboot,timeout=42" in timeout, "New timeout value not seen")
+        timeout = self.console.run_command(
+            'nvram --print-config | grep petitboot,timeout')
+        self.assertTrue(
+            "petitboot,timeout=42" in timeout,
+            "New timeout value not seen")
 
         # exit shell
         self.system.goto_state(OpSystemState.PETITBOOT)
@@ -327,25 +402,28 @@ class RestoreConfigDefaultTestCase(unittest.TestCase):
         c.send('c')
         c.expect('Petitboot System Configuration')
         c.expect('Boot Order')
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.send(self.KEY_TAB)
-        c.sendcontrol('h')
-        c.sendcontrol('h')
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.TAB)
+        c.send(keys.BACKSPACE)
+        c.send(keys.BACKSPACE)
         c.send('10')
 
         # save config again, exit from UI
-        c.send(self.KEY_PGDOWN)
-        c.send(self.KEY_BTAB)
-        c.send(self.KEY_BTAB)
+        c.send(keys.PGDOWN)
+        c.send(keys.BTAB)
+        c.send(keys.BTAB)
         c.send(' ')
 
         self.system.goto_state(OpSystemState.PETITBOOT_SHELL)
 
-        # we should see that the auto-boot nvram setting has been removed
-        timeout = self.console.run_command_ignore_fail('nvram --print-config | grep -q petitboot,timeout')
-        self.assertTrue("0" in timeout, "Timeout doesn't appear to be reset")
+        # we should see that the timeout nvram setting has been removed
+        timeout = self.console.run_command_ignore_fail(
+            'nvram --print-config | grep -q petitboot,timeout')
+        self.assertTrue(
+            "timeout=42" not in timeout,
+            "Timeout doesn't appear to be reset")
 
         self.system.goto_state(OpSystemState.PETITBOOT)


### PR DESCRIPTION
A bunch of configuration-related tests were waiting for NVRAM support
and a reliable network address in Qemu. Now that we have it, update
these tests so that
a) they run at all,
b) they reflect current Petitboot behaviour, and
c) try to preserve the state of NVRAM before the test.

This has also had autopep8 run against it so bring it in to line with
other work.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>