### PR TITLE
OptestKernelDump.py: Fix NameError: name 'boot_type' is not defined

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -1329,7 +1329,7 @@ class OpTestMakedump(OptestKernelDump):
         obj.update_kernel_cmdline(self.distro, remove_args="disable_radix",
                                   reboot=True, reboot_cmd=True)
         self.setup_test()
-        self.kernel_crash()
+        boot_type = self.kernel_crash()
         self.makedump_check()
         self.verify_dump_file(boot_type)
 


### PR DESCRIPTION
Defined boot_type before calling it