### PR TITLE
OpTestKernelDump.py Add testcase for timezone change with kdump

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -2633,6 +2633,85 @@ class OpTestUtil():
                 raise OpTestError(f"Unable to uninstall package: {packages}")
         except CommandFailed as cf:
             log.debug("Failed to uninstall packages CommandFailed={}".format(cf))
+
+    def get_timezone(self):
+        """
+        Retrieve the system's current timezone.
+
+        This method runs the `timedatectl` command on the configured host
+        and parses its output to extract the active timezone setting.
+        It searches for the line containing 'Time zone' and returns it
+        as a stripped string. If no timezone information is found,
+        the method returns None.
+
+        Returns:
+        str: The timezone line from `timedatectl` output, or None if not found.
+        """
+        host = self.conf.host()
+        output = host.host_run_command("timedatectl")
+        for line in output:
+            if "Time zone" in line:
+                return line.strip()
+        return None
+
+    def set_random_timezone(self):
+        """
+        Set the system timezone to a randomly selected valid timezone.
+
+        This method chooses a timezone at random from a predefined list
+        (e.g., UTC, Asia/Kolkata, America/New_York, Europe/London, Asia/Tokyo,
+        Australia/Sydney) and applies it to the configured host using
+        the `timedatectl set-timezone` command. It then returns the
+        selected timezone string.
+    
+        Returns:
+        str: The randomly chosen timezone that was applied to the host.
+        """
+        # List of some valid timezones
+        host = self.conf.host()
+        timezones = [
+            "UTC",
+            "Asia/Kolkata",
+            "America/New_York",
+            "Europe/London",
+            "Asia/Tokyo",
+            "Australia/Sydney"
+        ]
+
+        tz = random.choice(timezones)
+        host.host_run_command(f"timedatectl set-timezone {tz}")
+        return tz
+
+    def get_latest_crash_dir(self):
+        '''
+        Retrieve the most recent crash directory
+        '''
+        host = self.conf.host()
+        cmd = "ls -td /var/crash/* 2>/dev/null | head -1"
+        output = host.host_run_command(cmd)
+        if output:
+            return output[0].strip()
+        return None
+
+    def get_file_timestamps(self, crash_dir):
+        """
+        Retrieve detailed file timestamps from a crash directory.
+
+        This method runs the `ls -l --time-style=full-iso` command on the
+        specified crash directory of the configured host. It returns the
+        command output, which includes file metadata such as permissions,
+        ownership, size, and full ISO‑formatted timestamps.
+    
+        Args:
+        crash_dir (str): Path to the crash directory to inspect.
+    
+        Returns:
+        list[str]: A list of strings representing the detailed file
+                   information and timestamps from the directory.
+        """
+        host = self.conf.host()
+        cmd = f"ls -l --time-style=full-iso {crash_dir}"
+        return host.host_run_command(cmd)
         
     def get_distro_src(self, package, dest_path, build_option=None, pack_dir=None):
         

--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -2326,6 +2326,7 @@ class OpTestKdumpKernelSwitch(OptestKernelDump):
 
     def runTest(self):
         running_kernel = self.c.run_command("uname -r")[0].strip()
+        kernels = []
         if self.distro == "sles":
             self.skipTest(
                 "skipping the testcase for now.. Need to figure out a way to verify kdump kernel version in sles")
@@ -2858,6 +2859,54 @@ class KernelCrash_CrashkernelOffset(OptestKernelDump):
                                         reboot_cmd=True):
             self.fail("KernelArgTest failed to update kernel args")
 
+
+class TestTimezoneKdump(OptestKernelDump):
+
+    def rebuild_kdump(self):
+
+        if self.distro == 'sles':
+            self.c.run_command("mkdumprd -f")
+            self.c.run_command("systemctl restart kdump.service")
+        elif self.distro == 'rhel':
+            self.c.run_command("kdumpctl rebuild")
+            self.c.run_command("kdumpctl restart")
+        else:
+            raise Exception("Unsupported OS")
+
+    def runTest(self):
+
+        original_tz = self.op_test_util.get_timezone()
+        log.info(f"Original timezone: {original_tz}")
+        new_tz = self.op_test_util.set_random_timezone()
+        time.sleep(2)
+        changed_tz = self.op_test_util.get_timezone()
+        log.info(f"Changed timezone: {changed_tz}")
+        if new_tz not in changed_tz:
+            self.fail("Timezone change failed")
+        self.rebuild_kdump()
+        self.kernel_crash()
+        crash_dir = self.op_test_util.get_latest_crash_dir()
+        if not crash_dir:
+            self.fail("No crash directory found")
+        log.info(f"Crash directory: {crash_dir}")
+        timestamps = self.op_test_util.get_file_timestamps(crash_dir)
+        log.info("Crash directory file timestamps:")
+        for line in timestamps:
+            log.info(line)
+        timedatectl_output = self.c.run_command("timedatectl")
+        tz_line = [l for l in timedatectl_output if "Time zone" in l][0]
+        log.info(f"Post-crash timezone:{tz_line}")
+        if not timestamps:
+            self.fail("No files found in crash directory")
+        match = re.search(r'([+-]\d{2}:\d{2})', tz_line)
+        if match:
+            offset = match.group(1)
+            found = any(offset in line for line in timestamps)
+            if not found:
+                raise Exception("Crash files do not reflect timezone offset")
+
+        log.info("Timezone validation on crash dump: SUCCESS")
+
 def crash_suite():
     s = unittest.TestSuite()
     s.addTest(OpTestWatchdog())
@@ -2899,5 +2948,5 @@ def crash_suite():
     s.addTest(PstoreCheck())
     s.addTest(MeasureMakedumpTime())
     s.addTest(KernelCrash_CrashkernelOffset())
-
+    s.addTest(TestTimezoneKdump())
     return s


### PR DESCRIPTION
Introduce a testcase that modifies the system timezone, triggers a crash dump, and verifies that the crash directory and generated files reflect the updated timezone setting.