### PR TITLE
fix: Handle transient network failures

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -48,6 +48,7 @@ from http.client import HTTPConnection
 # HTTPConnection.debuglevel = 1 # this will print some additional info to stdout
 import urllib3  # setUpChildLogger enables integrated logging with op-test
 import json
+from .Exceptions import SSHSessionDisconnected
 import tempfile
 
 from .OpTestConstants import OpTestConstants as BMC_CONST
@@ -2089,6 +2090,30 @@ class OpTestUtil():
         else:
             rc = pty.expect([expect_prompt, r"[Pp]assword for",
                              pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+        
+        # Handle transient network disconnections (EOF/TIMEOUT on primary interface)
+        if rc in [pexpect.EOF, pexpect.TIMEOUT]:
+            log.warning("Detected connection issue (EOF/TIMEOUT) - attempting recovery")
+            # Give the network a moment to stabilize
+            time.sleep(2)
+            try:
+                # Try to reconnect the console/SSH session
+                term_obj.close()
+                time.sleep(1)
+                term_obj.connect()
+                log.info("Connection recovered, retrying command")
+                # Retry the command after reconnection
+                pty = term_obj.get_console()
+                pty.sendline(command)
+                if command == 'sudo -s':
+                    rc = pty.expect([".*#", r"[Pp]assword for",
+                                   pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+                else:
+                    rc = pty.expect([expect_prompt, r"[Pp]assword for",
+                                   pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
+            except Exception as e:
+                log.error("Connection recovery failed: {}".format(e))
+                raise SSHSessionDisconnected("Transient network issue - connection recovery failed", e)
         output_list = []
         output_list += pty.before.replace("\r\r\n", "\n").splitlines()
         try:

--- a/op-test
+++ b/op-test
@@ -135,6 +135,15 @@ def optest_handler(signum, frame):
     # structure to monitor for signals if needing to close this exposure
     signal_dict = dict((key, value) for value, key in reversed(sorted(signal.__dict__.items()))
                        if value.startswith('SIG') and not value.startswith('SIG_'))
+    
+    # Handle SIGHUP more gracefully - it often indicates transient network issues
+    if signum == signal.SIGHUP:
+        optestlog.warning("OpTestSystem received SIGHUP (signum={}), likely due to transient network issue".format(signum))
+        optestlog.warning("Allowing test framework to handle reconnection instead of immediate exit")
+        # Don't exit immediately - let the connection recovery logic handle it
+        return
+    
+    # For other signals, proceed with cleanup and exit
     if OpTestConfiguration.conf.signal_ready == True:
         OpTestConfiguration.conf.util.cleanup()
     traceback.print_stack()


### PR DESCRIPTION
Problem:

- SIGHUP signal caused immediate process termination via os._exit(1)
- Infrastructure network flakiness on primary interface (eth0) caused brief SSH disconnections
- Tests running over pexpect failed when connection dropped momentarily

Root Cause:
When eth0 experiences brief network interruption:
1. SSH session drops → pexpect receives EOF/TIMEOUT
2. SIGHUP signal sent → signal handler calls os._exit(1)
3. All tests cancelled even though network reconnects immediately

Solution:
1. Added automatic connection recovery in OpTestUtil.try_command()
   - Detects EOF/TIMEOUT from pexpect
   - Waits 2 seconds for network stabilization
   - Reconnects session and retries command
   - Only fails if recovery impossible

2. Modified SIGHUP handler in op-test to be non-fatal
   - SIGHUP now logs warning instead of immediate exit
   - Allows connection recovery logic to handle transient issues
   - Other signals still trigger cleanup and exit as before

3. Added SSHSessionDisconnected exception import