### PR TITLE
github/workflow: pylint checker update

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Update the python verion list to include 3.13 and 3.14. 
These versions are available with newer distributions.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>