### PR TITLE
Adding ndctl to package list.

### DIFF
--- a/testcases/OpTestHtxBootme.py
+++ b/testcases/OpTestHtxBootme.py
@@ -126,7 +126,7 @@ class OpTestHtxBootmeIO():
         """
         Builds HTX
         """
-        packages = ['git', 'gcc', 'make', 'wget']
+        packages = ['git', 'gcc', 'make', 'wget', 'ndctl']
         if self.host_distro_name in ['centos', 'fedora', 'rhel', 'redhat']:
             packages.extend(['gcc-c++', 'ncurses-devel', 'tar'])
         elif self.host_distro_name == "Ubuntu":


### PR DESCRIPTION
mdt.pmem_all will require ndctl package to be installed adding the same.