### PR TITLE
OpTestKernelDump.py: fix ebizzy workload testcase

### DIFF
--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -132,7 +132,11 @@ class OpTestSSH():
             # Execute command
             log.info(f"Executing direct SSH command: {command}")
             stdin, stdout, stderr = client.exec_command(command, timeout=timeout)
-            
+            background = command.strip().endswith("&")
+            if background:
+                log.info("Background command - not waiting")
+                time.sleep(0.5)
+                return []
             # Get output
             if expect_disconnect:
                 # Don't wait for exit status - system will crash/disconnect

--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -1580,13 +1580,12 @@ class KernelCrash_KdumpWorkLoad(OptestKernelDump):
         except CommandFailed:
             self.fail("Failed to download ebizzy tar")
         self.c.run_command("tar -xf /tmp/ebizzy*.tar.gz -C /tmp", timeout=120)
-        self.c.run_command("cd /tmp/ebizzy*/")
         try:
-            self.c.run_command("./configure; make", timeout=120)
+            self.c.run_command("cd /tmp/ebizzy-0.3 && ./configure && make", timeout=120)
         except CommandFailed:
             self.fail("Failed to compile ebizzy")
-        self.c.run_command("./ebizzy -S 60&")
-        self.c.run_command("./ebizzy -s 10737418240 -S 60 &")
+        self.c.run_command("cd /tmp/ebizzy-0.3 && ./ebizzy -S 60 &")
+        self.c.run_command("cd /tmp/ebizzy-0.3 && ./ebizzy -s 10737418240 -S 60 &")
         time.sleep(50)
         self.c.run_command("ps -ef|grep ebizzy")
         self.c.run_command("free -h")


### PR DESCRIPTION
Fixed testcase behavior impacted by recent framework changes: run_command now waits for command completion, which caused the crash to trigger only after workload execution, altering the original functionality. Adjusted logic to restore intended behavior.