### PR TITLE
Fix run_command failure on RHEL10 lpars

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1866,7 +1866,12 @@ class OpTestUtil():
                 except Exception as e:
                     pass  # nothing there
                 try:
-                    echo_rc = int(echo_output[-1])
+                    # Filter out ANSI escape sequences and empty lines before parsing exit code
+                    filtered_output = [line for line in echo_output if line and not line.startswith('\x1b[')]
+                    if filtered_output:
+                        echo_rc = int(filtered_output[-1])
+                    else:
+                        echo_rc = -1
                 except Exception as e:
                     echo_rc = -1
             else:


### PR DESCRIPTION
OpTestUtil.try_command() was incorrectly reporting failures when commands succeeded due to ANSI escape sequences (bracketed paste mode) interfering with exit code parsing. Filter out lines starting with '\x1b[' before parsing the exit code to prevent false negatives.

Without Patch:
------------------------
[console-expect]#2026-04-25 12:19:13,999:op-test.common.OpTestUtil:run_command:INFO:
 
OpTestSystem detected a command issue, we will retry the command, this will be retry "05" of a total of "05"
 

cat /etc/os-release
cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="10.0 (Coughlan)"
ID="rhel"
ID_LIKE="centos fedora"
VERSION_ID="10.0"
PLATFORM_ID="platform:el10"
PRETTY_NAME="Red Hat Enterprise Linux 10.0 (Coughlan)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:10::baseos"
HOME_URL="https://www.redhat.com/"
VENDOR_NAME="Red Hat"
VENDOR_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/10"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 10"
REDHAT_BUGZILLA_PRODUCT_VERSION=10.0
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="10.0"
[console-expect]#echo $?
echo $?
0
[console-expect]#2026-04-25 12:19:14,862:op-test.testcases.OpTestOSRelease:runTest:ERROR:Command failed with exit code -1: Command 'cat /etc/os-release' exited with '-1'.
Output
['\x1b[?2004l', 'NAME="Red Hat Enterprise Linux"', 'VERSION="10.0 (Coughlan)"', 'ID="rhel"', 'ID_LIKE="centos fedora"', 'VERSION_ID="10.0"', 'PLATFORM_ID="platform:el10"', 'PRETTY_NAME="Red Hat Enterprise Linux 10.0 (Coughlan)"', 'ANSI_COLOR="0;31"', 'LOGO="fedora-logo-icon"', 'CPE_NAME="cpe:/o:redhat:enterprise_linux:10::baseos"', 'HOME_URL="https://www.redhat.com/"', 'VENDOR_NAME="Red Hat"', 'VENDOR_URL="https://www.redhat.com/"', 'DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/10"', 'BUG_REPORT_URL="https://issues.redhat.com/"', '', 'REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 10"', 'REDHAT_BUGZILLA_PRODUCT_VERSION=10.0', 'REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"', 'REDHAT_SUPPORT_PRODUCT_VERSION="10.0"', '\x1b[?2004h']
FAIL
