### PR TITLE
Fix FSP_PHYP to avoid FSP operations and use HMC directly

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -867,13 +867,9 @@ class OpTestConfiguration():
                 else:
                     raise Exception(
                         "HMC IP, username and password is required")
-                bmc = OpTestFSP(self.args.bmc_ip,
-                                self.args.bmc_username,
-                                self.args.bmc_password,
-                                hmc=hmc,
-                                prompt=self.args.fsp_prompt if hasattr(
-                                    self.args, 'fsp_prompt') else "$",
-                                )
+                # For FSP_PHYP, use HMC directly as BMC to avoid FSP operations
+                # HMC now has get_ipmi(), get_hmc(), bmc_host() methods
+                bmc = hmc
                 self.op_system = common.OpTestSystem.OpTestLPARSystem(
                     state=self.startState,
                     bmc=bmc,

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1063,6 +1063,33 @@ class OpTestHMC(HMCUtil):
     def get_rest_api(self):
         return None
 
+    def get_ipmi(self):
+        '''
+        Get IPMI interface (not available in PHYP).
+        
+        Returns:
+            None: PHYP does not support IPMI
+        '''
+        return None
+
+    def get_hmc(self):
+        '''
+        Get HMC interface (returns self for PHYP).
+        
+        Returns:
+            OpTestHMC: self
+        '''
+        return self
+
+    def bmc_host(self):
+        '''
+        Return HMC IP as BMC host.
+        
+        Returns:
+            str: HMC IP address
+        '''
+        return self.hmc_ip
+
     def has_os_boot_sensor(self):
         return False
 

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1396,8 +1396,12 @@ class OpTestLPARSystem(OpTestSystem):
                  conf=None,
                  bmc_type=None,
                  state=OpSystemState.UNKNOWN):
-        if bmc_type in ['FSP_PHYP']:
-            bmc.fsp_get_console()
+        # For FSP_PHYP, bmc is HMC object directly (no FSP operations)
+        # For EBMC_PHYP, bmc is OpTestEBMC (has REST API but console via HMC)
+        # Skip fsp_get_console() for PHYP environments
+        if bmc_type in ['FSP_PHYP', 'EBMC_PHYP']:
+            # Console is managed through HMC, no FSP console setup needed
+            pass
         self.hmc = bmc.get_hmc()
         super(OpTestLPARSystem, self).__init__(host=host,
                                                bmc=bmc,

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1029,6 +1029,9 @@ class OpTestSystem(object):
         '''
         Get the sel elist to dump out
         '''
+        if self.cv_IPMI is None:
+            log.debug("sys_sel_elist: cv_IPMI is None, skipping ESEL gather")
+            return []
         output = self.cv_IPMI.ipmi_sel_elist(dump=dump)
 
         return output
@@ -1455,6 +1458,14 @@ class OpTestLPARSystem(OpTestSystem):
             if r == BMC_CONST.FW_FAILED:
                 raise 'Failed powering on system'
         return OpSystemState.BOOTING
+
+    def sys_sel_elist(self, dump=False):
+        '''
+        IPMI is not available in PHYP/HMC environments.
+        Return an empty list so the ESEL gather in cleanup does not crash.
+        '''
+        log.debug("sys_sel_elist: IPMI not available for LPAR/HMC system, skipping")
+        return []
 
     def skiboot_log_on_console(self):
         return False


### PR DESCRIPTION
When bmc_type is FSP_PHYP, the framework now uses HMC directly as the BMC object instead of creating an OpTestFSP object. This avoids all FSP-specific operations like fsp_get_console() which are not applicable in PHYP environments where all management is done through HMC.

Changes:
- OpTestHMC: Added get_ipmi(), get_hmc(), bmc_host() methods to make it compatible as a BMC object
- OpTestConfiguration: Use HMC directly as BMC for FSP_PHYP instead of creating OpTestFSP object
- OpTestSystem: Skip fsp_get_console() for both FSP_PHYP and EBMC_PHYP as console is managed through HMC

This ensures FSP/BMC-specific operations are avoided when using PHYP BMC types, preventing pexpect and FSP telnet connection issues.