### PR TITLE
Fix RunHostTest console execution and prevent duplicate sysinfo colle…

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -305,7 +305,7 @@ class OpTestSSH():
 
         return self.pty
 
-    def run_command(self, command, timeout=60, retry=0, use_console=False):
+    def run_command(self, command, timeout=60, retry=0, use_direct_ssh=True):
         """
         Execute command via SSH.
         Uses direct SSH execution (non-interactive) by default for better reliability.
@@ -315,24 +315,22 @@ class OpTestSSH():
             command: Command string to execute
             timeout: Command timeout in seconds
             retry: Number of retries (used by console method)
-            use_console: If True, force console-based execution (maintains session state for cd commands)
+            use_direct_ssh: If False, skip direct SSH and use console-based execution (default: True)
             
         Returns:
             Command output
         """
         # Force console-based execution if requested (for tests that need persistent sessions)
-        if use_console:
-            log.debug("Using console-based execution (persistent session)")
-            return self.util.run_command(self, command, timeout, retry)
         
         # Try direct SSH execution first (non-interactive, more reliable)
-        if HAS_PARAMIKO:
+        # Skip if use_direct_ssh=False (for tests that need persistent session state)
+        if use_direct_ssh and HAS_PARAMIKO:
             try:
                 return self.run_command_direct(command, timeout)
             except Exception as e:
                 log.warning(f"Direct SSH execution failed, falling back to console: {e}")
         
-        # Fall back to console-based execution
+        # Use console-based execution (maintains persistent session)
         return self.util.run_command(self, command, timeout, retry)
 
     def run_command_ignore_fail(self, command, timeout=60, retry=0):

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -448,9 +448,11 @@ class OpTestSystem(object):
         if isinstance(self.console, OpTestHMC.HMCConsole):
             try:
                 log.debug("SSH detection: Using HMC SSH connection")
+                # Use console-based execution for state detection to ensure reliable output
                 result = self.cv_HOST.host_run_command(
                     "cat /proc/version 2>/dev/null | grep -q '{}' && echo 'OS' || echo 'PETITBOOT'".format(self.openpower),
-                    timeout=5
+                    timeout=5,
+                    console=1  # Force console-based execution
                 )
                 output = '\n'.join(result).strip()
                 if 'OS' in output:

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -2075,7 +2075,9 @@ class OpTestUtil():
     def try_command(self, term_obj, command, timeout=60):
         running_sudo_s = False
         extra_sudo_output = False
-        expect_prompt = self.build_prompt(term_obj.prompt) + "$"
+        # Use the pre-built expect_prompt from term_obj to ensure consistency
+        # (term_obj.expect_prompt already includes the ssh parameter and "$")
+        expect_prompt = term_obj.expect_prompt
         # if previous caller environment leaves buffer hung can show up here, e.g. PS2 prompt
         pty = term_obj.get_console()
         pty.sendline(command)

--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -60,14 +60,16 @@ class RunHostTest(unittest.TestCase):
         con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         try:
             if self.host_cmd:
-                # Use console-based execution to maintain session state (cd commands persist)
-                con.run_command(self.host_cmd, timeout=self.host_cmd_timeout, use_console=True)
+                # Use console-based execution (not direct SSH) to maintain session state
+                con.run_command(self.host_cmd, timeout=self.host_cmd_timeout, use_direct_ssh=False)
             if self.host_cmd_file:
                 if not os.path.isfile(self.host_cmd_file):
                     self.fail("Provide valid host cmd file path")
                 fd = open(self.host_cmd_file, "r")
                 for line in fd.readlines():
                     line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue  # Skip empty lines and comments
                     if "reboot" in line:
                         self.console_thread.console_terminate()
                         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
@@ -76,8 +78,8 @@ class RunHostTest(unittest.TestCase):
                         self.console_thread = OpSOLMonitorThread(1, "console")
                         self.console_thread.start()
                         continue
-                    # Use console-based execution to maintain session state (cd commands persist)
-                    con.run_command(line, timeout=self.host_cmd_timeout, use_console=True)
+                    # Use console-based execution (not direct SSH) to maintain session state
+                    con.run_command(line, timeout=self.host_cmd_timeout, use_direct_ssh=False)
         finally:
             if self.host_cmd_resultpath:
                 self.cv_SYSTEM.cv_HOST.copy_files_from_host(self.resultpath,


### PR DESCRIPTION
…ction

This commit addresses multiple issues in the RunHostTest execution flow:

1. Fixed console prompt mismatch in OpTestUtil.try_command()
   - Use pre-built term_obj.expect_prompt instead of rebuilding
   - Ensures consistency between terminal PS1 and expect pattern
   - Resolves command hangs caused by prompt pattern mismatch

2. Added use_direct_ssh parameter to OpTestSSH.run_command()
   - Allows console-based execution for session persistence
   - Maintains working directory between command executions
   - Default True for backward compatibility

3. Updated RunHostTest to use console-based execution
   - Set use_direct_ssh=False for all run_command() calls
   - Skip empty lines and comments in command files
   - Ensures cd commands persist across executions

4. Fixed false PETITBOOT state detection in OpTestSystem
   - Added console=1 parameter to host_run_command()
   - Prevents unnecessary system reboots during tests

5. Prevented duplicate OS sysinfo collection in OpTestHMC
   - Added sysinfo_collected flag to track collection state
   - Check flag before collecting in set_system()
   - Eliminates duplicate sysinfo output and improves performance

These changes restore the original console-based execution behavior while maintaining compatibility with the SSH migration.