### PR TITLE
testcases/OpTestKernelDump: Handle vmcore.flat during dump verification

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -483,7 +483,7 @@ class OptestKernelDump(unittest.TestCase):
                 else:
                     res = self.c.run_command("ls /var/crash/%s/vmcore*" %
                                           self.crash_content[0])
-                    paths = res[0].split()
+                    paths = res
                     file_names = [os.path.basename(path) for path in paths]
                     # Check if vmcore-dmesg-incomplete.txt is present in file_names
                     if "vmcore-dmesg-incomplete.txt" in file_names:


### PR DESCRIPTION
Update dump verification logic to correctly detect all vmcore variants instead of assuming only "vmcore" is present.

The previous implementation processed only the first entry returned by the vmcore lookup, causing verification to fail when multiple files were present (e.g. vmcore-dmesg.txt and vmcore.flat). As a result, valid SSH kdump dumps on RHEL were incorrectly reported as failures.

Update the code to:
- Process all files returned by the vmcore lookup.
- Ignore vmcore-dmesg.txt while validating dump files.
- Accept any file beginning with "vmcore" (e.g. vmcore, vmcore.flat).