### PR TITLE
testcases/OpTestKernelDump.py: fixed ebizzy workload url failure

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -126,7 +126,7 @@ class OptestKernelDump(unittest.TestCase):
         self.rsa_path = "/root/.ssh/dmp_id_rsa"
         try: self.url = conf.args.url
         except AttributeError:
-            self.url = "https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz"
+            self.url = "https://downloads.sourceforge.net/project/ebizzy/ebizzy/0.3/ebizzy-0.3.tar.gz"
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
         res = self.cv_HOST.host_run_command("cat /etc/os-release", timeout=60)
         if "Ubuntu" in res[0] or "Ubuntu" in res[1]:
@@ -1099,7 +1099,7 @@ class KernelCrash_KdumpWorkLoad(OptestKernelDump):
 
     # This test verifies kdump/fadump after running ebizzy.
     # ebizzy url needs to be given in ~/.op-test-framework.conf.
-    # Ex: url=https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz
+    # Ex: url=https://downloads.sourceforge.net/project/ebizzy/ebizzy/0.3/ebizzy-0.3.tar.gz
 
 
     def runTest(self):


### PR DESCRIPTION
Pointed to the correct ebizzy workload url