### PR TITLE
TimeOut: Increase timeour value for host_run_command

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -203,7 +203,7 @@ class OpTestHost():
             log.warning(l_msg)
             raise OpTestError(l_msg)
 
-    def host_run_command(self, i_cmd, timeout=1500, retry=0, console=0):
+    def host_run_command(self, i_cmd, timeout=10800, retry=0, console=0):
         # if we are QEMU use the system console
         if isinstance(self.ssh.system.console, OpTestQemu.QemuConsole) or (console == 1):
             return self.ssh.system.console.run_command(i_cmd, timeout, retry)


### PR DESCRIPTION
Increasing the timeout value for host_run_command, to accommodate the build bisection runs, as it tend to takes around 2.5 to 3hrs.