### PR TITLE
OpTestKernelDump.py: Cleanup /var/crash for both local and network dumps

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -308,7 +308,7 @@ class OptestKernelDump(unittest.TestCase):
                 self.c.run_command("ls /var/crash/%s/opalcore*" %
                                    self.crash_content[0])
         finally:
-            if dump_place == "local" and self.dump_server_user == 'root':
+            if self.dump_server_user == 'root':
                 log.info("Cleaning up crash directory /var/crash/%s" % self.crash_content[0])
                 self.c.run_command("rm -rf /var/crash/%s; sync" % self.crash_content[0])
 
@@ -1327,8 +1327,10 @@ class OpTestMakedump(OptestKernelDump):
         obj = OpTestInstallUtil.InstallUtil()
         obj.update_kernel_cmdline(self.distro, remove_args="disable_radix",
                                   reboot=True, reboot_cmd=True)
+        self.setup_test()
         self.kernel_crash()
         self.makedump_check()
+        self.verify_dump_file(boot_type)
 
 
 class KernelCrash_KdumpPMEM(OptestKernelDump):


### PR DESCRIPTION
Previously, cleanup of crash directories under /var/crash/ was restricted to local dumps and root user. However, in network-based (SSH/NFS) kdump scenarios, dump folders are also copied to /var/crash/, so they should be cleaned up as well. The cleanup logic in the finally block is now updated to remove crash directories for all cases when dump_server_user is root.

Additionally:
- Added setup_test() and verify_dump_file() support to the OpTestMakedump() test case to handle cleanup of the crash folder after dump verification.
- Addressed scenarios where crash folders are created with the same names to ensure reliable dump verification and cleanup.