### PR TITLE
RunHostTest: Use console-based execution for persistent session state

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -305,7 +305,7 @@ class OpTestSSH():
 
         return self.pty
 
-    def run_command(self, command, timeout=60, retry=0):
+    def run_command(self, command, timeout=60, retry=0, use_console=False):
         """
         Execute command via SSH.
         Uses direct SSH execution (non-interactive) by default for better reliability.
@@ -315,10 +315,16 @@ class OpTestSSH():
             command: Command string to execute
             timeout: Command timeout in seconds
             retry: Number of retries (used by console method)
+            use_console: If True, force console-based execution (maintains session state for cd commands)
             
         Returns:
             Command output
         """
+        # Force console-based execution if requested (for tests that need persistent sessions)
+        if use_console:
+            log.debug("Using console-based execution (persistent session)")
+            return self.util.run_command(self, command, timeout, retry)
+        
         # Try direct SSH execution first (non-interactive, more reliable)
         if HAS_PARAMIKO:
             try:

--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -60,7 +60,8 @@ class RunHostTest(unittest.TestCase):
         con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         try:
             if self.host_cmd:
-                con.run_command(self.host_cmd, timeout=self.host_cmd_timeout)
+                # Use console-based execution to maintain session state (cd commands persist)
+                con.run_command(self.host_cmd, timeout=self.host_cmd_timeout, use_console=True)
             if self.host_cmd_file:
                 if not os.path.isfile(self.host_cmd_file):
                     self.fail("Provide valid host cmd file path")
@@ -75,7 +76,8 @@ class RunHostTest(unittest.TestCase):
                         self.console_thread = OpSOLMonitorThread(1, "console")
                         self.console_thread.start()
                         continue
-                    con.run_command(line, timeout=self.host_cmd_timeout)
+                    # Use console-based execution to maintain session state (cd commands persist)
+                    con.run_command(line, timeout=self.host_cmd_timeout, use_console=True)
         finally:
             if self.host_cmd_resultpath:
                 self.cv_SYSTEM.cv_HOST.copy_files_from_host(self.resultpath,


### PR DESCRIPTION
Modified RunHostTest to use console-based (pexpect) execution instead of direct SSH execution. This ensures that working directory changes (cd commands) and shell state persist across multiple command executions.

Changes:
- Added use_console parameter to OpTestSSH.run_command()
- Updated RunHostTest to pass use_console=True for all commands
- Console-based execution maintains persistent SSH session via pexpect

This fixes the issue where cd commands were not persisting because each direct SSH execution created a new session starting from the user's home directory (/root for root user).