### PR TITLE
OpTestKerneldump.py: Add a call to setup_test() in the KernelCrash_OnlyKdumpEnable 

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -764,6 +764,7 @@ class KernelCrash_OnlyKdumpEnable(OptestKernelDump):
         boot_type = self.kernel_crash()
         self.verify_dump_file(boot_type)
         if self.is_lpar:
+            self.setup_test()
             log.info("========= Testing kdump with HMC dumprestart ===========")
             boot_type = self.kernel_crash(crash_type="hmc")
             self.verify_dump_file(boot_type)


### PR DESCRIPTION

If the system clock is not updating correctly, consecutive crash dumps may generate directories with identical timestamps. To prevent this issue, it’s better to invoke setup_test() after cleaning up the crash folder, ensuring the environment and time synchronization are properly refreshed before each crash trigger.