### PR TITLE
Adding No space check in Build Error

### DIFF
--- a/testcases/OpTestKernelTest.py
+++ b/testcases/OpTestKernelTest.py
@@ -212,6 +212,8 @@ class KernelTest(unittest.TestCase):
         if exit_code != 0:
             entry = self.Store_loc(errVal)[-1]
             err_msg= self.util.err_message(error)
+            if ("No Space" in str(msg) for msg in err_msg):
+                 log.error("Error: No Space left on device. Exiting script.")
             if self.bisect_flag == '1':
                 log.info("BUILD_BISECTION STARTED")
                 res = self.util.build_bisector(self.linux_path, self.good_commit, self.repo)


### PR DESCRIPTION
Adding No space check in build error log, so that
bisection logic doesnt execute, when the build failure is due to disk space issue.