### PR TITLE
Fix IndentationError caused by commit e617ed1

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -830,14 +830,14 @@ class OpTestHost():
         res = self.host_run_command("lscpu --all -e| wc -l", console=console)
         return int(res[0])/(self.host_get_smt(console=console))
 
-   def host_get_online_cpus(self, console=0):
-       '''
-       Get total online cpu count
-       return : cpus
-       type: int
-       '''
-       res = self.host_run_command("lscpu --online -e | wc -l", console=console)
-       return int(res[0])-1
+    def host_get_online_cpus(self, console=0):
+        '''
+        Get total online cpu count
+        return : cpus
+        type: int
+        '''
+        res = self.host_run_command("lscpu --online -e | wc -l", console=console)
+        return int(res[0])-1
 
     def host_gather_debug_logs(self, console=0):
         self.host_run_command(


### PR DESCRIPTION
### Fix IndentationError caused by commit e617ed1

The Commit e617ed1 causes Indentation Error:

```
Traceback (most recent call last):
  File "/data/jenkins/workspace/kvmci/./op-test", line 29, in <module>
    from testcases import HelloWorld
  File "/data/jenkins/workspace/kvmci/testcases/HelloWorld.py", line 31, in <module>
    import OpTestConfiguration
  File "/data/jenkins/workspace/kvmci/OpTestConfiguration.py", line 7, in <module>
    from common.OpTestBMC import OpTestBMC, OpTestSMC
  File "/data/jenkins/workspace/kvmci/common/OpTestBMC.py", line 44, in <module>
    from .OpTestIPMI import OpTestIPMI
  File "/data/jenkins/workspace/kvmci/common/OpTestIPMI.py", line 48, in <module>
    from . import OpTestSystem
  File "/data/jenkins/workspace/kvmci/common/OpTestSystem.py", line 47, in <module>
    from . import OpTestHost
  File "/data/jenkins/workspace/kvmci/common/OpTestHost.py", line 833
    def host_get_online_cpus(self, console=0):
                                              ^
IndentationError: unindent does not match any outer indentation level
```

This Patch fixes the above error.

Signed-off-by: Misbah Anjum N <misanjum@linux.ibm.com>