### PR TITLE
Adding the grub rebuild command after Gcov kernel Install

### DIFF
--- a/testcases/GcovSetup.py
+++ b/testcases/GcovSetup.py
@@ -199,6 +199,7 @@ class GcovBuild(unittest.TestCase):
             cmd = f"make -j modules_install && make install"
             if not self.cv_HOST.host_run_command(cmd):
                 self.fail("module installation failed")
+            self.cv_HOST.host_run_command("grub2-mkconfig -o /boot/grub2/grub.cfg")
         except Exception:
             self.fail("compile and build of gcov kernel failed")
 


### PR DESCRIPTION
Few times grub-rebuild is not properly happening or not taking care after Gcov kernel installed. Hence The Gcov kernel doesnot listing in the grub entry during boot. So added the grub rebuild command, with which it builds the Gcov kernel properly.