### PR TITLE
testcases/OpTestKernelDump: Execute makedumpfile tests in crash directory

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -1924,8 +1924,9 @@ class OpTestMakedump(OptestKernelDump):
     '''
     function will trigger crash kernel and  run the makedumpfile on collected vmcore
     '''
-
+    
     def check_run(self, cmd, condition):
+        cmd = f"cd {self.crash_dir} && {cmd}"
         res = self.c.run_command(cmd, timeout=300)
         for value in res:
             if condition in value:
@@ -1933,65 +1934,70 @@ class OpTestMakedump(OptestKernelDump):
                 return
         self.fail("commnd %s failed" % cmd)
 
+    def run_in_crashdir(self, cmd, timeout=300):
+        return self.c.run_command(f"cd {self.crash_dir} && {cmd}", timeout=timeout)
+
     def makedump_check(self):
         '''
         Function will verify all makdump options on already colleted vmcore
         '''
         res = self.c.run_command("ls -1 /var/crash/")
-        crash_dir = self.c.run_command("cd /var/crash/%s" % res[0])
-        res = self.c.run_command("ls")
-        if 'vmcore' not in res[0]:
+        crash_dirs = sorted([x.strip() for x in res if x.strip()])
+        if not crash_dirs:
+            self.fail("No crash directory found")
+        self.crash_dir = f"/var/crash/{crash_dirs[-1]}"
+        log.info("Using crash directory: %s", self.crash_dir)
+        res = self.run_in_crashdir("ls")
+        if 'vmcore' not in res:
             self.fail("vmcore is not saved")
-        else:
-            log.info("vmcore is saved")
+        log.info("vmcore is saved")
 
         '''
         The vmcore file saved in flattened format on SLES distro.
         So, convert flattened format to kdump compress format.
         '''
         if self.distro == "sles":
-            self.c.run_command("mv vmcore vmcore.orig; makedumpfile -R vmcore <vmcore.orig", timeout=60)
+            self.run_in_crashdir("mv vmcore vmcore.orig; makedumpfile -R vmcore <vmcore.orig", timeout=60)
 
-        self.c.run_command("makedumpfile -v")
+        self.run_in_crashdir("makedumpfile -v")
         self.check_run("makedumpfile --split -d 31 -l vmcore dump3 dump4",
                        "The dumpfiles are saved to dump3, and dump4")
         self.check_run("makedumpfile --reassemble dump3 dump4 dump5",
                        "The dumpfile is saved to dump5")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile -b 8 -d 31 -l vmcore dump2",
                        "The dumpfile is saved to dump2")
         self.check_run("makedumpfile -f -d 31 -l vmcore dump6",
                        "The dumpfile is saved to dump6")
         self.check_run("makedumpfile --dump-dmesg vmcore log",
                        "The dmesg log is saved to log")
-        self.c.run_command("rm -rf dump*")
-        self.c.run_command("rm -rf log")
+        self.run_in_crashdir("rm -rf dump*")
+        self.run_in_crashdir("rm -rf log")
         self.check_run("makedumpfile --cyclic-buffer 1024 vmcore dump10",
                        "The dumpfile is saved to dump10")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile --split --splitblock-size 1024 vmcore dump12 dump13 dump14",
                        "The dumpfiles are saved to dump12, dump13, and dump14")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile --work-dir /tmp vmcore dump20",
                        "The dumpfile is saved to dump20")
         self.check_run("makedumpfile --non-mmap vmcore dump22",
                        "The dumpfile is saved to dump22")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile -D -d 31 -l vmcore dump1",
                        "The dumpfile is saved to dump1")
         self.check_run("makedumpfile -D -d 31 -l vmcore dump41 --num-threads 8",
                        "The dumpfile is saved to dump41")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile -d 31 -c vmcore dump42",
                        "The dumpfile is saved to dump42")
         self.check_run("makedumpfile -d 31 -p vmcore dump43",
                        "The dumpfile is saved to dump43")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("rm -rf dump*")
         self.check_run("makedumpfile -d 31 -e vmcore --work-dir /tmp dump44",
                        "The dumpfile is saved to dump44")
-        self.c.run_command(
-            "makedumpfile -d 31 -c vmcore dump51 --message-level 21")
-        self.c.run_command("rm -rf dump*")
+        self.run_in_crashdir("makedumpfile -d 31 -c vmcore dump51 --message-level 21")
+        self.run_in_crashdir("rm -rf dump*")
 
     def runTest(self):
         obj = OpTestInstallUtil.InstallUtil()


### PR DESCRIPTION

Run all makedumpfile commands from the latest crash directory instead of relying on a previous `cd` command, since each run_command() creates a new shell. Also verify vmcore before testing, perform SLES vmcore conversion in the crash directory, and improve validation for commands that produce verbose output instead of the standard success message.