### PR TITLE
OpTestHMC: Add support for kvm_capable flag management

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1003,6 +1003,45 @@ class HMCUtil():
             cmd = '%s0"' % cmd
         self.run_command(cmd, timeout=300)
 
+    def is_kvm_capable_enabled(self):
+        '''
+        Get KVM capable flag status in hmc profile
+
+        :returns: True if kvm_capable is enabled in hmc otherwise False
+        '''
+
+        rc = self.run_command("lssyscfg -m %s -r lpar --filter lpar_names=%s -F kvm_capable"
+                              % (self.mg_system, self.lpar_name))
+        if rc:
+            return True
+        return False
+
+    def enable_kvm_capable(self):
+        '''
+        Enable KVM capable flag from HMC
+        The value for enabling kvm_capable is 1.
+
+        Note: The kvm_capable flag can only be toggled when the partition
+        is in a deactivated state.
+        '''
+
+        cmd = ('chsyscfg -r lpar -m %s -i "name=%s, kvm_capable=1"' %
+               (self.mg_system, self.lpar_name))
+        self.run_command(cmd, timeout=300)
+
+    def disable_kvm_capable(self):
+        '''
+        Disable KVM capable flag from HMC
+        The value for disabling kvm_capable is 0.
+
+        Note: The kvm_capable flag can only be toggled when the partition
+        is in a deactivated state.
+        '''
+
+        cmd = ('chsyscfg -r lpar -m %s -i "name=%s, kvm_capable=0"' %
+               (self.mg_system, self.lpar_name))
+        self.run_command(cmd, timeout=300)
+
     def gather_logs(self, list_of_commands=[], remote_hmc=None, output_dir=None):
         '''
         Gather the logs for the commands at the given directory


### PR DESCRIPTION
Add three new methods to HMCUtil class for managing the kvm_capable flag:
- is_kvm_capable_enabled(): Check if KVM capable flag is enabled
- enable_kvm_capable(): Enable KVM capable flag (set to 1)
- disable_kvm_capable(): Disable KVM capable flag (set to 0)

These methods use HMC commands to query and modify the kvm_capable
LPAR configuration parameter.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>