### PR TITLE
Add softlockup scenario for kdump/Fadump testing

### DIFF
--- a/test_binaries/Makefile
+++ b/test_binaries/Makefile
@@ -1,0 +1,7 @@
+obj-m += softlockup.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test_binaries/softlockup.c
+++ b/test_binaries/softlockup.c
@@ -1,0 +1,35 @@
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/spinlock.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("LIKHITHA");
+MODULE_DESCRIPTION("Kernel Module for softlockups");
+
+static spinlock_t my_lock;
+
+int a;
+
+static int __init my_init(void)
+{
+    spin_lock_init(&my_lock);
+    printk(KERN_INFO "softlockup module: Initialized spinlock\n");
+
+    /* Perform critical section operations */
+    spin_lock(&my_lock);
+    while (1) {
+	a+=1;	
+    }
+    spin_unlock(&my_lock);
+
+    return 0;
+}
+
+static void __exit my_exit(void)
+{
+    printk(KERN_INFO "Exiting module\n");
+}
+
+module_init(my_init);
+module_exit(my_exit);


### PR DESCRIPTION
Add kdump-softlockup-testcase  to PowerNVDump.py.  This test needs kernel modules to create softlockup to  crash the system due to panic on softlockup.  Later , verify the dump file  . If  it exists ,  then test passed. otherwise , test failed.

How to run this testcase :
`./op-test -c  test.config --run testcases.PowerNVDump.KernelCrash_KdumpSoftlockup`

This testcase use source  files (softlockup.c and Makefile). These 2 files  added to op-tests framework's directory  `op-test/test_binaries` . This testcase copy softlockup.c and Makefile  to /tmp directory. Later, it will build kernel module for softlockup with the help of Makefile.  To activate the kernel panic on  soft lockup use this command 
$ sysctl -w kernel.softlockup_panic=1

The command `insmod` used to insert generated  kernel module ( i.e softlockup.ko) into the kernel. 

Finally , testcase will verify the dump file created  after kernel panic on  soft lockup.