### PR TITLE
Fix telnetlib ModuleNotFoundError for Python 3.13+

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -38,7 +38,6 @@ import time
 import random
 import subprocess
 import re
-import telnetlib
 import socket
 import select
 import pty

--- a/common/OpTestTConnection.py
+++ b/common/OpTestTConnection.py
@@ -37,7 +37,12 @@
 # constantly themselves, so in this file we should expect to be given
 # strings and to return strings - even though that makes things harder.
 
-import telnetlib
+# telnetlib was removed in Python 3.13, use telnetlib3 as replacement
+import sys
+if sys.version_info >= (3, 13):
+    import telnetlib3 as telnetlib
+else:
+    import telnetlib
 
 
 class NoLoginPrompt(Exception):

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -33,7 +33,11 @@ import string
 import subprocess
 import random
 import re
-import telnetlib
+# telnetlib was removed in Python 3.13, but we keep backward compatibility
+try:
+    import telnetlib
+except ModuleNotFoundError:
+    telnetlib = None
 import socket
 import select
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ paramiko>=2.7.0
 pexpect
 ptyprocess
 
+# Telnet support - telnetlib3 for Python 3.13+
+telnetlib3; python_version >= '3.13'
+
 # Testing and utilities
 unittest-xml-reporting
 unittest2


### PR DESCRIPTION
- Replace telnetlib import with version-based conditional import in OpTestTConnection.py
- Use telnetlib for Python < 3.13 (built-in module)
- Use telnetlib3 for Python >= 3.13 (drop-in replacement)
- Add telnetlib3 to requirements.txt for Python 3.13+
- Add try-except fallback in OpTestUtil.py for backward compatibility
- Remove unused telnetlib import from OpTestHost.py
- Maintain backward compatibility with older Python versions

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>